### PR TITLE
Fix multimodal input background opacity in dark mode

### DIFF
--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -839,7 +839,7 @@ function PureMultimodalInput({
             isDragActive && "border-primary bg-accent",
             className
           )}
-          inputGroupClassName="bg-muted"
+          inputGroupClassName="bg-muted dark:bg-muted"
           {...getRootProps({ onError: undefined, onSubmit: undefined })}
           onSubmit={(_message, event) => {
             event.preventDefault();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct multimodal input background styling in dark mode by applying the muted background class specifically for the dark theme.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the multimodal input background in dark mode. Adds `dark:bg-muted` to the input group so the field uses the muted background instead of appearing transparent.

<sup>Written for commit ffefe101e2cd23fc497fde6369451259f8257e70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode appearance of the multimodal input component to ensure consistent styling across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->