### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 # Production-Ready AI Chat Template
 
+[![Run in Smithery](https://smithery.ai/badge/skills/franciscomoretti)](https://smithery.ai/skills?ns=franciscomoretti&utm_source=github&utm_medium=badge)
+
+
 Build your own multi-model AI chat app with 120+ models, authentication, streaming, and advanced features.
 
 **Next.js • Vercel AI SDK • Shadcn/UI • Better Auth • Drizzle ORM**


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/FranciscoMoretti)](https://smithery.ai/skills?ns=FranciscoMoretti&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “Run in Smithery” badge to the README to improve skill discoverability.
The badge links directly to the project's Smithery skills page for one-click install.

<sup>Written for commit 505a922835539174766930f2c8530ef0a5073e69. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a badge link to the README positioned below the main title, providing access to an external resource.
* Updated README formatting with spacing adjustments to accommodate the new badge placement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->