### PR TITLE
Remove iscomposing from multimodal input condition

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -595,40 +595,36 @@ function PureMultimodalInput({
             uploadQueue={uploadQueue}
           />
 
-          <LexicalChatInput
-            autoFocus
-            className="max-h-[max(35svh,5rem)] min-h-[60px] overflow-y-scroll sm:min-h-[80px]"
-            data-testid="multimodal-input"
-            initialValue={getInitialInput()}
-            onEnterSubmit={(event) => {
-              const isComposing =
-                "isComposing" in event ? event.isComposing : false;
-              const shouldSubmit = isMobile
-                ? event.ctrlKey && !isComposing
-                : !(event.shiftKey || isComposing);
+            <LexicalChatInput
+              autoFocus
+              className="max-h-[max(35svh,5rem)] min-h-[60px] overflow-y-scroll sm:min-h-[80px]"
+              data-testid="multimodal-input"
+              initialValue={getInitialInput()}
+              onEnterSubmit={(event) => {
+                const shouldSubmit = isMobile ? event.ctrlKey : !event.shiftKey;
 
-              if (shouldSubmit) {
-                if (!submission.enabled) {
-                  if (submission.message) {
-                    toast.error(submission.message);
+                if (shouldSubmit) {
+                  if (!submission.enabled) {
+                    if (submission.message) {
+                      toast.error(submission.message);
+                    }
+                    return true;
                   }
+                  submitForm();
                   return true;
                 }
-                submitForm();
-                return true;
-              }
 
-              return false;
-            }}
-            onInputChange={handleInputChange}
-            onPaste={handlePaste}
-            placeholder={
-              isMobile
-                ? "Send a message... (Ctrl+Enter to send)"
-                : "Send a message..."
-            }
-            ref={editorRef}
-          />
+                return false;
+              }}
+              onInputChange={handleInputChange}
+              onPaste={handlePaste}
+              placeholder={
+                isMobile
+                  ? "Send a message... (Ctrl+Enter to send)"
+                  : "Send a message..."
+              }
+              ref={editorRef}
+            />
 
           <ChatInputBottomControls
             fileInputRef={fileInputRef}


### PR DESCRIPTION
Remove `isComposing` from the `onEnterSubmit` condition to allow submissions during IME composition.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e915ec9-e1cd-4f11-8ae4-7b2342b55e87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e915ec9-e1cd-4f11-8ae4-7b2342b55e87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

