### PR TITLE
Fix multimodal input message truncation

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -269,6 +269,7 @@ function PureMultimodalInput({
 
     const message: ChatMessage = {
       id: generateUUID(),
+      content: input,
       parts: [
         ...attachments.map((attachment) => ({
           type: "file" as const,

--- a/providers/chat-input-provider.tsx
+++ b/providers/chat-input-provider.tsx
@@ -109,6 +109,8 @@ export function ChatInputProvider({
     return initialInput || getLocalStorageInput();
   }, [initialInput, getLocalStorageInput, localStorageEnabled]);
 
+  const inputValueRef = useRef<string>(getInitialInput());
+
   const handleModelChange = useCallback(
     async (modelId: AppModelId) => {
       const modelDef = getAppModelDefinition(modelId);
@@ -135,6 +137,7 @@ export function ChatInputProvider({
 
   const clearInput = useCallback(() => {
     editorRef.current?.clear();
+    inputValueRef.current = "";
     setLocalStorageInput("");
     setIsEmpty(true);
   }, [setLocalStorageInput]);
@@ -147,14 +150,12 @@ export function ChatInputProvider({
     setAttachments([]);
   }, []);
 
-  const getInputValue = useCallback(
-    () => editorRef.current?.getValue() || "",
-    []
-  );
+  const getInputValue = useCallback(() => inputValueRef.current || "", []);
 
   // Save to localStorage when input changes (will be called by the lexical editor)
   const handleInputChange = useCallback(
     (value: string) => {
+      inputValueRef.current = value;
       if (localStorageEnabled) {
         setLocalStorageInput(value);
       }


### PR DESCRIPTION
Fixes a bug where multimodal input messages were truncated to the first character by ensuring the full input value is captured and sent.

The issue stemmed from two parts: the editor's value not being reliably captured for submission, and the chat message object missing the `content` field for the full text. This PR addresses both by caching the input value and explicitly including it in the message payload.

---
<a href="https://cursor.com/background-agent?bcId=bc-3029d3f7-4fde-48b7-aa46-13423aaff94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3029d3f7-4fde-48b7-aa46-13423aaff94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input value tracking and consistency between the UI state and stored values
  * Enhanced message construction to reliably capture current input values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->