### PR TITLE
Update @streamdown/code package version in bun.lock and package.json

### DIFF
--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -88,7 +88,7 @@
 		"@radix-ui/react-toggle": "^1.1.10",
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"@radix-ui/react-use-controllable-state": "^1.2.2",
-		"@streamdown/code": "^1.0.3",
+		"@streamdown/code": "^1.1.1",
 		"@streamdown/math": "^1.0.2",
 		"@streamdown/mermaid": "^1.0.2",
 		"@t3-oss/env-nextjs": "^0.13.8",

--- a/bun.lock
+++ b/bun.lock
@@ -63,7 +63,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
-        "@streamdown/code": "^1.0.3",
+        "@streamdown/code": "^1.1.1",
         "@streamdown/math": "^1.0.2",
         "@streamdown/mermaid": "^1.0.2",
         "@t3-oss/env-nextjs": "^0.13.8",
@@ -768,7 +768,7 @@
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
-    "@streamdown/code": ["@streamdown/code@1.0.3", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3Ym5TCLcGhrHY2qBaUVWpqNRtxnZvqh4Y5Qm/pTIKA4AmEWwAAoYjZnxG7mOsvOpWVWiDwETjUtchNL1XzQEAw=="],
+    "@streamdown/code": ["@streamdown/code@1.1.1", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg=="],
 
     "@streamdown/math": ["@streamdown/math@1.0.2", "", { "dependencies": { "katex": "^0.16.27", "rehype-katex": "^7.0.1", "remark-math": "^6.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g=="],
 


### PR DESCRIPTION
- Upgraded @streamdown/code from version 1.0.3 to 1.1.1 in both bun.lock and package.json to ensure compatibility with other dependencies.

## Summary by Sourcery

Build:
- Update @streamdown/code from 1.0.3 to 1.1.1 in apps/chat/package.json and bun.lock to use the newer package version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@streamdown/code` from 1.0.3 to 1.1.1 in the chat app to align with current dependencies and pick up recent fixes. Updates `apps/chat/package.json` and `bun.lock`.

<sup>Written for commit 819377e48c8567a4f659520422209f732fdedf2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

