### PR TITLE
multi package manager support

### DIFF
--- a/.github/workflows/cli-scaffold.yml
+++ b/.github/workflows/cli-scaffold.yml
@@ -1,0 +1,103 @@
+name: CLI Scaffold
+
+on:
+  pull_request:
+
+concurrency:
+  group: cli-scaffold-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-scaffold:
+    name: CLI Scaffold
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.1
+      - name: Enable Corepack
+        run: corepack enable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun
+            **/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - name: Build CLI
+        run: bun --filter @chat-js/cli build
+      - name: Scaffold and install with each package manager
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_case() {
+            local package_manager="$1"
+            local electron_flag="$2"
+            local temp_parent
+            local app_name
+            local app_dir
+            temp_parent="$(mktemp -d "/tmp/chat-js-${package_manager}-${electron_flag}-XXXXXX")"
+            app_name="chat-js-app"
+            app_dir="$temp_parent/$app_name"
+
+            local create_args=(
+              "$GITHUB_WORKSPACE/packages/cli/dist/index.js"
+              create
+              "$app_name"
+              --yes
+              --no-install
+              --package-manager
+              "$package_manager"
+            )
+
+            if [ "$electron_flag" = "true" ]; then
+              create_args+=(--electron)
+            else
+              create_args+=(--no-electron)
+            fi
+
+            (
+              cd "$temp_parent"
+              node "${create_args[@]}"
+            )
+
+            pushd "$app_dir" >/dev/null
+            case "$package_manager" in
+              bun) bun install ;;
+              npm) npm install ;;
+              pnpm) pnpm install ;;
+              yarn) yarn install ;;
+              *) echo "Unsupported package manager: $package_manager" >&2; exit 1 ;;
+            esac
+            popd >/dev/null
+
+            if [ "$electron_flag" = "true" ]; then
+              pushd "$app_dir/electron" >/dev/null
+              case "$package_manager" in
+                bun) bun install ;;
+                npm) npm install ;;
+                pnpm) pnpm install ;;
+                yarn) yarn install ;;
+                *) echo "Unsupported package manager: $package_manager" >&2; exit 1 ;;
+              esac
+              if [ "$package_manager" = "npm" ]; then
+                npm run make
+              fi
+              popd >/dev/null
+            fi
+
+            rm -rf "$temp_parent"
+          }
+
+          for package_manager in bun npm pnpm yarn; do
+            run_case "$package_manager" false
+            run_case "$package_manager" true
+          done

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -15,6 +15,6 @@ jobs:
           # ============================================
           # REQUIRED CHECKS - Add/remove check names here
           # ============================================
-          check-regexp: ^(Docs|Lint|Typecheck|Unit|Playwright)$
+          check-regexp: ^(Docs|Lint|Typecheck|Unit|Playwright|CLI Scaffold)$
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10

--- a/apps/docs/cli/create.mdx
+++ b/apps/docs/cli/create.mdx
@@ -20,9 +20,10 @@ npx @chat-js/cli@latest [directory] [options]
 
 | Flag               | Default | Description                                                                          |
 | ------------------ | ------- | ------------------------------------------------------------------------------------ |
-| `-y, --yes`        | `false` | Skip all prompts and use defaults (Vercel gateway, GitHub auth, no extra features).  |
-| `--no-install`     | —       | Skip automatic dependency installation.                                              |
-| `--from-git <url>` | —       | Clone from a git repository instead of the built-in template.                        |
+| `-y, --yes`                         | `false` | Skip all prompts and use defaults (Vercel gateway, GitHub auth, no extra features). |
+| `--no-install`                      | —       | Skip automatic dependency installation.                                             |
+| `--package-manager <bun\|npm\|pnpm\|yarn>` | —       | Override which package manager the CLI uses for install + next steps.               |
+| `--from-git <url>`                  | —       | Clone from a git repository instead of the built-in template.                       |
 
 ## Interactive prompts
 
@@ -35,7 +36,7 @@ When run without `--yes`, the CLI walks you through:
 5. **Electron desktop app** — optionally adds an `electron/` subfolder to package the app as a native desktop app (see [Desktop](/platforms/desktop))
 6. **Install dependencies** — whether to run the package manager automatically
 
-The CLI auto-detects your package manager from the `npm_config_user_agent` environment variable (npm, pnpm, yarn, or bun).
+The CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools. If you launch through `npx`/npm, it defaults the generated app to Bun unless you pass `--package-manager`.
 
 ## What gets generated
 
@@ -82,6 +83,12 @@ npx @chat-js/cli@latest create my-chat-app --yes
 npx @chat-js/cli@latest create my-chat-app --no-install
 ```
 
+**Use npm for install + printed next steps**
+
+```bash
+npx @chat-js/cli@latest create my-chat-app --package-manager npm
+```
+
 **Clone from a custom git repository**
 
 ```bash
@@ -95,6 +102,6 @@ npx @chat-js/cli@latest create my-chat-app
 cd my-chat-app
 cp .env.example .env.local
 # Fill in the env vars printed by the CLI
-npm run db:push
-npm run dev
+bun run db:push
+bun run dev
 ```

--- a/apps/docs/cli/create.mdx
+++ b/apps/docs/cli/create.mdx
@@ -36,7 +36,7 @@ When run without `--yes`, the CLI walks you through:
 5. **Electron desktop app** — optionally adds an `electron/` subfolder to package the app as a native desktop app (see [Desktop](/platforms/desktop))
 6. **Install dependencies** — whether to run the package manager automatically
 
-The CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools. If you launch through `npx`/npm, it defaults the generated app to Bun unless you pass `--package-manager`.
+The CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools. If you launch through `npx`/npm, it defaults the generated app to npm unless you pass `--package-manager`.
 
 ## What gets generated
 

--- a/apps/docs/platforms/desktop.mdx
+++ b/apps/docs/platforms/desktop.mdx
@@ -101,9 +101,11 @@ bun run dev
 
 # Terminal 2 — Electron
 cd electron
-bun install
-bun run dev
+npm install
+npm run dev
 ```
+
+Use the same package manager you selected during `create`. The default scaffold still uses Bun, so if you did not pass `--package-manager`, replace the Electron commands above with `bun install` and `bun run dev`.
 
 In development, the Electron wrapper points at `http://localhost:3000` by default.
 

--- a/apps/docs/platforms/desktop.mdx
+++ b/apps/docs/platforms/desktop.mdx
@@ -101,11 +101,11 @@ bun run dev
 
 # Terminal 2 — Electron
 cd electron
