### PR TITLE
Update MCP_ENCRYPTION_KEY length to 32 bytes

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -29,7 +29,7 @@ export const env = createEnv({
     TAVILY_API_KEY: z.string().optional(),
     EXA_API_KEY: z.string().optional(),
     FIRECRAWL_API_KEY: z.string().optional(),
-    MCP_ENCRYPTION_KEY: z.string().length(44).optional(), // 44 bytes base64
+    MCP_ENCRYPTION_KEY: z.string().length(32).optional(), // 32 bytes base64
 
     // Misc / platform
     VERCEL_URL: z.string().optional(),


### PR DESCRIPTION
Change MCP_ENCRYPTION_KEY length from 44 to 32 bytes.

## Summary by Sourcery

Enhancements:
- Adjust MCP_ENCRYPTION_KEY env schema to expect a 32-character base64 string instead of 44 characters.