### PR TITLE
Refactor chat synchronization logic to improve message handling

### DIFF
--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -2,7 +2,7 @@
 
 import { useChat, useChatActions } from "@ai-sdk-tools/store";
 import { DefaultChatTransport } from "ai";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useDataStream } from "@/components/data-stream-provider";
 import { useSaveMessageMutation } from "@/hooks/chat-sync-hooks";
@@ -34,6 +34,8 @@ export function ChatSync({
   const addMessageToTree = useAddMessageToTree();
 
   const lastMessage = threadInitialMessages.at(-1);
+  const lastMessageRef = useRef(lastMessage);
+  lastMessageRef.current = lastMessage;
   const isLastMessagePartial = !!lastMessage?.metadata?.activeStreamId;
 
   // Backstop: if we remount ChatSync (e.g. threadEpoch changes), ensure the prior
@@ -77,8 +79,9 @@ export function ChatSync({
         };
       },
       prepareReconnectToStreamRequest({ id: chatId }) {
-        const partialMessageId = lastMessage?.metadata?.activeStreamId
-          ? lastMessage.id
+        const current = lastMessageRef.current;
+        const partialMessageId = current?.metadata?.activeStreamId
+          ? current.id
           : null;
         return {
           api: `/api/chat/${chatId}/stream${partialMessageId ? `?messageId=${partialMessageId}` : ""}`,

--- a/apps/chat/lib/stores/with-threads.ts
+++ b/apps/chat/lib/stores/with-threads.ts
@@ -131,13 +131,30 @@ export const withThreads =
       },
 
       setAllMessages: (messages: UI_MESSAGE[]) => {
-        const currentVisibleMessages = get().messages;
-        const existingTreeMessages = get().allMessages;
+        const state = get();
+        const currentVisibleMessages = state.messages;
+        const existingTreeMessages = state.allMessages;
         const mergedMessages = mergeTreeMessages(
           messages,
           existingTreeMessages,
           currentVisibleMessages
         );
+
+        // While the SDK is actively streaming, updating the visible thread with
+        // server data would mix the SDK's client-generated message ID with the
+        // server's assistantMessageId. The mismatch causes the SDK to push a
+        // second assistant message on the next chunk, bumping the epoch and
+        // remounting ChatSync mid-stream. Only update the tree index here and
+        // let the normal post-stream invalidation apply the full visible update.
+        if (state.status === "streaming" || state.status === "submitted") {
+          set((prev) => ({
+            ...prev,
+            allMessages: mergedMessages,
+            childrenMap: rebuildMap(mergedMessages),
+          }));
+          return;
+        }
+
         const currentLeafId = currentVisibleMessages.at(-1)?.id;
         const nextVisibleThread = currentLeafId
           ? (buildThreadFromLeaf(
@@ -147,8 +164,8 @@ export const withThreads =
           : currentVisibleMessages;
 
         originalSetMessages(nextVisibleThread);
-        set((state) => ({
-          ...state,
+        set((prev) => ({
+          ...prev,
           messages: nextVisibleThread,
           threadInitialMessages: nextVisibleThread,
           allMessages: mergedMessages,


### PR DESCRIPTION
- Introduced useRef for tracking the last message in ChatSync, ensuring accurate message state during streaming.
- Enhanced setAllMessages function in withThreads to prevent mixing client-generated and server message IDs during active streaming, improving message integrity.
- Updated message merging logic to maintain consistency in the message tree structure while streaming.

## Summary by Sourcery

Refine chat message synchronization during streaming to avoid ID mismatches and ensure consistent thread reconstruction.

Enhancements:
- Limit message updates during streaming to only refresh the message tree index and children map, deferring visible thread updates until after streaming completes.
- Track the last thread message via a React ref in ChatSync so streaming reconnections reliably target the correct partial message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored chat streaming sync to prevent ID mismatches and mid-stream remounts, keeping the message tree and visible thread consistent.

- **Bug Fixes**
  - During streaming or submission, `setAllMessages` updates only `allMessages` and `childrenMap`, deferring visible thread updates to avoid mixing client temp IDs with server `assistantMessageId`.
  - In ChatSync, track the last message with a ref so stream reconnects target the correct partial message.

<sup>Written for commit 3a04a04cd6af20d8f19b9bcd3470409edab4fe57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