-npm install
-npm run dev
+bun install
+bun run dev
 ```
 
-Use the same package manager you selected during `create`. The default scaffold still uses Bun, so if you did not pass `--package-manager`, replace the Electron commands above with `bun install` and `bun run dev`.
+Use the same package manager you selected during `create`. If you passed `--package-manager npm` (or another manager), replace `bun` above with that manager.
 
 In development, the Electron wrapper points at `http://localhost:3000` by default.
 

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -19,7 +19,7 @@ npx @chat-js/cli@latest create my-app
 cd my-app
 ```
 
-The CLI walks you through selecting your AI gateway, features, and auth providers, then generates a configured project with `chat.config.ts` ready to go. It also asks whether to include a [Desktop app](/platforms/desktop). It preserves `bun`, `pnpm`, and `yarn` when launched from those tools, and defaults `npx`/npm launches to Bun unless you pass `--package-manager`.
+The CLI walks you through selecting your AI gateway, features, and auth providers, then generates a configured project with `chat.config.ts` ready to go. It also asks whether to include a [Desktop app](/platforms/desktop). It preserves `bun`, `pnpm`, and `yarn` when launched from those tools, and defaults `npx`/npm launches to npm unless you pass `--package-manager`.
 
 ## Understanding `chat.config.ts`
 

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -19,7 +19,7 @@ npx @chat-js/cli@latest create my-app
 cd my-app
 ```
 
-The CLI walks you through selecting your AI gateway, features, and auth providers, then generates a configured project with `chat.config.ts` ready to go. It also asks whether to include a [Desktop app](/platforms/desktop). It automatically detects your package manager and creates the appropriate lock file.
+The CLI walks you through selecting your AI gateway, features, and auth providers, then generates a configured project with `chat.config.ts` ready to go. It also asks whether to include a [Desktop app](/platforms/desktop). It preserves `bun`, `pnpm`, and `yarn` when launched from those tools, and defaults `npx`/npm launches to Bun unless you pass `--package-manager`.
 
 ## Understanding `chat.config.ts`
 

--- a/apps/docs/reference/cli.mdx
+++ b/apps/docs/reference/cli.mdx
@@ -43,12 +43,13 @@ npx @chat-js/cli@latest [directory] [options]
 
 | Flag               | Default | Description                                                                         |
 | ------------------ | ------- | ----------------------------------------------------------------------------------- |
-| `-y, --yes`        | `false` | Skip all prompts and use defaults (Vercel gateway, GitHub auth, no extra features). |
-| `--no-install`     | —       | Skip automatic dependency installation.                                             |
-| `--from-git <url>` | —       | Clone from a git repository instead of the built-in template.                       |
-| `-v, --version`    | —       | Print the CLI version.                                                              |
+| `-y, --yes`                         | `false` | Skip all prompts and use defaults (Vercel gateway, GitHub auth, no extra features). |
+| `--no-install`                      | —       | Skip automatic dependency installation.                                             |
+| `--package-manager <bun\|npm\|pnpm\|yarn>` | —       | Override which package manager the CLI uses for install + next steps.               |
+| `--from-git <url>`                  | —       | Clone from a git repository instead of the built-in template.                       |
+| `-v, --version`                     | —       | Print the CLI version.                                                              |
 
-The CLI auto-detects your package manager from the `npm_config_user_agent` environment variable (npm, pnpm, yarn, or bun).
+The CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools. If you launch through `npx`/npm, it defaults the generated app to Bun unless you pass `--package-manager`.
 
 After scaffolding, the CLI prints the exact environment variables required for your chosen configuration.
 
@@ -111,6 +112,12 @@ Defaults: Vercel AI Gateway, GitHub OAuth, Follow-up Suggestions only, bun insta
 npx @chat-js/cli@latest create my-chat-app --no-install
 ```
 
+**Use npm for install + printed next steps**
+
+```bash
+npx @chat-js/cli@latest create my-chat-app --package-manager npm
+```
+
 **Clone from a custom git repository**
 
 ```bash
@@ -124,6 +131,6 @@ npx @chat-js/cli@latest create my-chat-app
 cd my-chat-app
 cp .env.example .env.local
 # Fill in the env vars printed by the CLI
