### PR TITLE
Align releases on Changesets and normalize package changelogs

### DIFF
--- a/.changeset/loud-bulldogs-jump.md
+++ b/.changeset/loud-bulldogs-jump.md
@@ -1,5 +1,0 @@
----
-"@chat-js/registry": patch
----
-
-Publish `@chat-js/registry` as a public package and expose its generated registry artifacts plus shared tool env requirement types.

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -1,4 +1,4 @@
-name: Electron Release
+name: Publish Desktop Artifacts
 
 on:
   push:
@@ -15,7 +15,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   prepare:
-    name: Prepare Electron release
+    name: Prepare desktop artifact publish
     runs-on: ubuntu-22.04
     outputs:
       should_release: ${{ steps.versions.outputs.should_release }}
@@ -65,7 +65,7 @@ jobs:
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=@chatjs/electron@$VERSION" >> "$GITHUB_OUTPUT"
           echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
 
   build:
@@ -123,7 +123,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish Electron release
+    name: Publish desktop artifacts
     permissions:
       contents: write
     needs: [prepare, build]
@@ -139,7 +139,7 @@ jobs:
         with:
           path: /tmp/electron-release-assets
 
-      - name: Create tag and GitHub release
+      - name: Create package release tag and GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
@@ -158,8 +158,8 @@ jobs:
 
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release create "$RELEASE_TAG" \
-              --title "Electron $RELEASE_VERSION" \
-              --notes "Desktop release for ChatJS $RELEASE_VERSION." \
+              --title "@chatjs/electron $RELEASE_VERSION" \
+              --notes "Desktop artifact release for @chatjs/electron $RELEASE_VERSION." \
               --target "$GITHUB_SHA"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: bun run release
