### PR TITLE
Improve user message editing behavior by preventing mode switch when text is selected; enhance button styling for better usability

### DIFF
--- a/apps/chat/components/user-message.tsx
+++ b/apps/chat/components/user-message.tsx
@@ -78,8 +78,13 @@ const PureUserMessage = ({
             <button
               className="block cursor-pointer select-text text-left transition-opacity hover:opacity-80"
               data-testid="message-content"
-              onClick={() => {
-                if (window.getSelection()?.toString()) return;
+              onClick={(e) => {
+                const selection = window.getSelection();
+                if (
+                  selection?.toString() &&
+                  e.currentTarget.contains(selection.anchorNode)
+                )
+                  return;
                 setMode("edit");
               }}
               type="button"


### PR DESCRIPTION
## Summary by Sourcery

Prevent user messages from switching to edit mode when text is selected and make message content selectable in view mode for improved usability.

Enhancements:
- Allow selecting text in user messages while in view mode.
- Guard the edit-mode toggle so clicking while text is selected no longer enters edit mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop switching to edit mode when clicking a message if text inside it is selected, so selecting and copying works as expected.
Also allow text selection in view mode by adding the select-text class to the message button.

<sup>Written for commit 99788474a3c5f87be1cc57ff4079dd95bebc229a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change limited to client-side click handling for message editing; unlikely to affect data flow or backend logic.
> 
> **Overview**
> User messages in `apps/chat/components/user-message.tsx` now allow text selection in view mode and **won’t toggle into edit mode** when the user clicks while a selection exists inside the message content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99788474a3c5f87be1cc57ff4079dd95bebc229a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->