-npm run db:push
-npm run dev
+bun run db:push
+bun run dev
 ```

--- a/apps/electron/forge.config.ts
+++ b/apps/electron/forge.config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import type { ForgeConfig } from "@electron-forge/shared-types";
@@ -59,10 +59,6 @@ function ensurePrebuild(): void {
 
   runBunScript("prebuild");
   prebuildComplete = true;
-}
-
-function removeLocalNodeModules(): void {
-  rmSync(join(appRoot, "node_modules"), { recursive: true, force: true });
 }
 
 function createForgeConfig(): ForgeConfig {
@@ -146,7 +142,6 @@ function createForgeConfig(): ForgeConfig {
       },
       prePackage: async () => {
         runBunScript("build", { NODE_ENV: "production" });
-        removeLocalNodeModules();
       },
     },
   };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,10 +39,10 @@
 	},
 	"scripts": {
 		"start": "bun src/index.ts",
-		"build": "bun build ./src/index.ts --target=node --format=esm --outfile ./dist/index.js",
-		"test:unit": "bun test src",
+		"build": "bun run template:sync && bun build ./src/index.ts --target=node --format=esm --outfile ./dist/index.js",
+		"test:unit": "bun run template:sync && bun test src",
 		"template:sync": "bun ../../scripts/sync-template.ts",
-		"prepublishOnly": "bun run template:sync && bun run build && node ./dist/index.js --help >/dev/null"
+		"prepublishOnly": "bun run build && node ./dist/index.js --help >/dev/null"
 	},
 	"type": "module",
 	"devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
 	"scripts": {
 		"start": "bun src/index.ts",
 		"build": "bun build ./src/index.ts --target=node --format=esm --outfile ./dist/index.js",
+		"test:unit": "bun test src",
 		"template:sync": "bun ../../scripts/sync-template.ts",
 		"prepublishOnly": "bun run template:sync && bun run build && node ./dist/index.js --help >/dev/null"
 	},

--- a/packages/cli/src/commands/create.test.ts
+++ b/packages/cli/src/commands/create.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { create } from "./create";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(name: string): string {
+  const dir = join(tmpdir(), `chat-js-create-${name}-${crypto.randomUUID()}`);
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe("create command", () => {
+  it("uses the explicitly requested package manager for scaffold defaults", async () => {
+    const tempParent = makeTempDir("npm-app");
+    const appName = "my-chat-app";
+    const originalCwd = process.cwd();
+
+    await mkdir(tempParent, { recursive: true });
+    process.chdir(tempParent);
+    try {
+      await create.parseAsync(
+        [appName, "--yes", "--no-install", "--package-manager", "npm"],
+        {
+          from: "user",
+        }
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const packageJson = JSON.parse(
+      await readFile(join(tempParent, appName, "package.json"), "utf8")
+    ) as {
+      packageManager?: string;
+      overrides?: Record<string, string>;
+    };
+
+    expect(packageJson.packageManager).toBeUndefined();
+    expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
+  });
+});

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -61,6 +61,7 @@ const createOptionsSchema = z.object({
 	install: z.boolean(),
 	electron: z.boolean().optional(),
 	fromGit: z.string().optional(),
+	packageManager: z.enum(["bun", "npm", "pnpm", "yarn"]).optional(),
 });
 
 export const create = new Command()
@@ -72,6 +73,10 @@ export const create = new Command()
 	.option("--electron", "include the Electron desktop app")
 	.option("--no-electron", "do not include the Electron desktop app")
 	.option(
+		"--package-manager <manager>",
+		"package manager for install + next steps (bun, npm, pnpm, yarn)",
+	)
+	.option(
 		"--from-git <url>",
 		"clone from a git repository instead of the built-in scaffold",
 	)
@@ -82,7 +87,7 @@ export const create = new Command()
 				...opts,
 			});
 
-			const packageManager = inferPackageManager();
+			const packageManager = options.packageManager ?? inferPackageManager();
 
 			if (!options.yes) {
 				intro("Create ChatJS App");
@@ -125,11 +130,12 @@ export const create = new Command()
 				if (options.fromGit) {
 					await scaffoldFromGit(options.fromGit, targetDir);
 				} else {
-					await scaffoldFromTemplate(targetDir);
+					await scaffoldFromTemplate(targetDir, { packageManager });
 				}
 				if (withElectron) {
 					await scaffoldElectron(targetDir, {
 						projectName,
+						packageManager,
 					});
 				}
 				scaffoldSpinner.succeed("Project scaffolded.");
@@ -219,7 +225,7 @@ export const create = new Command()
 				logger.break();
 				logger.info("Electron desktop app:");
 				logger.log(
-					`  Run the web app first, then: ${highlighter.info(`cd electron && bun install && bun run dev`)}`,
+					`  Run the web app first, then: ${highlighter.info(`cd electron && ${packageManager} install && ${packageManager} run dev`)}`,
 				);
 			}
 			logger.break();

--- a/packages/cli/src/helpers/package-manifest.ts
+++ b/packages/cli/src/helpers/package-manifest.ts
@@ -1,0 +1,181 @@
+import type { PackageManager } from "../types";
+
+type DependencyMap = Record<string, string>;
+type ScriptMap = Record<string, string>;
+
+type PackageJson = {
+  packageManager?: string;
+  scripts?: ScriptMap;
+  dependencies?: DependencyMap;
+  devDependencies?: DependencyMap;
+  overrides?: Record<string, unknown>;
+};
+
+const ESBUILD_VERSION = "^0.28.0";
+const BETTER_AUTH_PACKAGES = [
+  "@better-auth/core",
+  "@better-auth/electron",
+  "better-auth",
+] as const;
+
+function toExactVersion(range: string): string {
+  return range.replace(/^[~^]/, "");
+}
+
+function resolveBetterAuthVersion(packageJson: PackageJson): string | null {
+  for (const dependencyGroup of [
+    packageJson.dependencies,
+    packageJson.devDependencies,
+  ]) {
+    if (!dependencyGroup) {
+      continue;
+    }
+
+    for (const packageName of BETTER_AUTH_PACKAGES) {
+      const version = dependencyGroup[packageName];
+      if (version) {
+        return toExactVersion(version);
+      }
+    }
+  }
+
+  return null;
+}
+
+function pinBetterAuthVersions(
+  dependencyGroup: DependencyMap | undefined,
+  version: string
+): void {
+  if (!dependencyGroup) {
+    return;
+  }
+
+  for (const packageName of BETTER_AUTH_PACKAGES) {
+    if (dependencyGroup[packageName]) {
+      dependencyGroup[packageName] = version;
+    }
+  }
+}
+
+function normalizeChatAppScripts(scripts: ScriptMap): void {
+  const defaultBranchName = "$" + "{1:-dev-local}";
+
+  scripts.prebuild = "tsx scripts/check-env.ts";
+  scripts.dev = "tsx scripts/check-env.ts && bash scripts/with-db.sh next dev";
+  scripts["dev:inspect"] =
+    "tsx scripts/check-env.ts && bash scripts/with-db.sh next dev --inspect";
+  scripts.prod =
+    "tsx scripts/check-env.ts && tsx lib/db/migrate.ts && next build && next start";
+  scripts.lint = "ultracite check";
+  scripts.format = "ultracite fix";
+  scripts["check-env"] = "tsx scripts/check-env.ts";
+  scripts["db:migrate"] =
+    "export VERCEL_ENV=production && bash scripts/with-db.sh tsx lib/db/migrate.ts";
+  scripts["db:backfill-parts"] = "tsx lib/db/backfill-parts.ts";
+  scripts["db:branch:start"] =
+    `bash -c 'N=${defaultBranchName}; bash scripts/db-branch-create.sh "$N" && bash scripts/db-branch-use.sh "$N"' --`;
+  scripts["db:branch:stop"] =
+    `bash -c 'N=${defaultBranchName}; bash scripts/db-branch-use.sh main && bash scripts/db-branch-delete.sh "$N"' --`;
+  scripts["db:branch:list"] = "npx neonctl branches list";
+  scripts["skiller:apply"] = "npx skiller@latest apply";
+  scripts.test =
+    "export PLAYWRIGHT=True && playwright test --workers=4 && vitest run";
+  scripts["test:e2e"] = "export PLAYWRIGHT=True && playwright test --workers=4";
+  scripts["ai:devtools"] = "npx @ai-sdk/devtools";
+  scripts["fetch:models"] = "tsx scripts/fetch-models.ts && ultracite fix";
+}
+
+function normalizeElectronScripts(scripts: ScriptMap): void {
+  const prebuild =
+    "tsx scripts/write-branding.ts && tsx scripts/generate-icons.ts";
+  const build =
+    "esbuild src/main.ts --bundle --platform=node --format=cjs --outfile=dist/main.js --external:electron --external:electron-updater --alias:@=.. && esbuild src/preload.ts --bundle --platform=browser --format=cjs --outfile=dist/preload.js --external:electron --alias:@=..";
+
+  scripts.forge = "node ./scripts/run-forge.cjs";
+  scripts["generate-icons"] = "tsx scripts/generate-icons.ts";
+  scripts.prebuild = prebuild;
+  scripts.build = build;
+  scripts.start = "node ./scripts/run-forge.cjs start";
+  scripts.dev = "node ./scripts/run-forge.cjs start";
+  scripts.package = "node ./scripts/run-forge.cjs package";
+  scripts.make = "node ./scripts/run-forge.cjs make";
+  scripts["make:mac"] =
+    "node ./scripts/run-forge.cjs make --platform=darwin --arch=universal";
+  scripts["make:win"] =
+    "node ./scripts/run-forge.cjs make --platform=win32 --arch=x64";
+  scripts["make:linux"] =
+    "node ./scripts/run-forge.cjs make --platform=linux --arch=x64";
+  scripts.publish = "node ./scripts/run-forge.cjs publish";
+  scripts["electron:build"] = build;
+  scripts["electron:dev"] = scripts.dev;
+  scripts["electron:make"] = scripts.make;
+  scripts["electron:publish"] = scripts.publish;
+  delete scripts["dist:mac"];
+  delete scripts["dist:win"];
+  delete scripts["dist:linux"];
+  delete scripts["publish:mac"];
+  delete scripts["publish:win"];
+}
+
+function normalizeElectronDevDependencies(
+  devDependencies: DependencyMap | undefined,
+  tsxVersion?: string
+): void {
+  if (!devDependencies) {
+    return;
+  }
+
+  devDependencies.esbuild = ESBUILD_VERSION;
+  if (tsxVersion) {
+    devDependencies.tsx = tsxVersion;
+  }
+}
+
+export function normalizeScaffoldedPackageJson(
+  packageJson: PackageJson,
+  options?: {
+    packageManager?: PackageManager;
+    persistPackageManager?: boolean;
+    template?: "chat-app" | "electron";
+    tsxVersion?: string;
+  }
+): PackageJson {
+  const betterAuthVersion = resolveBetterAuthVersion(packageJson);
+
+  if (betterAuthVersion) {
+    pinBetterAuthVersions(packageJson.dependencies, betterAuthVersion);
+    pinBetterAuthVersions(packageJson.devDependencies, betterAuthVersion);
+    packageJson.overrides = {
+      ...(packageJson.overrides ?? {}),
+      "@better-auth/core": betterAuthVersion,
+    };
+  }
+
+  switch (options?.template) {
+    case "chat-app":
+      if (packageJson.scripts) {
+        normalizeChatAppScripts(packageJson.scripts);
+      }
+      break;
+    case "electron":
+      if (packageJson.scripts) {
+        normalizeElectronScripts(packageJson.scripts);
+      }
+      normalizeElectronDevDependencies(
+        packageJson.devDependencies,
+        options?.tsxVersion
+      );
+      break;
+    default:
+      break;
+  }
+
+  if (options?.persistPackageManager !== false) {
+    const packageManager = options?.packageManager ?? "bun";
+    if (packageManager !== "bun") {
+      delete packageJson.packageManager;
+    }
+  }
+
+  return packageJson;
+}

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { buildConfigTs } from "./config-builder";
+import { scaffoldElectron, scaffoldFromTemplate } from "./scaffold";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(name: string): Promise<string> {
+  const dir = join(tmpdir(), `chat-js-cli-${name}-${crypto.randomUUID()}`);
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
 
 describe("buildConfigTs", () => {
   it("writes desktopApp.enabled=false for web-only scaffolds", () => {
@@ -55,5 +73,107 @@ describe("buildConfigTs", () => {
     });
 
     expect(output).toMatch(/desktopApp:\s*{\s*enabled:\s*true,/m);
+  });
+});
+
+describe("scaffoldFromTemplate", () => {
+  it("writes a standalone-safe root package.json", async () => {
+    const destination = await makeTempDir("chat-app");
+
+    await scaffoldFromTemplate(destination);
+
+    const packageJson = JSON.parse(
+      await readFile(join(destination, "package.json"), "utf8")
+    ) as {
+      packageManager?: string;
+      dependencies: Record<string, string>;
+      overrides?: Record<string, string>;
+    };
+
+    expect(packageJson.packageManager).toBe("bun@1.3.1");
+    expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
+    expect(packageJson.dependencies["@better-auth/electron"]).toBe("1.5.6");
+    expect(packageJson.dependencies["better-auth"]).toBe("1.5.6");
+    expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
+  });
+
+  it("rewrites the generated web app to be npm-friendly", async () => {
+    const destination = await makeTempDir("chat-app-npm");
+
+    await scaffoldFromTemplate(destination, { packageManager: "npm" });
+
+    const packageJson = JSON.parse(
+      await readFile(join(destination, "package.json"), "utf8")
+    ) as {
+      packageManager?: string;
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.packageManager).toBeUndefined();
+    for (const script of Object.values(packageJson.scripts)) {
+      expect(script).not.toContain("bun ");
+      expect(script).not.toContain("bunx");
+    }
+
+    expect(
+      await readFile(join(destination, "playwright.config.ts"), "utf8")
+    ).toContain('command: "npm run dev"');
+    expect(
+      await readFile(join(destination, "scripts", "check-env.ts"), "utf8")
+    ).toContain("npm run fetch:models");
+    expect(
+      await readFile(
+        join(destination, "lib", "ai", "gateways", "fallback-models.ts"),
+        "utf8"
+      )
+    ).toContain("npm run fetch:models");
+    expect(
+      await readFile(join(destination, "scripts", "with-db.sh"), "utf8")
+    ).not.toContain("bun");
+    expect(
+      await readFile(join(destination, "scripts", "db-branch-use.sh"), "utf8")
+    ).not.toContain("bun");
+  });
+});
+
+describe("scaffoldElectron", () => {
+  it("pins Better Auth versions in the generated electron app", async () => {
+    const projectDir = await makeTempDir("electron");
+
+    await scaffoldFromTemplate(projectDir, { packageManager: "npm" });
+    await scaffoldElectron(projectDir, {
+      projectName: "my-chat-app",
+      packageManager: "npm",
+    });
+
+    const packageJson = JSON.parse(
+      await readFile(join(projectDir, "electron", "package.json"), "utf8")
+    ) as {
+      packageManager?: string;
+      devDependencies: Record<string, string>;
+      scripts: Record<string, string>;
+      overrides?: Record<string, string>;
+    };
+
+    expect(packageJson.packageManager).toBeUndefined();
+    expect(packageJson.devDependencies["@better-auth/electron"]).toBe("1.5.6");
+    expect(packageJson.devDependencies["better-auth"]).toBe("1.5.6");
+    expect(packageJson.devDependencies.esbuild).toBeDefined();
+    const rootPackageJson = JSON.parse(
+      await readFile(join(projectDir, "package.json"), "utf8")
+    ) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(packageJson.devDependencies.tsx).toBe(
+      rootPackageJson.devDependencies.tsx
+    );
+    for (const script of Object.values(packageJson.scripts)) {
+      expect(script).not.toContain("bun ");
+      expect(script).not.toContain("bunx");
+    }
+    expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
+    expect(
+      await readFile(join(projectDir, "electron", "README.md"), "utf8")
+    ).not.toContain("bun ");
   });
 });

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -1,7 +1,9 @@
+import { existsSync } from "node:fs";
 import { afterEach, describe, expect, it } from "bun:test";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildConfigTs } from "./config-builder";
 import { scaffoldElectron, scaffoldFromTemplate } from "./scaffold";
 
@@ -11,6 +13,10 @@ async function makeTempDir(name: string): Promise<string> {
   const dir = join(tmpdir(), `chat-js-cli-${name}-${crypto.randomUUID()}`);
   tempDirs.push(dir);
   return dir;
+}
+
+function getCliPackageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 }
 
 afterEach(async () => {
@@ -133,6 +139,47 @@ describe("scaffoldFromTemplate", () => {
     expect(
       await readFile(join(destination, "scripts", "db-branch-use.sh"), "utf8")
     ).not.toContain("bun");
+  });
+
+  it("falls back to repo source apps when synced templates are missing", async () => {
+    const projectDir = await makeTempDir("chat-app-fallback");
+    const templatesDir = join(getCliPackageRoot(), "templates");
+    const backupDir = join(
+      tmpdir(),
+      `chat-js-cli-templates-${crypto.randomUUID()}`
+    );
+
+    if (existsSync(templatesDir)) {
+      await rename(templatesDir, backupDir);
+    }
+
+    try {
+      await scaffoldFromTemplate(projectDir, { packageManager: "npm" });
+      await scaffoldElectron(projectDir, {
+        projectName: "my-chat-app",
+        packageManager: "npm",
+      });
+
+      const packageJson = JSON.parse(
+        await readFile(join(projectDir, "package.json"), "utf8")
+      ) as {
+        dependencies: Record<string, string>;
+      };
+      const electronPackageJson = JSON.parse(
+        await readFile(join(projectDir, "electron", "package.json"), "utf8")
+      ) as {
+        devDependencies: Record<string, string>;
+      };
+
+      expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
+      expect(electronPackageJson.devDependencies["@better-auth/electron"]).toBe(
+        "1.5.6"
+      );
+    } finally {
+      if (existsSync(backupDir)) {
+        await rename(backupDir, templatesDir);
+      }
+    }
   });
 });
 

--- a/packages/cli/src/helpers/scaffold.ts
+++ b/packages/cli/src/helpers/scaffold.ts
@@ -90,6 +90,19 @@ function runScript(packageManager: PackageManager, script: string): string {
   return `${packageManager} run ${script}`;
 }
 
+function execCommand(packageManager: PackageManager): string {
+  switch (packageManager) {
+    case "bun":
+      return "bunx";
+    case "pnpm":
+      return "pnpm dlx";
+    case "yarn":
+      return "yarn dlx";
+    case "npm":
+      return "npx";
+  }
+}
+
 async function replaceInFile(
   filePath: string,
   replacements: Array<[string, string]>
@@ -207,8 +220,8 @@ async function normalizeChatAppFiles(
   );
 
   await replaceInFile(join(destination, "scripts", "with-db.sh"), [
-    ["bunx neonctl", "npx neonctl"],
-    ["filter out bun's package resolution output", "filter out npx resolution output"],
+    ["bunx neonctl", `${execCommand(packageManager)} neonctl`],
+    ["filter out bun's package resolution output", `filter out ${execCommand(packageManager)} resolution output`],
     [
       "Run: bun db:branch:use main  (to switch back to main)",
       "Run: bash scripts/db-branch-use.sh main  (to switch back to main)",
@@ -216,7 +229,7 @@ async function normalizeChatAppFiles(
   ]);
 
   await replaceInFile(join(destination, "scripts", "db-branch-create.sh"), [
-    ["bunx neonctl", "npx neonctl"],
+    ["bunx neonctl", `${execCommand(packageManager)} neonctl`],
     [
       'echo "To use it: bun db:branch:use $BRANCH_NAME"',
       'echo "To use it: bash scripts/db-branch-use.sh $BRANCH_NAME"',
@@ -224,18 +237,18 @@ async function normalizeChatAppFiles(
   ]);
 
   await replaceInFile(join(destination, "scripts", "db-branch-use.sh"), [
-    ["bunx neonctl", "npx neonctl"],
+    ["bunx neonctl", `${execCommand(packageManager)} neonctl`],
     ['echo "Usage: bun db:branch:use <branch-name>"', 'echo "Usage: bash scripts/db-branch-use.sh <branch-name>"'],
     [
       'echo "       bun db:branch:use main  (switch to production)"',
       'echo "       bash scripts/db-branch-use.sh main  (switch to production)"',
     ],
-    ['echo "Available branches: bun db:branch:list"', 'echo "Available branches: npx neonctl branches list"'],
+    ['echo "Available branches: bun db:branch:list"', `echo "Available branches: ${execCommand(packageManager)} neonctl branches list"`],
     ['echo "Create branch: bun db:branch:create"', 'echo "Create branch: bash scripts/db-branch-create.sh"'],
   ]);
 
   await replaceInFile(join(destination, "scripts", "db-branch-delete.sh"), [
-    ["bunx neonctl", "npx neonctl"],
+    ["bunx neonctl", `${execCommand(packageManager)} neonctl`],
   ]);
 
   await replaceInFile(join(destination, "scripts", "worktree-setup.sh"), [
@@ -259,7 +272,7 @@ async function normalizeElectronFiles(
   const scriptPlaceholder = "$" + "{script}";
 
   await replaceInFile(join(destination, "forge.config.ts"), [
-    ["Run `bun run prebuild`", `Run \`${runScript(packageManager, "prebuild")}\``],
+    ["Run \\`bun run prebuild\\`", "Run \\`" + runScript(packageManager, "prebuild") + "\\`"],
     ["function runBunScript", "function runPackageManagerScript"],
     ['spawnSync("bun", ["run", script], {', `spawnSync("${packageManager}", ["run", script], {`],
     [`bun run ${scriptPlaceholder} failed`, `${packageManager} run ${scriptPlaceholder} failed`],
