### PR TITLE
Fix collapsed sidebar toggle hover behavior

### DIFF
--- a/apps/chat/components/sidebar-top-row.tsx
+++ b/apps/chat/components/sidebar-top-row.tsx
@@ -39,18 +39,18 @@ export function SidebarTopRow() {
       ) : (
         <button
           aria-label="Expand sidebar"
-          className="group/logo relative flex size-8 items-center justify-center rounded-md hover:bg-muted"
+          className="relative flex size-8 items-center justify-center rounded-md transition-colors group-hover/sidebar:bg-muted"
           onClick={toggleSidebar}
           type="button"
         >
           <Image
             alt={config.appName}
-            className="h-5 w-5 transition-opacity duration-150 group-hover/logo:opacity-0"
+            className="h-5 w-5 transition-opacity duration-150 group-hover/sidebar:opacity-0"
             height={20}
             src="/icon.svg"
             width={20}
           />
-          <PanelLeft className="absolute size-4 opacity-0 transition-opacity duration-150 group-hover/logo:opacity-100" />
+          <PanelLeft className="absolute size-4 opacity-0 transition-opacity duration-150 group-hover/sidebar:opacity-100" />
         </button>
       )}
 

--- a/apps/chat/components/ui/sidebar.tsx
+++ b/apps/chat/components/ui/sidebar.tsx
@@ -219,7 +219,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer hidden text-sidebar-foreground md:block"
+      className="group peer hidden text-sidebar-foreground md:block group/sidebar"
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-side={side}
       data-slot="sidebar"


### PR DESCRIPTION
## Summary
- move the collapsed sidebar toggle hover state from the button to the sidebar hover group
- add a named sidebar group so the icon/background swap responds when the sidebar is hovered

## Testing
- `bun run format`
- `bun run test:types` *(fails: missing `@better-auth/electron` and `@better-auth/electron/proxy` modules in the repo)*

## Summary by Sourcery

Bug Fixes:
- Ensure the collapsed sidebar toggle icon and background update correctly when the sidebar is hovered by associating them with a named sidebar group.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the collapsed sidebar toggle so the icon and background react when hovering the sidebar, not just the button. Improves discoverability of the expand action.

- **Bug Fixes**
  - Shift hover styles from the toggle button to the sidebar’s hover group.
  - Add a named group `group/sidebar` to the sidebar container.
  - Update toggle/icon classes to use `group-hover/sidebar` for background and opacity transitions.

<sup>Written for commit 809a1ddb295dcad03702464118682346400f582c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sidebar expand button hover state styling by refactoring Tailwind group selectors for better consistency across UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->