-          title: "chore: version packages"
-          commit: "chore: version packages"
+          title: "chore: version releases"
+          commit: "chore: version releases"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ The CLI walks you through gateway, features, and auth choices, generates `chat.c
 - `bun lint`: run workspace lint
 - `bun test:types`: run chat app typecheck
 
+## Releases
+
+Releases are driven by Changesets for the whole repository.
+
+- Add a changeset for each releasable package you change.
+- Merge the generated version PR from the Changesets workflow.
+- Public packages such as `@chat-js/cli` publish to npm.
+- Desktop installers for `@chatjs/electron` publish to GitHub Releases.
+
 ## License
 
 Apache-2.0

--- a/apps/docs/platforms/desktop.mdx
+++ b/apps/docs/platforms/desktop.mdx
@@ -202,18 +202,26 @@ bun run package
 
 ## Release Flow
 
-In the ChatJS monorepo, desktop releases follow the same version-bump PR model used for package releases:
+In the ChatJS monorepo, Changesets is the only release mechanism for both npm packages and desktop artifacts.
+
+The release flow is:
 
 1. Add a changeset that includes `@chatjs/electron`
 2. Let the Changesets workflow open the version PR
 3. Merge that version PR
-4. The Electron release workflow reads the new `apps/electron/package.json` version, builds macOS, Windows, and Linux artifacts, and publishes them to GitHub Releases
+4. The npm release workflow publishes any changed public packages, including `@chat-js/cli`
+5. The desktop artifact workflow reads the new `apps/electron/package.json` version, builds macOS, Windows, and Linux artifacts, and publishes them to GitHub Releases under the package-scoped tag `@chatjs/electron@<version>`
+
+That keeps versioning, changelogs, and release triggering consistent across the repository. The only difference is the publish destination:
+
+- `@chat-js/cli` publishes to npm
+- `@chatjs/electron` publishes installers to GitHub Releases
 
 For a concrete reference, see the workflow used in this repository:
 
 - [`.github/workflows/electron-release.yml`](https://github.com/franciscomoretti/chat-js/blob/main/.github/workflows/electron-release.yml)
 
-If you scaffold a new app with the Electron option, you get the desktop app code and Forge config, but not this repository's release automation automatically. Use the workflow above as a starting point for your own project if you want the same PR-driven release flow.
+If you scaffold a new app with the Electron option, you get the desktop app code and Forge config, but not this repository's release automation automatically. Use the workflow above as a starting point if you want the same Changesets-driven versioning flow in your own project.
 
 ## macOS Distribution Notes
 

--- a/apps/electron/CHANGELOG.md
+++ b/apps/electron/CHANGELOG.md
@@ -1,7 +1,13 @@
 # @chatjs/electron
 
+## 0.3.1
+
+### Patch Changes
+
+- Test patch release generation across all releasable packages.
+
 ## 0.3.0
 
 ### Minor Changes
 
-- [#136](https://github.com/FranciscoMoretti/chat-js/pull/136) [`6b1458c`](https://github.com/FranciscoMoretti/chat-js/commit/6b1458cb071fe4e67bca99fa86ff55bfb4852c64) Thanks [@FranciscoMoretti](https://github.com/FranciscoMoretti)! - Add a PR-driven desktop release flow for the Electron app. Desktop releases now follow the same Changesets version-bump pattern as the CLI: merge the generated version PR, then publish macOS and Windows installers to GitHub Releases using stable download asset names for the site.
+- [#136](https://github.com/FranciscoMoretti/chat-js/pull/136) [`6b1458c`](https://github.com/FranciscoMoretti/chat-js/commit/6b1458cb071fe4e67bca99fa86ff55bfb4852c64) Thanks [@FranciscoMoretti](https://github.com/FranciscoMoretti)! - Add a Changesets-driven desktop release flow for the Electron app. Desktop artifacts are versioned through the shared version PR flow, then published to GitHub Releases for the ChatJS reference app.

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@chatjs/electron",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"private": true,
 	"description": "ChatJS desktop application",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"template:check": "bun scripts/sync-template.ts --check",
 		"chat-js": "bun --filter @chat-js/cli start",
 		"skiller:apply": "bunx skiller@latest apply && turbo run skiller:apply",
-		"publish:cli": "echo 'Legacy CLI-only publish path. Prefer bun run release for standard releases.' && bun run template:sync && bun --filter @chat-js/cli build && npm publish --ignore-scripts -w packages/cli",
 		"db:generate": "dotenv -e .env.local -- bun --filter=@chatjs/chat run db:generate",
 		"db:migrate": "dotenv -e .env.local -- bun --filter=@chatjs/chat run db:migrate",
 		"db:branch:start": "dotenv -e .env.local -- bun --filter=@chatjs/chat run db:branch:start",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chat-js/cli
 
+## 0.6.2
+
+### Patch Changes
+
+- Test patch release generation across all releasable packages.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@chat-js/cli",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"description": "CLI for creating and extending ChatJS apps",
 	"license": "Apache-2.0",
 	"repository": {

--- a/packages/registry/CHANGELOG.md
+++ b/packages/registry/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @chat-js/registry
+
+## 0.1.1
+
+### Patch Changes
+
+- [#159](https://github.com/FranciscoMoretti/chat-js/pull/159) [`a507edd`](https://github.com/FranciscoMoretti/chat-js/commit/a507edd5e6678cadc5b73937d3c5baac49af246e) Thanks [@FranciscoMoretti](https://github.com/FranciscoMoretti)! - Publish `@chat-js/registry` as a public package and expose its generated registry artifacts plus shared tool env requirement types.
+
+- Test patch release generation across all releasable packages.

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chat-js/registry",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ChatJS tool registry items",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- remove the legacy `publish:cli` path so Changesets is the only release mechanism
- align release workflow wording and Electron GitHub release tags with package-scoped versioning
- update README and desktop docs to describe one shared Changesets-driven release flow
- generate patch version and changelog updates for `@chatjs/electron`, `@chat-js/cli`, and `@chat-js/registry`
- add the initial `@chat-js/registry` changelog and consume the pending registry changeset

## Testing
- Ran `bunx changeset version` with `GITHUB_TOKEN` from `gh auth token`
- Ran `bun run docs:links`

## Summary by Sourcery

Align repository release flows on Changesets and package-scoped versioning for both npm packages and desktop artifacts.

Enhancements:
- Standardize desktop artifact GitHub release tags, titles, and notes on the @chatjs/electron package name and version.
- Clarify desktop documentation and README to describe a single Changesets-driven release flow for npm packages and desktop artifacts.
- Remove the legacy CLI-only publish script in favor of the shared Changesets-based release process.
- Retitle the Changesets versioning workflow to reflect that it drives all releases, not just package versions.

CI:
- Rename and tweak the Electron GitHub Actions workflow to publish desktop artifacts under package-scoped tags.

Documentation:
- Document the unified Changesets-powered release process in the README and desktop platform docs.

Chores:
- Add initial changelog for @chat-js/registry and consume its pending changeset.
- Bump patch versions and changelogs for @chatjs/electron, @chat-js/cli, and @chat-js/registry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes all releases on Changesets and aligns desktop GitHub releases with package-scoped tags. Removes the legacy CLI-only publish path, updates workflows and docs, and bumps patch versions for `@chatjs/electron`, `@chat-js/cli`, and `@chat-js/registry`.

- **Refactors**
  - Removed `publish:cli`; Changesets is the only release path for packages and desktop artifacts.
  - Updated desktop workflow to use tag `@chatjs/electron@<version>` with clearer names/titles, and align wording across jobs.
  - Simplified Changesets workflow commit/title to “version releases”.
  - Normalized changelogs: added initial `@chat-js/registry` changelog, generated patch entries, and removed the consumed changeset.
  - Updated README and desktop docs to describe the single Changesets-driven release flow.

<sup>Written for commit 03d001c919c0185c6032c71ae39dde84c7e8217e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release process documentation describing the Changesets workflow for npm packages and desktop installers
  * Updated desktop release flow documentation with clarified publication paths

* **Chores**
  * Released patch updates for multiple packages
  * Updated release workflow naming and metadata configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->