@@ -278,9 +291,6 @@ async function normalizeElectronFiles(
     ["bun install", `${packageManager} install`],
     ["bun run dev", runScript(packageManager, "dev")],
     ["bun run generate-icons", runScript(packageManager, "generate-icons")],
-    ["bun run dist:mac", runScript(packageManager, "dist:mac")],
-    ["bun run dist:win", runScript(packageManager, "dist:win")],
-    ["bun run dist:linux", runScript(packageManager, "dist:linux")],
     ["bun run make:mac", runScript(packageManager, "make:mac")],
     ["bun run make:win", runScript(packageManager, "make:win")],
     ["bun run make:linux", runScript(packageManager, "make:linux")],

--- a/packages/cli/src/helpers/scaffold.ts
+++ b/packages/cli/src/helpers/scaffold.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { cp, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PackageManager } from "../types";
 import { normalizeScaffoldedPackageJson } from "./package-manifest";
@@ -64,8 +64,8 @@ function findTemplateDir(name: string): string | null {
 }
 
 function shouldCopyChatAppFilePath(sourceDir: string, filePath: string): boolean {
-  const relativePath = filePath.replace(`${sourceDir}/`, "");
-  const segments = relativePath.split("/");
+  const relativePath = relative(sourceDir, filePath);
+  const segments = relativePath.split(sep);
   if (segments.some((segment) => CHAT_APP_EXCLUDED_SEGMENTS.has(segment))) {
     return false;
   }
@@ -77,8 +77,8 @@ function shouldCopyElectronFilePath(
   sourceDir: string,
   filePath: string
 ): boolean {
-  const relativePath = filePath.replace(`${sourceDir}/`, "");
-  const segments = relativePath.split("/");
+  const relativePath = relative(sourceDir, filePath);
+  const segments = relativePath.split(sep);
   if (segments.some((segment) => ELECTRON_EXCLUDED_SEGMENTS.has(segment))) {
     return false;
   }

--- a/packages/cli/src/helpers/scaffold.ts
+++ b/packages/cli/src/helpers/scaffold.ts
@@ -2,6 +2,8 @@ import { existsSync } from "node:fs";
 import { cp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { PackageManager } from "../types";
+import { normalizeScaffoldedPackageJson } from "./package-manifest";
 import { runCommand } from "../utils/run-command";
 
 function findTemplateDir(name: string): string {
@@ -15,27 +17,185 @@ function findTemplateDir(name: string): string {
   );
 }
 
-export async function scaffoldFromTemplate(
-  destination: string
+function runScript(packageManager: PackageManager, script: string): string {
+  return `${packageManager} run ${script}`;
+}
+
+async function replaceInFile(
+  filePath: string,
+  replacements: Array<[string, string]>
 ): Promise<void> {
+  if (!existsSync(filePath)) {
+    return;
+  }
+  let content = await readFile(filePath, "utf8");
+  for (const [search, replacement] of replacements) {
+    content = content.replaceAll(search, replacement);
+  }
+  await writeFile(filePath, content);
+}
+
+async function normalizeChatAppFiles(
+  destination: string,
+  packageManager: PackageManager
+): Promise<void> {
+  await replaceInFile(join(destination, "playwright.config.ts"), [
+    ['command: "bun dev"', `command: "${runScript(packageManager, "dev")}"`],
+  ]);
+
+  await replaceInFile(join(destination, "scripts", "check-env.ts"), [
+    [
+      " * Run via `bun run check-env` or automatically in prebuild.",
+      ` * Run via \`${runScript(packageManager, "check-env")}\` or automatically in prebuild.`,
+    ],
+    [
+      "bun fetch:models",
+      runScript(packageManager, "fetch:models"),
+    ],
+  ]);
+
+  await replaceInFile(
+    join(destination, "lib", "ai", "gateways", "fallback-models.ts"),
+    [
+      [
+        "bun fetch:models",
+        runScript(packageManager, "fetch:models"),
+      ],
+    ]
+  );
+
+  await replaceInFile(join(destination, "scripts", "with-db.sh"), [
+    ["bunx neonctl", "npx neonctl"],
+    ["filter out bun's package resolution output", "filter out npx resolution output"],
+    [
+      "Run: bun db:branch:use main  (to switch back to main)",
+      "Run: bash scripts/db-branch-use.sh main  (to switch back to main)",
+    ],
+  ]);
+
+  await replaceInFile(join(destination, "scripts", "db-branch-create.sh"), [
+    ["bunx neonctl", "npx neonctl"],
+    [
+      'echo "To use it: bun db:branch:use $BRANCH_NAME"',
+      'echo "To use it: bash scripts/db-branch-use.sh $BRANCH_NAME"',
+    ],
+  ]);
+
+  await replaceInFile(join(destination, "scripts", "db-branch-use.sh"), [
+    ["bunx neonctl", "npx neonctl"],
+    ['echo "Usage: bun db:branch:use <branch-name>"', 'echo "Usage: bash scripts/db-branch-use.sh <branch-name>"'],
+    [
+      'echo "       bun db:branch:use main  (switch to production)"',
+      'echo "       bash scripts/db-branch-use.sh main  (switch to production)"',
+    ],
+    ['echo "Available branches: bun db:branch:list"', 'echo "Available branches: npx neonctl branches list"'],
+    ['echo "Create branch: bun db:branch:create"', 'echo "Create branch: bash scripts/db-branch-create.sh"'],
+  ]);
+
+  await replaceInFile(join(destination, "scripts", "db-branch-delete.sh"), [
+    ["bunx neonctl", "npx neonctl"],
+  ]);
+
+  await replaceInFile(join(destination, "scripts", "worktree-setup.sh"), [
+    ["bun i", `${packageManager} install`],
+  ]);
+
+  const vercelJsonPath = join(destination, "vercel.json");
+  const vercelJson = JSON.parse(await readFile(vercelJsonPath, "utf8")) as {
+    installCommand?: string;
+    buildCommand?: string;
+  };
+  vercelJson.installCommand = `${packageManager} install`;
+  vercelJson.buildCommand = runScript(packageManager, "build");
+  await writeFile(vercelJsonPath, `${JSON.stringify(vercelJson, null, 2)}\n`);
+}
+
+async function normalizeElectronFiles(
+  destination: string,
+  packageManager: PackageManager
+): Promise<void> {
+  const scriptPlaceholder = "$" + "{script}";
+
+  await replaceInFile(join(destination, "forge.config.ts"), [
+    ["Run `bun run prebuild`", `Run \`${runScript(packageManager, "prebuild")}\``],
+    ["function runBunScript", "function runPackageManagerScript"],
+    ['spawnSync("bun", ["run", script], {', `spawnSync("${packageManager}", ["run", script], {`],
+    [`bun run ${scriptPlaceholder} failed`, `${packageManager} run ${scriptPlaceholder} failed`],
+    ["  runBunScript(\"prebuild\");", "  runPackageManagerScript(\"prebuild\");"],
+    [
+      '        runBunScript("build", { NODE_ENV: "development" });',
+      '        runPackageManagerScript("build", { NODE_ENV: "development" });',
+    ],
+    [
+      '        runBunScript("build", { NODE_ENV: "production" });',
+      '        runPackageManagerScript("build", { NODE_ENV: "production" });',
+    ],
+  ]);
+
+  await replaceInFile(join(destination, "README.md"), [
+    ["bun install", `${packageManager} install`],
+    ["bun run dev", runScript(packageManager, "dev")],
+    ["bun run generate-icons", runScript(packageManager, "generate-icons")],
+    ["bun run dist:mac", runScript(packageManager, "dist:mac")],
+    ["bun run dist:win", runScript(packageManager, "dist:win")],
+    ["bun run dist:linux", runScript(packageManager, "dist:linux")],
+    ["bun run make:mac", runScript(packageManager, "make:mac")],
+    ["bun run make:win", runScript(packageManager, "make:win")],
+    ["bun run make:linux", runScript(packageManager, "make:linux")],
+  ]);
+}
+
+export async function scaffoldFromTemplate(
+  destination: string,
+  options?: { packageManager?: PackageManager }
+): Promise<void> {
+  const packageManager = options?.packageManager ?? "bun";
   const templateDir = findTemplateDir("chat-app");
   await cp(templateDir, destination, { recursive: true });
+
+  const packageJsonPath = join(destination, "package.json");
+  const packageJson = normalizeScaffoldedPackageJson(
+    JSON.parse(await readFile(packageJsonPath, "utf8")) as Record<string, unknown>,
+    {
+      packageManager,
+      template: "chat-app",
+    }
+  );
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  await normalizeChatAppFiles(destination, packageManager);
 }
 
 export async function scaffoldElectron(
   projectDir: string,
-  opts: { projectName: string }
+  opts: { projectName: string; packageManager?: PackageManager }
 ): Promise<void> {
+  const packageManager = opts.packageManager ?? "bun";
+  const rootPackageJsonPath = join(projectDir, "package.json");
+  const rootPackageJson = JSON.parse(
+    await readFile(rootPackageJsonPath, "utf8")
+  ) as {
+    devDependencies?: Record<string, string>;
+  };
   const templateDir = findTemplateDir("electron");
   const destination = join(projectDir, "electron");
   await cp(templateDir, destination, { recursive: true });
 
   const packageJsonPath = join(destination, "package.json");
-  const packageJson = (await readFile(packageJsonPath, "utf8"))
-    .replace("__PROJECT_NAME__-electron", `${opts.projectName}-electron`)
-    .replace("__GITHUB_OWNER__", "your-github-username")
-    .replace("__GITHUB_REPO__", opts.projectName);
-  await writeFile(packageJsonPath, packageJson);
+  const packageJson = normalizeScaffoldedPackageJson(
+    JSON.parse(
+      (await readFile(packageJsonPath, "utf8"))
+        .replace("__PROJECT_NAME__-electron", `${opts.projectName}-electron`)
+        .replace("__GITHUB_OWNER__", "your-github-username")
+        .replace("__GITHUB_REPO__", opts.projectName)
+    ) as Record<string, unknown>,
+    {
+      packageManager,
+      template: "electron",
+      tsxVersion: rootPackageJson.devDependencies?.tsx,
+    }
+  );
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  await normalizeElectronFiles(destination, packageManager);
 }
 
 export async function scaffoldFromGit(

--- a/packages/cli/src/helpers/scaffold.ts
+++ b/packages/cli/src/helpers/scaffold.ts
@@ -6,15 +6,84 @@ import type { PackageManager } from "../types";
 import { normalizeScaffoldedPackageJson } from "./package-manifest";
 import { runCommand } from "../utils/run-command";
 
-function findTemplateDir(name: string): string {
+const CHAT_APP_EXCLUDED_SEGMENTS = new Set([
+  "node_modules",
+  ".next",
+  ".turbo",
+  "playwright",
+  "playwright-report",
+  "test-results",
+  "blob-report",
+  "dist",
+  "build",
+]);
+
+const CHAT_APP_EXCLUDED_FILES = new Set([
+  ".env.local",
+  ".DS_Store",
+  "bun.lock",
+  "bun.lockb",
+]);
+
+const ELECTRON_EXCLUDED_SEGMENTS = new Set([
+  "node_modules",
+  ".turbo",
+  "build",
+  "dist",
+  "release",
+]);
+
+const ELECTRON_EXCLUDED_FILES = new Set([
+  ".DS_Store",
+  "bun.lock",
+  "bun.lockb",
+  "branding.json",
+]);
+
+function getCliPackageRoot(): string {
   const __dir = dirname(fileURLToPath(import.meta.url));
-  for (const relative of [`../templates/${name}`, `../../templates/${name}`]) {
+
+  for (const relative of ["..", "../.."]) {
     const candidate = resolve(__dir, relative);
-    if (existsSync(candidate)) return candidate;
+    if (existsSync(join(candidate, "package.json"))) {
+      return candidate;
+    }
   }
-  throw new Error(
-    `Template "${name}" not found. Run \`bun template:sync\` to generate templates.`
-  );
+
+  throw new Error("Could not locate the @chat-js/cli package root.");
+}
+
+function getRepoRoot(): string {
+  return resolve(getCliPackageRoot(), "../..");
+}
+
+function findTemplateDir(name: string): string | null {
+  const cliRoot = getCliPackageRoot();
+  const candidate = join(cliRoot, "templates", name);
+  return existsSync(candidate) ? candidate : null;
+}
+
+function shouldCopyChatAppFilePath(sourceDir: string, filePath: string): boolean {
+  const relativePath = filePath.replace(`${sourceDir}/`, "");
+  const segments = relativePath.split("/");
+  if (segments.some((segment) => CHAT_APP_EXCLUDED_SEGMENTS.has(segment))) {
+    return false;
+  }
+  const fileName = segments.at(-1);
+  return !(fileName && CHAT_APP_EXCLUDED_FILES.has(fileName));
+}
+
+function shouldCopyElectronFilePath(
+  sourceDir: string,
+  filePath: string
+): boolean {
+  const relativePath = filePath.replace(`${sourceDir}/`, "");
+  const segments = relativePath.split("/");
+  if (segments.some((segment) => ELECTRON_EXCLUDED_SEGMENTS.has(segment))) {
+    return false;
+  }
+  const fileName = segments.at(-1);
+  return !(fileName && ELECTRON_EXCLUDED_FILES.has(fileName));
 }
 
 function runScript(packageManager: PackageManager, script: string): string {
@@ -33,6 +102,79 @@ async function replaceInFile(
     content = content.replaceAll(search, replacement);
   }
   await writeFile(filePath, content);
+}
+
+async function applyChatTemplateSourceTransforms(
+  destination: string
+): Promise<void> {
+  await Promise.all(
+    ["components/github-link.tsx", "components/docs-link.tsx"].map((file) =>
+      rm(join(destination, file), { force: true })
+    )
+  );
+
+  const headerPath = join(destination, "components", "header-actions.tsx");
+  await replaceInFile(headerPath, [
+    ['import { DocsLink } from "@/components/docs-link";\n', ""],
+    ['import { GitHubLink } from "@/components/github-link";\n', ""],
+    ["<DocsLink />", ""],
+    ["<GitHubLink />", ""],
+  ]);
+
+  const globalsCssPath = join(destination, "app", "globals.css");
+  await replaceInFile(globalsCssPath, [
+    [
+      '@source "../node_modules/streamdown/dist/*.js";\n@source "../../../node_modules/streamdown/dist/*.js";',
+      '@source "../node_modules/streamdown/dist/*.js";',
+    ],
+  ]);
+
+  const repoPackageJsonPath = join(getRepoRoot(), "package.json");
+  const rootPackageJson = JSON.parse(
+    await readFile(repoPackageJsonPath, "utf8")
+  ) as { packageManager?: string };
+  const packageJsonPath = join(destination, "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    packageManager?: string;
+  };
+  packageJson.packageManager = rootPackageJson.packageManager;
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+async function applyElectronTemplateSourceTransforms(
+  destination: string
+): Promise<void> {
+  const tsconfigPath = join(destination, "tsconfig.json");
+  await replaceInFile(tsconfigPath, [['"../chat/*"', '"../*"']]);
+
+  const packageJsonPath = join(destination, "package.json");
+  await replaceInFile(packageJsonPath, [
+    ['"name": "@chatjs/electron"', '"name": "__PROJECT_NAME__-electron"'],
+    [
+      '"url": "https://github.com/FranciscoMoretti/chat-js.git"',
+      '"url": "https://github.com/__GITHUB_OWNER__/__GITHUB_REPO__.git"',
+    ],
+  ]);
+}
+
+async function copyChatTemplateFromRepoSource(destination: string): Promise<void> {
+  const sourceDir = join(getRepoRoot(), "apps", "chat");
+  await cp(sourceDir, destination, {
+    recursive: true,
+    filter: (filePath) => shouldCopyChatAppFilePath(sourceDir, filePath),
+  });
+  await applyChatTemplateSourceTransforms(destination);
+}
+
+async function copyElectronTemplateFromRepoSource(
+  destination: string
+): Promise<void> {
+  const sourceDir = join(getRepoRoot(), "apps", "electron");
+  await cp(sourceDir, destination, {
+    recursive: true,
+    filter: (filePath) => shouldCopyElectronFilePath(sourceDir, filePath),
+  });
+  await applyElectronTemplateSourceTransforms(destination);
 }
 
 async function normalizeChatAppFiles(
@@ -151,7 +293,12 @@ export async function scaffoldFromTemplate(
 ): Promise<void> {
   const packageManager = options?.packageManager ?? "bun";
   const templateDir = findTemplateDir("chat-app");
-  await cp(templateDir, destination, { recursive: true });
+
+  if (templateDir) {
+    await cp(templateDir, destination, { recursive: true });
+  } else {
+    await copyChatTemplateFromRepoSource(destination);
+  }
 
   const packageJsonPath = join(destination, "package.json");
   const packageJson = normalizeScaffoldedPackageJson(
@@ -176,9 +323,14 @@ export async function scaffoldElectron(
   ) as {
     devDependencies?: Record<string, string>;
   };
-  const templateDir = findTemplateDir("electron");
   const destination = join(projectDir, "electron");
-  await cp(templateDir, destination, { recursive: true });
+  const templateDir = findTemplateDir("electron");
+
+  if (templateDir) {
+    await cp(templateDir, destination, { recursive: true });
+  } else {
+    await copyElectronTemplateFromRepoSource(destination);
+  }
 
   const packageJsonPath = join(destination, "package.json");
   const packageJson = normalizeScaffoldedPackageJson(

--- a/packages/cli/src/utils/get-package-manager.test.ts
+++ b/packages/cli/src/utils/get-package-manager.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { inferPackageManager } from "./get-package-manager";
+
+describe("inferPackageManager", () => {
+  it("defaults to npm when launched through npm-compatible shims", () => {
+    const originalUserAgent = process.env.npm_config_user_agent;
+
+    process.env.npm_config_user_agent = "npm/10.9.0 node/v22.14.0 darwin arm64";
+
+    try {
+      expect(inferPackageManager()).toBe("npm");
+    } finally {
+      if (originalUserAgent === undefined) {
+        delete process.env.npm_config_user_agent;
+      } else {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
+    }
+  });
+});

--- a/scripts/sync-template.ts
+++ b/scripts/sync-template.ts
@@ -14,6 +14,7 @@ import { join, relative, resolve, sep } from "node:path";
 
 const rootDir = resolve(import.meta.dir, "..");
 const isCheck = process.argv.includes("--check");
+const rootPackageJsonPath = join(rootDir, "package.json");
 
 // --- chat-app ---
 const sourceDir = join(rootDir, "apps", "chat");
@@ -140,6 +141,17 @@ async function applyTemplateTransforms(destination: string): Promise<void> {
     '@source "../node_modules/streamdown/dist/*.js";'
   );
   await writeFile(globalsCssPath, globalsCss);
+
+  // Stamp the template with the monorepo-controlled Bun version at build time.
+  const rootPackageJson = JSON.parse(
+    await readFile(rootPackageJsonPath, "utf8")
+  ) as { packageManager?: string };
+  const packageJsonPath = join(destination, "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    packageManager?: string;
+  };
+  packageJson.packageManager = rootPackageJson.packageManager;
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 }
 
 async function applyElectronTemplateTransforms(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add first-class support for Bun, npm, pnpm, and Yarn in the `@chat-js/cli` scaffold and Electron template. Generated projects, docs, and CI now honor the selected package manager, and default to npm when launched via `npx`/npm unless overridden.

- **New Features**
  - Added `--package-manager <bun|npm|pnpm|yarn>` to control install and next-step commands; the CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools, and `npx`/npm launches default to npm unless overridden.
  - Scaffolds tailor `package.json` scripts and project files to the chosen tool (vercel install/build, Playwright command, Neon scripts, `npx`/`dlx` shims), rewrite Electron README/`forge.config.ts` to generic commands, and print Electron next steps with the selected manager.
  - Pinned Better Auth packages to exact versions and added `overrides` for `@better-auth/core`; Electron dev deps now include `esbuild` and reuse the root `tsx` version.
  - The template stamps the Bun version from the monorepo at build time; scaffolding falls back to repo sources when synced templates are missing.
  - `apps/electron/forge.config.ts` no longer deletes local `node_modules` during packaging.

- **CI**
  - New “CLI Scaffold” GitHub Action builds the CLI and scaffolds + installs with Bun/npm/pnpm/Yarn for web and Electron (runs `npm run make` for npm Electron); added as a required check.
  - Added unit tests for package manager inference and scaffold rewrites; introduced `packages/cli` `test:unit`.

<sup>Written for commit 4b678595b8789dfaa0f19c46dd8199f6761bfbf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI adds --package-manager <bun|npm|pnpm|yarn> to control installs and printed next steps.

* **Documentation**
  * Updated CLI, Quickstart, reference and desktop docs to document package-manager behavior and examples.

* **Scaffolding / UX**
  * Scaffolds preserve or honor the selected/invoking package manager; generated templates rewrite commands and normalize package.json fields/overrides.

* **CI**
  * New "CLI Scaffold" workflow runs scaffold+installs across managers and is now a required check.

* **Tests**
  * New and expanded tests covering scaffolding, package-manager inference, and create command behavior.

* **Packaging**
  * Desktop packaging no longer removes local node_modules during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->