### PR TITLE
Reorder scaffold menus to separate core features from assistant tools

### DIFF
--- a/apps/chat/lib/ai/gateway-model-defaults.ts
+++ b/apps/chat/lib/ai/gateway-model-defaults.ts
@@ -31,6 +31,14 @@ export interface ModelDefaultsFor<G extends GatewayType> {
     urlRetrieval: { enabled: boolean };
     codeExecution: { enabled: boolean };
     mcp: { enabled: boolean };
+    documents: {
+      enabled: boolean;
+      types: {
+        text: boolean;
+        code: boolean;
+        sheet: boolean;
+      };
+    };
     followupSuggestions: { enabled: boolean; default: GatewayModelIdMap[G] };
     text: { polish: GatewayModelIdMap[G] };
     sheet: { format: GatewayModelIdMap[G]; analyze: GatewayModelIdMap[G] };
@@ -82,6 +90,10 @@ const vercelDefaults = {
     urlRetrieval: { enabled: false },
     codeExecution: { enabled: false },
     mcp: { enabled: false },
+    documents: {
+      enabled: true,
+      types: { text: true, code: true, sheet: true },
+    },
     followupSuggestions: {
       enabled: false,
       default: "google/gemini-2.5-flash-lite",
@@ -130,6 +142,10 @@ const openrouterDefaults = {
     urlRetrieval: { enabled: false },
     codeExecution: { enabled: false },
     mcp: { enabled: false },
+    documents: {
+      enabled: true,
+      types: { text: true, code: true, sheet: true },
+    },
     followupSuggestions: {
       enabled: false,
       default: "google/gemini-2.5-flash-lite",
@@ -172,6 +188,10 @@ const openaiDefaults = {
     urlRetrieval: { enabled: false },
     codeExecution: { enabled: false },
     mcp: { enabled: false },
+    documents: {
+      enabled: true,
+      types: { text: true, code: true, sheet: true },
+    },
     followupSuggestions: { enabled: false, default: "gpt-5-nano" },
     text: { polish: "gpt-5-mini" },
     sheet: { format: "gpt-5-mini", analyze: "gpt-5-mini" },
@@ -211,6 +231,10 @@ const openaiCompatibleDefaults = {
     urlRetrieval: { enabled: false },
     codeExecution: { enabled: false },
     mcp: { enabled: false },
+    documents: {
+      enabled: true,
+      types: { text: true, code: true, sheet: true },
+    },
     followupSuggestions: { enabled: false, default: "gpt-5-nano" },
     text: { polish: "gpt-5-mini" },
     sheet: { format: "gpt-5-mini", analyze: "gpt-5-mini" },

--- a/apps/chat/lib/config-schema.ts
+++ b/apps/chat/lib/config-schema.ts
@@ -92,6 +92,14 @@ function createAiSchema<G extends GatewayType>(g: G) {
         mcp: z.object({
           enabled: z.boolean(),
         }),
+        documents: z.object({
+          enabled: z.boolean(),
+          types: z.object({
+            text: z.boolean(),
+            code: z.boolean(),
+            sheet: z.boolean(),
+          }),
+        }),
         followupSuggestions: z.object({
           enabled: z.boolean(),
           default: gatewayModelId<G>(),
@@ -404,6 +412,9 @@ interface AiToolsInputFor<G extends GatewayType> {
   code?: Partial<{ [P in keyof AiToolsShape["code"]]: GatewayModelIdMap[G] }>;
   codeExecution?: Partial<AiToolsShape["codeExecution"]>;
   deepResearch?: DeepResearchToolInputFor<G>;
+  documents?: Partial<AiToolsShape["documents"]> & {
+    types?: Partial<AiToolsShape["documents"]["types"]>;
+  };
   followupSuggestions?: FollowupSuggestionsToolInputFor<G>;
   image?: ImageToolInputFor<G>;
   mcp?: Partial<AiToolsShape["mcp"]>;

--- a/apps/chat/lib/config-schema.ts
+++ b/apps/chat/lib/config-schema.ts
@@ -412,8 +412,8 @@ interface AiToolsInputFor<G extends GatewayType> {
   code?: Partial<{ [P in keyof AiToolsShape["code"]]: GatewayModelIdMap[G] }>;
   codeExecution?: Partial<AiToolsShape["codeExecution"]>;
   deepResearch?: DeepResearchToolInputFor<G>;
-  documents?: Partial<AiToolsShape["documents"]> & {
-    types?: Partial<AiToolsShape["documents"]["types"]>;
+  documents?: Partial<Omit<AiToolsShape["documents"], "types">> & {
+    types?: AiToolsShape["documents"]["types"];
   };
   followupSuggestions?: FollowupSuggestionsToolInputFor<G>;
   image?: ImageToolInputFor<G>;

--- a/apps/chat/tools/platform/tools.ts
+++ b/apps/chat/tools/platform/tools.ts
@@ -56,6 +56,8 @@ export function getTools({
   );
   const documentTypes = config.ai.tools.documents.types;
   const documentsEnabled = config.ai.tools.documents.enabled;
+  const hasEnabledDocumentType =
+    documentTypes.text || documentTypes.code || documentTypes.sheet;
 
   return {
     ...(documentsEnabled
@@ -78,10 +80,14 @@ export function getTools({
                 editSheetDocument: editSheetDocumentTool(documentToolProps),
               }
             : {}),
-          readDocument: readDocument({
-            session,
-            dataStream,
-          }),
+          ...(hasEnabledDocumentType
+            ? {
+                readDocument: readDocument({
+                  session,
+                  dataStream,
+                }),
+              }
+            : {}),
         }
       : {}),
     ...(config.ai.tools.webSearch.enabled

--- a/apps/chat/tools/platform/tools.ts
+++ b/apps/chat/tools/platform/tools.ts
@@ -54,18 +54,36 @@ export function getTools({
       ([name]) => name !== "retrieveUrl" || config.ai.tools.urlRetrieval.enabled
     )
   );
+  const documentTypes = config.ai.tools.documents.types;
+  const documentsEnabled = config.ai.tools.documents.enabled;
 
   return {
-    createTextDocument: createTextDocumentTool(documentToolProps),
-    createCodeDocument: createCodeDocumentTool(documentToolProps),
-    createSheetDocument: createSheetDocumentTool(documentToolProps),
-    editTextDocument: editTextDocumentTool(documentToolProps),
-    editCodeDocument: editCodeDocumentTool(documentToolProps),
-    editSheetDocument: editSheetDocumentTool(documentToolProps),
-    readDocument: readDocument({
-      session,
-      dataStream,
-    }),
+    ...(documentsEnabled
+      ? {
+          ...(documentTypes.text
+            ? {
+                createTextDocument: createTextDocumentTool(documentToolProps),
+                editTextDocument: editTextDocumentTool(documentToolProps),
+              }
+            : {}),
+          ...(documentTypes.code
+            ? {
+                createCodeDocument: createCodeDocumentTool(documentToolProps),
+                editCodeDocument: editCodeDocumentTool(documentToolProps),
+              }
+            : {}),
+          ...(documentTypes.sheet
+            ? {
+                createSheetDocument: createSheetDocumentTool(documentToolProps),
+                editSheetDocument: editSheetDocumentTool(documentToolProps),
+              }
+            : {}),
+          readDocument: readDocument({
+            session,
+            dataStream,
+          }),
+        }
+      : {}),
     ...(config.ai.tools.webSearch.enabled
       ? {
           webSearch: tavilyWebSearch({

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -8,78 +8,90 @@ import { installRegistryTools } from "../utils/install-registry-tools";
 import { spinner } from "../utils/spinner";
 
 export const add = new Command()
-  .name("add")
-  .description("add a tool to an existing ChatJS project")
-  .argument("[tools...]", "tool names to add (e.g. word-count)")
-  .option("-y, --yes", "skip confirmation prompt", false)
-  .option("-o, --overwrite", "overwrite existing files without prompting", false)
-  .option(
-    "-c, --cwd <cwd>",
-    "the working directory (defaults to current directory)",
-    process.cwd()
-  )
-  .option(
-    "-r, --registry <url>",
-    "registry URL or local path template (e.g. ./packages/registry/items/{name}.json)"
-  )
-  .action(async (tools: string[], opts) => {
-    try {
-      const cwd = path.resolve(opts.cwd);
+	.name("add")
+	.description("add a tool to an existing ChatJS project")
+	.argument("[tools...]", "tool names to add (e.g. word-count)")
+	.option("-y, --yes", "skip confirmation prompt", false)
+	.option(
+		"-o, --overwrite",
+		"overwrite existing files without prompting",
+		false,
+	)
+	.option(
+		"-c, --cwd <cwd>",
+		"the working directory (defaults to current directory)",
+		process.cwd(),
+	)
+	.option(
+		"-r, --registry <url>",
+		"registry URL or local path template (e.g. ./packages/registry/items/{name}.json)",
+	)
+	.action(async (tools: string[], opts) => {
+		try {
+			const cwd = path.resolve(opts.cwd);
 
-      if (tools.length === 0) {
-        log.error(
-          "Please specify one or more tool names, e.g. chatjs add word-count"
-        );
-        process.exit(1);
-      }
+			if (tools.length === 0) {
+				log.error(
+					"Please specify one or more tool names, e.g. chatjs add word-count",
+				);
+				process.exit(1);
+			}
 
-      try {
-        await fs.stat(path.join(cwd, "chat.config.ts"));
-      } catch {
-        log.error(
-          "No chat.config.ts found. Run `chat-js create` first or specify --cwd."
-        );
-        process.exit(1);
-      }
+			try {
+				await fs.stat(path.join(cwd, "chat.config.ts"));
+			} catch {
+				log.error(
+					"No chat.config.ts found. Run `chat-js create` first or specify --cwd.",
+				);
+				process.exit(1);
+			}
 
-      intro("chatjs add");
+			intro("chatjs add");
 
-      const configSpinner = spinner("Loading project config...");
-      configSpinner.start();
-      let config: { paths: { tools: string } };
-      try {
-        config = await loadProjectConfig(cwd);
-        configSpinner.succeed("Project config loaded");
-      } catch (err) {
-        configSpinner.fail("Failed to load project config");
-        throw err;
-      }
+			const configSpinner = spinner("Loading project config...");
+			configSpinner.start();
+			let config: { paths: { tools: string } };
+			try {
+				config = await loadProjectConfig(cwd);
+				configSpinner.succeed("Project config loaded");
+			} catch (err) {
+				configSpinner.fail("Failed to load project config");
+				throw err;
+			}
 
-      const toolsDir = resolveToolsPath(config.paths.tools, cwd);
+			const toolsDir = resolveToolsPath(config.paths.tools, cwd);
 
-      if (!opts.yes) {
-        const answer = await confirm({
-          message: `Install ${tools.join(", ")} into ${path.relative(process.cwd(), toolsDir)}/?`,
-        });
-        if (isCancel(answer) || !answer) {
-          outro("Cancelled.");
-          process.exit(0);
-        }
-      }
+			if (!opts.yes) {
+				const answer = await confirm({
+					message: `Install ${tools.join(", ")} into ${path.relative(process.cwd(), toolsDir)}/?`,
+				});
+				if (isCancel(answer) || !answer) {
+					outro("Cancelled.");
+					process.exit(0);
+				}
+			}
 
-      await installRegistryTools({
-        tools,
-        cwd,
-        toolsDir,
-        toolsAlias: config.paths.tools,
-        overwrite: opts.overwrite as boolean,
-        registryUrl: opts.registry,
-      });
+			await installRegistryTools({
+				tools,
+				cwd,
+				toolsDir,
+				toolsAlias: config.paths.tools,
+				overwrite: opts.overwrite as boolean,
+				registryUrl: opts.registry,
+				confirmOverwrite: async (existingFiles) => {
+					const answer = await confirm({
+						message: `${existingFiles
+							.map((file) => path.relative(cwd, file))
+							.join(", ")} already exist. Overwrite?`,
+					});
+					return !(isCancel(answer) || !answer);
+				},
+			});
 
-      outro(
-        `Done! ${tools.length === 1 ? `"${tools[0]}"` : `${tools.length} tools`} installed successfully.`
-      );
-    } catch (error) {
-      handleError(error);
-    }
-  });
+			outro(
+				`Done! ${tools.length === 1 ? `"${tools[0]}"` : `${tools.length} tools`} installed successfully.`,
+			);
+		} catch (error) {
+			handleError(error);
+		}
+	});

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -2,25 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { confirm, intro, isCancel, log, outro } from "@clack/prompts";
 import { Command } from "commander";
-import { resolveRegistryItems } from "../registry/resolve";
-import type { EnvRequirement } from "../registry/schema";
 import { loadProjectConfig, resolveToolsPath } from "../utils/get-config";
 import { handleError } from "../utils/handle-error";
-import {
-  createEmptyToolsTemplate,
-  createEmptyUiTemplate,
-  injectTool,
-} from "../utils/inject-tool";
-import { installDependencies } from "../utils/install-deps";
+import { installRegistryTools } from "../utils/install-registry-tools";
 import { spinner } from "../utils/spinner";
-import { writeToolFiles } from "../utils/write-files";
-
-function formatRequirementDescription(requirement: EnvRequirement): string {
-  return (
-    requirement.description ??
-    requirement.options.map((option) => option.join(" + ")).join(" or ")
-  );
-}
 
 export const add = new Command()
   .name("add")
@@ -48,7 +33,6 @@ export const add = new Command()
         process.exit(1);
       }
 
-      // Preflight: ensure this is a ChatJS project
       try {
         await fs.stat(path.join(cwd, "chat.config.ts"));
       } catch {
@@ -60,7 +44,6 @@ export const add = new Command()
 
       intro("chatjs add");
 
-      // Load project config to resolve the tools directory
       const configSpinner = spinner("Loading project config...");
       configSpinner.start();
       let config: { paths: { tools: string } };
@@ -73,10 +56,7 @@ export const add = new Command()
       }
 
       const toolsDir = resolveToolsPath(config.paths.tools, cwd);
-      const toolsIndexPath = path.join(toolsDir, "tools.ts");
-      const uiIndexPath = path.join(toolsDir, "ui.ts");
 
-      // Confirm installation unless --yes
       if (!opts.yes) {
         const answer = await confirm({
           message: `Install ${tools.join(", ")} into ${path.relative(process.cwd(), toolsDir)}/?`,
@@ -87,149 +67,14 @@ export const add = new Command()
         }
       }
 
-      // Install each tool
-      const processedItems = new Set<string>();
-      for (const name of tools) {
-        log.step(`Installing ${name}`);
-
-        // 1. Resolve the full registry tree
-        const fetchSpinner = spinner(`Fetching ${name}...`);
-        fetchSpinner.start();
-        let resolution: Awaited<ReturnType<typeof resolveRegistryItems>>;
-        try {
-          resolution = await resolveRegistryItems([name], opts.registry);
-          fetchSpinner.succeed(`Fetched ${name}`);
-        } catch (err) {
-          fetchSpinner.fail(`Failed to fetch ${name}`);
-          throw err;
-        }
-
-        const itemsToInstall = resolution.items.filter((item) => {
-          if (processedItems.has(item.name)) {
-            return false;
-          }
-          processedItems.add(item.name);
-          return true;
-        });
-
-        const filesToWrite = itemsToInstall.flatMap((item) => item.files);
-        const dependencies = Array.from(
-          new Set(itemsToInstall.flatMap((item) => item.dependencies ?? []))
-        );
-        const devDependencies = Array.from(
-          new Set(itemsToInstall.flatMap((item) => item.devDependencies ?? []))
-        );
-        const requiredEnvRequirements = itemsToInstall.flatMap((item) =>
-          (item.envRequirements ?? []).map((requirement) => ({
-            tool: item.name,
-            requirement: formatRequirementDescription(requirement),
-          }))
-        );
-        const mainItem = resolution.items.find((item) => item.name === name);
-
-        // 2. Write files to disk
-        const overwrite = opts.overwrite as boolean;
-        try {
-          // First pass: skip existing files unless --overwrite
-          const writeSpinner = spinner("Writing files...");
-          writeSpinner.start();
-          const { written, existing } = await writeToolFiles(filesToWrite, {
-            overwrite,
-            toolsDir,
-            toolsAlias: config.paths.tools,
-          });
-          writeSpinner.stop();
-
-          if (existing.length > 0 && !overwrite) {
-            const answer = await confirm({
-              message: `${existing.map((f) => path.relative(cwd, f)).join(", ")} already exist. Overwrite?`,
-            });
-            if (isCancel(answer) || !answer) {
-              log.warn(
-                `Kept existing files for ${name}; installed remaining new files`
-              );
-            } else {
-              // Write the files that were skipped
-              const { written: rest } = await writeToolFiles(filesToWrite, {
-                overwrite: true,
-                toolsDir,
-                toolsAlias: config.paths.tools,
-              });
-              written.push(...rest);
-            }
-          }
-
-          if (written.length > 0) {
-            log.step(written.map((f) => path.relative(cwd, f)).join(", "));
-          } else {
-            log.step(`No file changes needed for ${name}`);
-          }
-        } catch (err) {
-          log.error("Failed to write files");
-          throw err;
-        }
-
-        // 3. Install npm dependencies
-        if (dependencies.length > 0 || devDependencies.length > 0) {
-          const depsSpinner = spinner("Installing dependencies...");
-          depsSpinner.start();
-          try {
-            await installDependencies(dependencies, devDependencies, cwd);
-            const installed = [
-              ...dependencies,
-              ...devDependencies.map((dep) => `${dep} (dev)`),
-            ];
-            depsSpinner.succeed(`Installed: ${installed.join(", ")}`);
-          } catch (err) {
-            depsSpinner.fail("Failed to install dependencies");
-            throw err;
-          }
-        }
-
-        if (requiredEnvRequirements.length > 0) {
-          const details = requiredEnvRequirements
-            .map(({ tool, requirement }) => `${tool}: ${requirement}`)
-            .join(", ");
-          log.warn(`Required env vars for installed tools: ${details}`);
-        }
-
-        // 4. Inject into the CLI-managed registry files
-        const injectSpinner = spinner("Updating tool registry index...");
-        injectSpinner.start();
-        try {
-          let toolsSource: string;
-          let uiSource: string;
-          try {
-            toolsSource = await fs.readFile(toolsIndexPath, "utf8");
-          } catch {
-            toolsSource = createEmptyToolsTemplate();
-          }
-          try {
-            uiSource = await fs.readFile(uiIndexPath, "utf8");
-          } catch {
-            uiSource = createEmptyUiTemplate();
-          }
-          const shouldInject =
-            mainItem?.files.some(
-              (file) => file.type === "tool" || file.type === "renderer"
-            ) ?? false;
-          const updated = shouldInject
-            ? injectTool({
-                toolsSource,
-                uiSource,
-                name,
-                toolsAlias: config.paths.tools,
-              })
-            : { toolsSource, uiSource };
-          await fs.mkdir(path.dirname(toolsIndexPath), { recursive: true });
-          await fs.writeFile(toolsIndexPath, updated.toolsSource, "utf8");
-          await fs.writeFile(uiIndexPath, updated.uiSource, "utf8");
-          injectSpinner.succeed("Updated tool registry index");
-        } catch (err) {
-          injectSpinner.fail("Failed to update tool registry index");
-          throw err;
-        }
-      }
+      await installRegistryTools({
+        tools,
+        cwd,
+        toolsDir,
+        toolsAlias: config.paths.tools,
+        overwrite: opts.overwrite as boolean,
+        registryUrl: opts.registry,
+      });
 
       outro(
         `Done! ${tools.length === 1 ? `"${tools[0]}"` : `${tools.length} tools`} installed successfully.`

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -6,27 +6,27 @@ import { z } from "zod";
 import { buildConfigTs } from "../helpers/config-builder";
 import { ensureTargetEmpty } from "../helpers/ensure-target";
 import {
-  collectEnvChecklist,
-  type EnvVarEntry,
+	collectEnvChecklist,
+	type EnvVarEntry,
 } from "../helpers/env-checklist";
 import {
-  promptAssistantTools,
-  promptAuth,
-  promptCoreFeatures,
-  promptDocumentTypes,
-  promptElectron,
-  promptGateway,
-  promptInstall,
-  promptProjectName,
+	promptAssistantTools,
+	promptAuth,
+	promptCoreFeatures,
+	promptDocumentTypes,
+	promptElectron,
+	promptGateway,
+	promptInstall,
+	promptProjectName,
 } from "../helpers/prompts";
 import {
-  scaffoldElectron,
-  scaffoldFromGit,
-  scaffoldFromTemplate,
+	scaffoldElectron,
+	scaffoldFromGit,
+	scaffoldFromTemplate,
 } from "../helpers/scaffold";
 import { fetchRegistryIndex } from "../registry/fetch";
-import { inferPackageManager } from "../utils/get-package-manager";
 import { resolveToolsPath } from "../utils/get-config";
+import { inferPackageManager } from "../utils/get-package-manager";
 import { handleError } from "../utils/handle-error";
 import { highlighter } from "../utils/highlighter";
 import { installRegistryTools } from "../utils/install-registry-tools";
@@ -35,271 +35,284 @@ import { runCommand } from "../utils/run-command";
 import { spinner } from "../utils/spinner";
 
 function resolveCreateTarget(targetArg: string | undefined): {
-  projectName: string;
-  targetDir: string;
-  displayPath: string;
+	projectName: string;
+	targetDir: string;
+	displayPath: string;
 } {
-  if (!targetArg) {
-    const projectName = "my-chat-app";
-    return {
-      projectName,
-      targetDir: resolve(process.cwd(), projectName),
-      displayPath: projectName,
-    };
-  }
+	if (!targetArg) {
+		const projectName = "my-chat-app";
+		return {
+			projectName,
+			targetDir: resolve(process.cwd(), projectName),
+			displayPath: projectName,
+		};
+	}
 
-  const targetDir = resolve(process.cwd(), targetArg);
-  const projectName = basename(targetDir);
-  const relativePath = relative(process.cwd(), targetDir);
+	const targetDir = resolve(process.cwd(), targetArg);
+	const projectName = basename(targetDir);
+	const relativePath = relative(process.cwd(), targetDir);
 
-  return {
-    projectName,
-    targetDir,
-    displayPath: relativePath || ".",
-  };
+	return {
+		projectName,
+		targetDir,
+		displayPath: relativePath || ".",
+	};
 }
 
 function printEnvChecklist(entries: EnvVarEntry[]): void {
-  logger.info("Required for your configuration:");
-  logger.break();
+	logger.info("Required for your configuration:");
+	logger.break();
 
-  for (let i = 0; i < entries.length; i += 1) {
-    const entry = entries[i];
+	for (let i = 0; i < entries.length; i += 1) {
+		const entry = entries[i];
 
-    if (!entry.oneOfGroup) {
-      logger.log(
-        `  ${highlighter.warn("*")} ${highlighter.warn(entry.vars)} ${highlighter.dim(`- ${entry.description}`)}`
-      );
-      continue;
-    }
+		if (!entry.oneOfGroup) {
+			logger.log(
+				`  ${highlighter.warn("*")} ${highlighter.warn(entry.vars)} ${highlighter.dim(`- ${entry.description}`)}`,
+			);
+			continue;
+		}
 
-    logger.log(`  ${highlighter.warn("*")} ${highlighter.dim("One of:")}`);
-    while (i < entries.length && entries[i].oneOfGroup === entry.oneOfGroup) {
-      const option = entries[i];
-      logger.log(
-        `    ${highlighter.warn("*")} ${highlighter.warn(option.vars)} ${highlighter.dim(`- ${option.description}`)}`
-      );
-      i += 1;
-    }
-    i -= 1;
-  }
+		logger.log(`  ${highlighter.warn("*")} ${highlighter.dim("One of:")}`);
+		while (i < entries.length && entries[i].oneOfGroup === entry.oneOfGroup) {
+			const option = entries[i];
+			logger.log(
+				`    ${highlighter.warn("*")} ${highlighter.warn(option.vars)} ${highlighter.dim(`- ${option.description}`)}`,
+			);
+			i += 1;
+		}
+		i -= 1;
+	}
 }
 
 const createOptionsSchema = z.object({
-  target: z.string().optional(),
-  yes: z.boolean(),
-  install: z.boolean(),
-  electron: z.boolean().optional(),
-  fromGit: z.string().optional(),
-  registry: z.string().optional(),
-  packageManager: z.enum(["bun", "npm", "pnpm", "yarn"]).optional(),
+	target: z.string().optional(),
+	yes: z.boolean(),
+	install: z.boolean(),
+	electron: z.boolean().optional(),
+	fromGit: z.string().optional(),
+	registry: z.string().optional(),
+	packageManager: z.enum(["bun", "npm", "pnpm", "yarn"]).optional(),
 });
 
 export const create = new Command()
-  .name("create")
-  .description("scaffold a new ChatJS chat application")
-  .argument("[directory]", "target directory for the project")
-  .option("-y, --yes", "skip prompts and use defaults", false)
-  .option("--no-install", "skip dependency installation")
-  .option("--electron", "include the Electron desktop app")
-  .option("--no-electron", "do not include the Electron desktop app")
-  .option(
-    "-r, --registry <url>",
-    "registry URL or local path template (e.g. ./packages/registry/items/{name}.json)"
-  )
-  .option(
-    "--package-manager <manager>",
-    "package manager for install + next steps (bun, npm, pnpm, yarn)"
-  )
-  .option(
-    "--from-git <url>",
-    "clone from a git repository instead of the built-in scaffold"
-  )
-  .action(async (directory, opts) => {
-    try {
-      const options = createOptionsSchema.parse({
-        target: directory,
-        ...opts,
-      });
+	.name("create")
+	.description("scaffold a new ChatJS chat application")
+	.argument("[directory]", "target directory for the project")
+	.option("-y, --yes", "skip prompts and use defaults", false)
+	.option("--no-install", "skip dependency installation")
+	.option("--electron", "include the Electron desktop app")
+	.option("--no-electron", "do not include the Electron desktop app")
+	.option(
+		"-r, --registry <url>",
+		"registry URL or local path template (e.g. ./packages/registry/items/{name}.json)",
+	)
+	.option(
+		"--package-manager <manager>",
+		"package manager for install + next steps (bun, npm, pnpm, yarn)",
+	)
+	.option(
+		"--from-git <url>",
+		"clone from a git repository instead of the built-in scaffold",
+	)
+	.action(async (directory, opts) => {
+		try {
+			const options = createOptionsSchema.parse({
+				target: directory,
+				...opts,
+			});
 
-      const packageManager = options.packageManager ?? inferPackageManager();
+			const packageManager = options.packageManager ?? inferPackageManager();
 
-      if (!options.yes) {
-        intro("Create ChatJS App");
-      }
+			if (!options.yes) {
+				intro("Create ChatJS App");
+			}
 
-      const initialTarget = resolveCreateTarget(options.target);
-      const projectName = await promptProjectName(
-        initialTarget.projectName,
-        options.yes
-      );
-      const targetDir = options.target
-        ? initialTarget.targetDir
-        : resolve(process.cwd(), projectName);
-      const displayPath = options.target ? initialTarget.displayPath : projectName;
+			const initialTarget = resolveCreateTarget(options.target);
+			const projectName = await promptProjectName(
+				initialTarget.projectName,
+				options.yes,
+			);
+			const targetDir = options.target
+				? initialTarget.targetDir
+				: resolve(process.cwd(), projectName);
+			const displayPath = options.target
+				? initialTarget.displayPath
+				: projectName;
 
-      await ensureTargetEmpty(targetDir);
+			await ensureTargetEmpty(targetDir);
 
-      const appName = projectName
-        .split("-")
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(" ");
-      const appPrefix = projectName;
-      const appUrl = "http://localhost:3000";
+			const appName = projectName
+				.split("-")
+				.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+				.join(" ");
+			const appPrefix = projectName;
+			const appUrl = "http://localhost:3000";
 
-      const gateway = await promptGateway(options.yes);
-      const coreFeatures = await promptCoreFeatures(options.yes);
-      const documentTypes = await promptDocumentTypes(
-        options.yes,
-        coreFeatures.documents
-      );
+			const gateway = await promptGateway(options.yes);
+			const coreFeatures = await promptCoreFeatures(options.yes);
+			const documentTypes = await promptDocumentTypes(
+				options.yes,
+				coreFeatures.documents,
+			);
 
-      let registryItems: Awaited<ReturnType<typeof fetchRegistryIndex>> = [];
-      if (!options.yes) {
-        const registrySpinner = spinner("Loading installable tools...");
-        registrySpinner.start();
-        try {
-          registryItems = await fetchRegistryIndex(options.registry);
-          registrySpinner.succeed("Installable tools loaded.");
-        } catch (error) {
-          registrySpinner.fail("Could not load installable tools.");
-          logger.warn(
-            error instanceof Error
-              ? error.message
-              : "Continuing with built-in tools only."
-          );
-        }
-      }
+			let registryItems: Awaited<ReturnType<typeof fetchRegistryIndex>> = [];
+			if (!options.yes) {
+				const registrySpinner = spinner("Loading installable tools...");
+				registrySpinner.start();
+				try {
+					registryItems = await fetchRegistryIndex(options.registry);
+					registrySpinner.succeed("Installable tools loaded.");
+				} catch (error) {
+					registrySpinner.fail("Could not load installable tools.");
+					logger.warn(
+						error instanceof Error
+							? error.message
+							: "Continuing with built-in tools only.",
+					);
+				}
+			}
 
-      const assistantTools = await promptAssistantTools(registryItems, options.yes);
-      const auth = await promptAuth(options.yes);
-      const withElectron = await promptElectron(options.yes, options.electron);
+			const assistantTools = await promptAssistantTools(
+				registryItems,
+				options.yes,
+			);
+			const auth = await promptAuth(options.yes);
+			const withElectron = await promptElectron(options.yes, options.electron);
 
-      logger.break();
-      const scaffoldSpinner = spinner("Scaffolding project...").start();
-      try {
-        if (options.fromGit) {
-          await scaffoldFromGit(options.fromGit, targetDir);
-        } else {
-          await scaffoldFromTemplate(targetDir, { packageManager });
-        }
-        if (withElectron) {
-          await scaffoldElectron(targetDir, {
-            projectName,
-            packageManager,
-          });
-        }
-        scaffoldSpinner.succeed("Project scaffolded.");
-      } catch (error) {
-        scaffoldSpinner.fail("Failed to scaffold project.");
-        throw error;
-      }
+			logger.break();
+			const scaffoldSpinner = spinner("Scaffolding project...").start();
+			try {
+				if (options.fromGit) {
+					await scaffoldFromGit(options.fromGit, targetDir);
+				} else {
+					await scaffoldFromTemplate(targetDir, { packageManager });
+				}
+				if (withElectron) {
+					await scaffoldElectron(targetDir, {
+						projectName,
+						packageManager,
+					});
+				}
+				scaffoldSpinner.succeed("Project scaffolded.");
+			} catch (error) {
+				scaffoldSpinner.fail("Failed to scaffold project.");
+				throw error;
+			}
 
-      const configSpinner = spinner("Writing configuration...").start();
-      try {
-        const packageJsonPath = join(targetDir, "package.json");
-        const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-          name?: string;
-        };
-        packageJson.name = projectName;
-        await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+			const configSpinner = spinner("Writing configuration...").start();
+			try {
+				const packageJsonPath = join(targetDir, "package.json");
+				const packageJson = JSON.parse(
+					await readFile(packageJsonPath, "utf8"),
+				) as {
+					name?: string;
+				};
+				packageJson.name = projectName;
+				await writeFile(
+					packageJsonPath,
+					`${JSON.stringify(packageJson, null, 2)}\n`,
+				);
 
-        const configSource = buildConfigTs({
-          appName,
-          appPrefix,
-          appUrl,
-          withElectron,
-          gateway,
-          coreFeatures,
-          documentTypes,
-          builtInTools: assistantTools.builtInTools,
-          auth,
-        });
-        await writeFile(join(targetDir, "chat.config.ts"), configSource);
-        configSpinner.succeed("Configuration written.");
-      } catch (error) {
-        configSpinner.fail("Failed to write configuration.");
-        throw error;
-      }
+				const configSource = buildConfigTs({
+					appName,
+					appPrefix,
+					appUrl,
+					withElectron,
+					gateway,
+					coreFeatures,
+					documentTypes,
+					builtInTools: assistantTools.builtInTools,
+					auth,
+				});
+				await writeFile(join(targetDir, "chat.config.ts"), configSource);
+				configSpinner.succeed("Configuration written.");
+			} catch (error) {
+				configSpinner.fail("Failed to write configuration.");
+				throw error;
+			}
 
-      const installNow = !options.install
-        ? false
-        : await promptInstall(packageManager, options.yes);
+			const installNow = !options.install
+				? false
+				: await promptInstall(packageManager, options.yes);
 
-      if (assistantTools.installableTools.length > 0) {
-        const toolsDir = resolveToolsPath("@/tools/chatjs", targetDir);
-        await installRegistryTools({
-          tools: assistantTools.installableTools,
-          cwd: targetDir,
-          toolsDir,
-          toolsAlias: "@/tools/chatjs",
-          registryUrl: options.registry,
-          installDependenciesNow: installNow,
-        });
-      }
+			if (assistantTools.installableTools.length > 0) {
+				const toolsDir = resolveToolsPath("@/tools/chatjs", targetDir);
+				await installRegistryTools({
+					tools: assistantTools.installableTools,
+					cwd: targetDir,
+					toolsDir,
+					toolsAlias: "@/tools/chatjs",
+					registryUrl: options.registry,
+					installDependenciesNow: false,
+					packageManager,
+				});
+			}
 
-      if (installNow) {
-        const installSpinner = spinner(
-          `Installing dependencies with ${highlighter.info(packageManager)}...`
-        ).start();
-        try {
-          await runCommand(packageManager, ["install"], targetDir);
-          installSpinner.succeed("Dependencies installed.");
-        } catch (error) {
-          installSpinner.fail("Failed to install dependencies.");
-          throw error;
-        }
-      }
+			if (installNow) {
+				const installSpinner = spinner(
+					`Installing dependencies with ${highlighter.info(packageManager)}...`,
+				).start();
+				try {
+					await runCommand(packageManager, ["install"], targetDir);
+					installSpinner.succeed("Dependencies installed.");
+				} catch (error) {
+					installSpinner.fail("Failed to install dependencies.");
+					throw error;
+				}
+			}
 
-      const envEntries = collectEnvChecklist({
-        gateway,
-        coreFeatures,
-        builtInTools: assistantTools.builtInTools,
-        auth,
-      });
+			const envEntries = collectEnvChecklist({
+				gateway,
+				coreFeatures,
+				builtInTools: assistantTools.builtInTools,
+				auth,
+			});
 
-      outro("Your ChatJS app is ready!");
+			outro("Your ChatJS app is ready!");
 
-      logger.info("Next steps:");
-      logger.break();
-      logger.log(`  ${highlighter.dim("1.")} cd ${highlighter.info(displayPath)}`);
-      logger.log(
-        `  ${highlighter.dim("2.")} Copy ${highlighter.info(".env.example")} to ${highlighter.info(".env.local")} and fill in the values below`
-      );
-      if (!installNow) {
-        logger.log(
-          `  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} install`)}`
-        );
-        logger.log(
-          `  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run db:push`)}`
-        );
-        logger.log(
-          `  ${highlighter.dim("5.")} ${highlighter.info(`${packageManager} run dev`)}`
-        );
-      } else {
-        logger.log(
-          `  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} run db:push`)}`
-        );
-        logger.log(
-          `  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run dev`)}`
-        );
-      }
-      if (withElectron) {
-        logger.break();
-        logger.info("Electron desktop app:");
-        logger.log(
-          `  Run the web app first, then: ${highlighter.info(`cd electron && ${packageManager} install && ${packageManager} run dev`)}`
-        );
-      }
-      logger.break();
+			logger.info("Next steps:");
+			logger.break();
+			logger.log(
+				`  ${highlighter.dim("1.")} cd ${highlighter.info(displayPath)}`,
+			);
+			logger.log(
+				`  ${highlighter.dim("2.")} Copy ${highlighter.info(".env.example")} to ${highlighter.info(".env.local")} and fill in the values below`,
+			);
+			if (!installNow) {
+				logger.log(
+					`  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} install`)}`,
+				);
+				logger.log(
+					`  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run db:push`)}`,
+				);
+				logger.log(
+					`  ${highlighter.dim("5.")} ${highlighter.info(`${packageManager} run dev`)}`,
+				);
+			} else {
+				logger.log(
+					`  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} run db:push`)}`,
+				);
+				logger.log(
+					`  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run dev`)}`,
+				);
+			}
+			if (withElectron) {
+				logger.break();
+				logger.info("Electron desktop app:");
+				logger.log(
+					`  Run the web app first, then: ${highlighter.info(`cd electron && ${packageManager} install && ${packageManager} run dev`)}`,
+				);
+			}
+			logger.break();
 
-      printEnvChecklist(envEntries);
+			printEnvChecklist(envEntries);
 
-      logger.break();
-      logger.log(
-        `  For detailed setup instructions, visit ${highlighter.info("https://www.chatjs.dev/docs/quickstart")}`
-      );
-    } catch (error) {
-      handleError(error);
-    }
-  });
+			logger.break();
+			logger.log(
+				`  For detailed setup instructions, visit ${highlighter.info("https://www.chatjs.dev/docs/quickstart")}`,
+			);
+		} catch (error) {
+			handleError(error);
+		}
+	});

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -6,272 +6,300 @@ import { z } from "zod";
 import { buildConfigTs } from "../helpers/config-builder";
 import { ensureTargetEmpty } from "../helpers/ensure-target";
 import {
-	collectEnvChecklist,
-	type EnvVarEntry,
+  collectEnvChecklist,
+  type EnvVarEntry,
 } from "../helpers/env-checklist";
 import {
-	promptAuth,
-	promptElectron,
-	promptFeatures,
-	promptGateway,
-	promptInstall,
-	promptProjectName,
+  promptAssistantTools,
+  promptAuth,
+  promptCoreFeatures,
+  promptDocumentTypes,
+  promptElectron,
+  promptGateway,
+  promptInstall,
+  promptProjectName,
 } from "../helpers/prompts";
 import {
-	scaffoldElectron,
-	scaffoldFromGit,
-	scaffoldFromTemplate,
+  scaffoldElectron,
+  scaffoldFromGit,
+  scaffoldFromTemplate,
 } from "../helpers/scaffold";
+import { fetchRegistryIndex } from "../registry/fetch";
 import { inferPackageManager } from "../utils/get-package-manager";
+import { resolveToolsPath } from "../utils/get-config";
 import { handleError } from "../utils/handle-error";
 import { highlighter } from "../utils/highlighter";
+import { installRegistryTools } from "../utils/install-registry-tools";
 import { logger } from "../utils/logger";
 import { runCommand } from "../utils/run-command";
 import { spinner } from "../utils/spinner";
 
 function resolveCreateTarget(targetArg: string | undefined): {
-	projectName: string;
-	targetDir: string;
-	displayPath: string;
+  projectName: string;
+  targetDir: string;
+  displayPath: string;
 } {
-	if (!targetArg) {
-		const projectName = "my-chat-app";
-		return {
-			projectName,
-			targetDir: resolve(process.cwd(), projectName),
-			displayPath: projectName,
-		};
-	}
+  if (!targetArg) {
+    const projectName = "my-chat-app";
+    return {
+      projectName,
+      targetDir: resolve(process.cwd(), projectName),
+      displayPath: projectName,
+    };
+  }
 
-	const targetDir = resolve(process.cwd(), targetArg);
-	const projectName = basename(targetDir);
-	const relativePath = relative(process.cwd(), targetDir);
+  const targetDir = resolve(process.cwd(), targetArg);
+  const projectName = basename(targetDir);
+  const relativePath = relative(process.cwd(), targetDir);
 
-	return {
-		projectName,
-		targetDir,
-		displayPath: relativePath || ".",
-	};
+  return {
+    projectName,
+    targetDir,
+    displayPath: relativePath || ".",
+  };
 }
 
 function printEnvChecklist(entries: EnvVarEntry[]): void {
-	logger.info("Required for your configuration:");
-	logger.break();
+  logger.info("Required for your configuration:");
+  logger.break();
 
-	for (let i = 0; i < entries.length; i += 1) {
-		const entry = entries[i];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
 
-		if (!entry.oneOfGroup) {
-			logger.log(
-				`  ${highlighter.warn("*")} ${highlighter.warn(entry.vars)} ${highlighter.dim(`- ${entry.description}`)}`,
-			);
-			continue;
-		}
+    if (!entry.oneOfGroup) {
+      logger.log(
+        `  ${highlighter.warn("*")} ${highlighter.warn(entry.vars)} ${highlighter.dim(`- ${entry.description}`)}`
+      );
+      continue;
+    }
 
-		logger.log(`  ${highlighter.warn("*")} ${highlighter.dim("One of:")}`);
-		while (i < entries.length && entries[i].oneOfGroup === entry.oneOfGroup) {
-			const option = entries[i];
-			logger.log(
-				`    ${highlighter.warn("*")} ${highlighter.warn(option.vars)} ${highlighter.dim(`- ${option.description}`)}`,
-			);
-			i += 1;
-		}
-		i -= 1;
-	}
+    logger.log(`  ${highlighter.warn("*")} ${highlighter.dim("One of:")}`);
+    while (i < entries.length && entries[i].oneOfGroup === entry.oneOfGroup) {
+      const option = entries[i];
+      logger.log(
+        `    ${highlighter.warn("*")} ${highlighter.warn(option.vars)} ${highlighter.dim(`- ${option.description}`)}`
+      );
+      i += 1;
+    }
+    i -= 1;
+  }
 }
 
 const createOptionsSchema = z.object({
-	target: z.string().optional(),
-	yes: z.boolean(),
-	install: z.boolean(),
-	electron: z.boolean().optional(),
-	fromGit: z.string().optional(),
-	packageManager: z.enum(["bun", "npm", "pnpm", "yarn"]).optional(),
+  target: z.string().optional(),
+  yes: z.boolean(),
+  install: z.boolean(),
+  electron: z.boolean().optional(),
+  fromGit: z.string().optional(),
+  registry: z.string().optional(),
+  packageManager: z.enum(["bun", "npm", "pnpm", "yarn"]).optional(),
 });
 
 export const create = new Command()
-	.name("create")
-	.description("scaffold a new ChatJS chat application")
-	.argument("[directory]", "target directory for the project")
-	.option("-y, --yes", "skip prompts and use defaults", false)
-	.option("--no-install", "skip dependency installation")
-	.option("--electron", "include the Electron desktop app")
-	.option("--no-electron", "do not include the Electron desktop app")
-	.option(
-		"--package-manager <manager>",
-		"package manager for install + next steps (bun, npm, pnpm, yarn)",
-	)
-	.option(
-		"--from-git <url>",
-		"clone from a git repository instead of the built-in scaffold",
-	)
-	.action(async (directory, opts) => {
-		try {
-			const options = createOptionsSchema.parse({
-				target: directory,
-				...opts,
-			});
+  .name("create")
+  .description("scaffold a new ChatJS chat application")
+  .argument("[directory]", "target directory for the project")
+  .option("-y, --yes", "skip prompts and use defaults", false)
+  .option("--no-install", "skip dependency installation")
+  .option("--electron", "include the Electron desktop app")
+  .option("--no-electron", "do not include the Electron desktop app")
+  .option(
+    "-r, --registry <url>",
+    "registry URL or local path template (e.g. ./packages/registry/items/{name}.json)"
+  )
+  .option(
+    "--package-manager <manager>",
+    "package manager for install + next steps (bun, npm, pnpm, yarn)"
+  )
+  .option(
+    "--from-git <url>",
+    "clone from a git repository instead of the built-in scaffold"
+  )
+  .action(async (directory, opts) => {
+    try {
+      const options = createOptionsSchema.parse({
+        target: directory,
+        ...opts,
+      });
 
-			const packageManager = options.packageManager ?? inferPackageManager();
+      const packageManager = options.packageManager ?? inferPackageManager();
 
-			if (!options.yes) {
-				intro("Create ChatJS App");
-			}
+      if (!options.yes) {
+        intro("Create ChatJS App");
+      }
 
-			// 1. Project name + target directory
-			const initialTarget = resolveCreateTarget(options.target);
-			const promptedProjectName = await promptProjectName(
-				initialTarget.projectName,
-				options.yes,
-			);
-			const projectName = promptedProjectName;
-			const targetDir = options.target
-				? initialTarget.targetDir
-				: resolve(process.cwd(), projectName);
-			const displayPath = options.target
-				? initialTarget.displayPath
-				: projectName;
+      const initialTarget = resolveCreateTarget(options.target);
+      const projectName = await promptProjectName(
+        initialTarget.projectName,
+        options.yes
+      );
+      const targetDir = options.target
+        ? initialTarget.targetDir
+        : resolve(process.cwd(), projectName);
+      const displayPath = options.target ? initialTarget.displayPath : projectName;
 
-			// 2. Validate target
-			await ensureTargetEmpty(targetDir);
+      await ensureTargetEmpty(targetDir);
 
-			// Derive app details from project name
-			const appName = projectName
-				.split("-")
-				.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-				.join(" ");
-			const appPrefix = projectName;
-			const appUrl = "http://localhost:3000";
+      const appName = projectName
+        .split("-")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      const appPrefix = projectName;
+      const appUrl = "http://localhost:3000";
 
-			// 3. Gateway selection
-			const gateway = await promptGateway(options.yes);
+      const gateway = await promptGateway(options.yes);
+      const coreFeatures = await promptCoreFeatures(options.yes);
+      const documentTypes = await promptDocumentTypes(
+        options.yes,
+        coreFeatures.documents
+      );
 
-			// 4. Features
-			const features = await promptFeatures(options.yes);
+      let registryItems: Awaited<ReturnType<typeof fetchRegistryIndex>> = [];
+      if (!options.yes) {
+        const registrySpinner = spinner("Loading installable tools...");
+        registrySpinner.start();
+        try {
+          registryItems = await fetchRegistryIndex(options.registry);
+          registrySpinner.succeed("Installable tools loaded.");
+        } catch (error) {
+          registrySpinner.fail("Could not load installable tools.");
+          logger.warn(
+            error instanceof Error
+              ? error.message
+              : "Continuing with built-in tools only."
+          );
+        }
+      }
 
-			// 5. Auth providers
-			const auth = await promptAuth(options.yes);
+      const assistantTools = await promptAssistantTools(registryItems, options.yes);
+      const auth = await promptAuth(options.yes);
+      const withElectron = await promptElectron(options.yes, options.electron);
 
-			// 6. Electron
-			const withElectron = await promptElectron(
-				options.yes,
-				options.electron,
-			);
+      logger.break();
+      const scaffoldSpinner = spinner("Scaffolding project...").start();
+      try {
+        if (options.fromGit) {
+          await scaffoldFromGit(options.fromGit, targetDir);
+        } else {
+          await scaffoldFromTemplate(targetDir, { packageManager });
+        }
+        if (withElectron) {
+          await scaffoldElectron(targetDir, {
+            projectName,
+            packageManager,
+          });
+        }
+        scaffoldSpinner.succeed("Project scaffolded.");
+      } catch (error) {
+        scaffoldSpinner.fail("Failed to scaffold project.");
+        throw error;
+      }
 
-			// 7. Scaffold project
-			logger.break();
-			const scaffoldSpinner = spinner("Scaffolding project...").start();
-			try {
-				if (options.fromGit) {
-					await scaffoldFromGit(options.fromGit, targetDir);
-				} else {
-					await scaffoldFromTemplate(targetDir, { packageManager });
-				}
-				if (withElectron) {
-					await scaffoldElectron(targetDir, {
-						projectName,
-						packageManager,
-					});
-				}
-				scaffoldSpinner.succeed("Project scaffolded.");
-			} catch (error) {
-				scaffoldSpinner.fail("Failed to scaffold project.");
-				throw error;
-			}
+      const configSpinner = spinner("Writing configuration...").start();
+      try {
+        const packageJsonPath = join(targetDir, "package.json");
+        const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+          name?: string;
+        };
+        packageJson.name = projectName;
+        await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
-			// 8. Write configuration
-			const configSpinner = spinner("Writing configuration...").start();
-			try {
-				const packageJsonPath = join(targetDir, "package.json");
-				const packageJson = JSON.parse(
-					await readFile(packageJsonPath, "utf8"),
-				) as { name?: string };
-				packageJson.name = projectName;
-				await writeFile(
-					packageJsonPath,
-					`${JSON.stringify(packageJson, null, 2)}\n`,
-				);
+        const configSource = buildConfigTs({
+          appName,
+          appPrefix,
+          appUrl,
+          withElectron,
+          gateway,
+          coreFeatures,
+          documentTypes,
+          builtInTools: assistantTools.builtInTools,
+          auth,
+        });
+        await writeFile(join(targetDir, "chat.config.ts"), configSource);
+        configSpinner.succeed("Configuration written.");
+      } catch (error) {
+        configSpinner.fail("Failed to write configuration.");
+        throw error;
+      }
 
-				const configSource = buildConfigTs({
-					appName,
-					appPrefix,
-					appUrl,
-					withElectron,
-					gateway,
-					features,
-					auth,
-				});
-				await writeFile(join(targetDir, "chat.config.ts"), configSource);
-				configSpinner.succeed("Configuration written.");
-			} catch (error) {
-				configSpinner.fail("Failed to write configuration.");
-				throw error;
-			}
+      const installNow = !options.install
+        ? false
+        : await promptInstall(packageManager, options.yes);
 
-			// 8. Install dependencies
-			const installNow = !options.install
-				? false
-				: await promptInstall(packageManager, options.yes);
-			if (installNow) {
-				const installSpinner = spinner(
-					`Installing dependencies with ${highlighter.info(packageManager)}...`,
-				).start();
-				try {
-					await runCommand(packageManager, ["install"], targetDir);
-					installSpinner.succeed("Dependencies installed.");
-				} catch (error) {
-					installSpinner.fail("Failed to install dependencies.");
-					throw error;
-				}
-			}
+      if (assistantTools.installableTools.length > 0) {
+        const toolsDir = resolveToolsPath("@/tools/chatjs", targetDir);
+        await installRegistryTools({
+          tools: assistantTools.installableTools,
+          cwd: targetDir,
+          toolsDir,
+          toolsAlias: "@/tools/chatjs",
+          registryUrl: options.registry,
+          installDependenciesNow: installNow,
+        });
+      }
 
-			// 9. Success output
-			const envEntries = collectEnvChecklist({ gateway, features, auth });
+      if (installNow) {
+        const installSpinner = spinner(
+          `Installing dependencies with ${highlighter.info(packageManager)}...`
+        ).start();
+        try {
+          await runCommand(packageManager, ["install"], targetDir);
+          installSpinner.succeed("Dependencies installed.");
+        } catch (error) {
+          installSpinner.fail("Failed to install dependencies.");
+          throw error;
+        }
+      }
 
-			outro("Your ChatJS app is ready!");
+      const envEntries = collectEnvChecklist({
+        gateway,
+        coreFeatures,
+        builtInTools: assistantTools.builtInTools,
+        auth,
+      });
 
-			logger.info("Next steps:");
-			logger.break();
-			logger.log(
-				`  ${highlighter.dim("1.")} cd ${highlighter.info(displayPath)}`,
-			);
-			logger.log(
-				`  ${highlighter.dim("2.")} Copy ${highlighter.info(".env.example")} to ${highlighter.info(".env.local")} and fill in the values below`,
-			);
-			if (!installNow) {
-				logger.log(
-					`  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} install`)}`,
-				);
-				logger.log(
-					`  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run db:push`)}`,
-				);
-				logger.log(
-					`  ${highlighter.dim("5.")} ${highlighter.info(`${packageManager} run dev`)}`,
-				);
-			} else {
-				logger.log(
-					`  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} run db:push`)}`,
-				);
-				logger.log(
-					`  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run dev`)}`,
-				);
-			}
-			if (withElectron) {
-				logger.break();
-				logger.info("Electron desktop app:");
-				logger.log(
-					`  Run the web app first, then: ${highlighter.info(`cd electron && ${packageManager} install && ${packageManager} run dev`)}`,
-				);
-			}
-			logger.break();
+      outro("Your ChatJS app is ready!");
 
-			printEnvChecklist(envEntries);
+      logger.info("Next steps:");
+      logger.break();
+      logger.log(`  ${highlighter.dim("1.")} cd ${highlighter.info(displayPath)}`);
+      logger.log(
+        `  ${highlighter.dim("2.")} Copy ${highlighter.info(".env.example")} to ${highlighter.info(".env.local")} and fill in the values below`
+      );
+      if (!installNow) {
+        logger.log(
+          `  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} install`)}`
+        );
+        logger.log(
+          `  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run db:push`)}`
+        );
+        logger.log(
+          `  ${highlighter.dim("5.")} ${highlighter.info(`${packageManager} run dev`)}`
+        );
+      } else {
+        logger.log(
+          `  ${highlighter.dim("3.")} ${highlighter.info(`${packageManager} run db:push`)}`
+        );
+        logger.log(
+          `  ${highlighter.dim("4.")} ${highlighter.info(`${packageManager} run dev`)}`
+        );
+      }
+      if (withElectron) {
+        logger.break();
+        logger.info("Electron desktop app:");
+        logger.log(
+          `  Run the web app first, then: ${highlighter.info(`cd electron && ${packageManager} install && ${packageManager} run dev`)}`
+        );
+      }
+      logger.break();
 
-			logger.break();
-			logger.log(
-				`  For detailed setup instructions, visit ${highlighter.info("https://www.chatjs.dev/docs/quickstart")}`,
-			);
-		} catch (error) {
-			handleError(error);
-		}
-	});
+      printEnvChecklist(envEntries);
+
+      logger.break();
+      logger.log(
+        `  For detailed setup instructions, visit ${highlighter.info("https://www.chatjs.dev/docs/quickstart")}`
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  });

--- a/packages/cli/src/helpers/config-builder.ts
+++ b/packages/cli/src/helpers/config-builder.ts
@@ -1,4 +1,10 @@
-import type { AuthProvider, FeatureKey, Gateway } from "../types";
+import type {
+  AuthProvider,
+  BuiltInToolKey,
+  CoreFeatureKey,
+  DocumentTypeKey,
+  Gateway,
+} from "../types";
 
 const VALID_KEY_REGEX = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
@@ -16,6 +22,16 @@ const DESCRIPTIONS = new Map<string, string>([
     "authentication.vercel",
     "Vercel OAuth (requires VERCEL_APP_CLIENT_ID + VERCEL_APP_CLIENT_SECRET)",
   ],
+  ["ai.tools.mcp.enabled", "Requires MCP_ENCRYPTION_KEY"],
+  ["ai.tools.documents.enabled", "Document create/edit/review support"],
+  ["ai.tools.webSearch.enabled", "Requires TAVILY_API_KEY or FIRECRAWL_API_KEY"],
+  ["ai.tools.urlRetrieval.enabled", "Requires FIRECRAWL_API_KEY"],
+  [
+    "ai.tools.codeExecution.enabled",
+    "Requires Vercel sandbox credentials outside Vercel",
+  ],
+  ["ai.tools.image.enabled", "Requires BLOB_READ_WRITE_TOKEN"],
+  ["ai.tools.deepResearch.enabled", "Requires web search access"],
   [
     "paths.tools",
     "Import alias for the installable tools registry index and tool files",
@@ -39,7 +55,10 @@ type GeneratedConfig = {
     aiProviders: string[];
     paymentProcessors: string[];
   };
-  features: Record<FeatureKey, boolean>;
+  features: {
+    attachments: boolean;
+    parallelResponses: boolean;
+  };
   legal: {
     minimumAge: number;
     governingLaw: string;
@@ -55,6 +74,36 @@ type GeneratedConfig = {
   };
   ai: {
     gateway: Gateway;
+    tools: {
+      mcp: {
+        enabled: boolean;
+      };
+      followupSuggestions: {
+        enabled: boolean;
+      };
+      documents: {
+        enabled: boolean;
+        types: Record<DocumentTypeKey, boolean>;
+      };
+      webSearch: {
+        enabled: boolean;
+      };
+      urlRetrieval: {
+        enabled: boolean;
+      };
+      deepResearch: {
+        enabled: boolean;
+      };
+      codeExecution: {
+        enabled: boolean;
+      };
+      image: {
+        enabled: boolean;
+      };
+      video: {
+        enabled: boolean;
+      };
+    };
   };
   paths: {
     tools: string;
@@ -137,7 +186,7 @@ function generateConfig(
           indent + 1,
           path
         );
-        return `${spaces}${formatKey(key)}: {\n${nested}\n${spaces}},`;
+        return `${spaces}${formatKey(key)}: {\n${nested}\n${spaces}},${comment}`;
       }
 
       return `${spaces}${formatKey(key)}: ${formatValue(
@@ -154,7 +203,9 @@ export function buildConfigTs(input: {
   appUrl: string;
   withElectron: boolean;
   gateway: Gateway;
-  features: Record<FeatureKey, boolean>;
+  coreFeatures: Record<CoreFeatureKey, boolean>;
+  documentTypes: Record<DocumentTypeKey, boolean>;
+  builtInTools: Record<BuiltInToolKey, boolean>;
   auth: Record<AuthProvider, boolean>;
 }): string {
   const fullConfig: GeneratedConfig = {
@@ -174,7 +225,10 @@ export function buildConfigTs(input: {
       aiProviders: ["OpenAI", "Anthropic", "Google"],
       paymentProcessors: [],
     },
-    features: input.features,
+    features: {
+      attachments: input.coreFeatures.attachments,
+      parallelResponses: input.coreFeatures.parallelResponses,
+    },
     legal: {
       minimumAge: 13,
       governingLaw: "United States",
@@ -188,7 +242,39 @@ export function buildConfigTs(input: {
     desktopApp: {
       enabled: input.withElectron,
     },
-    ai: { gateway: input.gateway },
+    ai: {
+      gateway: input.gateway,
+      tools: {
+        mcp: {
+          enabled: input.coreFeatures.mcp,
+        },
+        followupSuggestions: {
+          enabled: input.coreFeatures.followupSuggestions,
+        },
+        documents: {
+          enabled: input.coreFeatures.documents,
+          types: input.documentTypes,
+        },
+        webSearch: {
+          enabled: input.builtInTools.webSearch,
+        },
+        urlRetrieval: {
+          enabled: input.builtInTools.urlRetrieval,
+        },
+        deepResearch: {
+          enabled: input.builtInTools.deepResearch,
+        },
+        codeExecution: {
+          enabled: input.builtInTools.codeExecution,
+        },
+        image: {
+          enabled: input.builtInTools.imageGeneration,
+        },
+        video: {
+          enabled: input.builtInTools.videoGeneration,
+        },
+      },
+    },
     paths: {
       tools: "@/tools/chatjs",
     },

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -1,4 +1,9 @@
-import type { AuthProvider, FeatureKey, Gateway } from "../types";
+import type {
+  AuthProvider,
+  BuiltInToolKey,
+  CoreFeatureKey,
+  Gateway,
+} from "../types";
 
 type EnvVarName = string;
 
@@ -26,8 +31,21 @@ export const gatewayEnvRequirements: Record<Gateway, EnvRequirement> = {
   },
 };
 
-export const featureEnvRequirements: Partial<
-  Record<FeatureKey, EnvRequirement>
+export const coreFeatureEnvRequirements: Partial<
+  Record<CoreFeatureKey, EnvRequirement>
+> = {
+  mcp: {
+    options: [["MCP_ENCRYPTION_KEY"]],
+    description: "MCP_ENCRYPTION_KEY",
+  },
+  attachments: {
+    options: [["BLOB_READ_WRITE_TOKEN"]],
+    description: "BLOB_READ_WRITE_TOKEN",
+  },
+};
+
+export const builtInToolEnvRequirements: Partial<
+  Record<BuiltInToolKey, EnvRequirement>
 > = {
   webSearch: {
     options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
@@ -41,25 +59,17 @@ export const featureEnvRequirements: Partial<
     options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
     description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
   },
-  mcp: {
-    options: [["MCP_ENCRYPTION_KEY"]],
-    description: "MCP_ENCRYPTION_KEY",
-  },
-  imageGeneration: {
-    options: [["BLOB_READ_WRITE_TOKEN"]],
-    description: "BLOB_READ_WRITE_TOKEN",
-  },
-  attachments: {
-    options: [["BLOB_READ_WRITE_TOKEN"]],
-    description: "BLOB_READ_WRITE_TOKEN",
-  },
-  sandbox: {
+  codeExecution: {
     options: [
       ["VERCEL_OIDC_TOKEN"],
       ["VERCEL_TEAM_ID", "VERCEL_PROJECT_ID", "VERCEL_TOKEN"],
     ],
     description:
       "VERCEL_OIDC_TOKEN or VERCEL_TEAM_ID + VERCEL_PROJECT_ID + VERCEL_TOKEN",
+  },
+  imageGeneration: {
+    options: [["BLOB_READ_WRITE_TOKEN"]],
+    description: "BLOB_READ_WRITE_TOKEN",
   },
 };
 

--- a/packages/cli/src/helpers/config-requirements.ts
+++ b/packages/cli/src/helpers/config-requirements.ts
@@ -1,113 +1,118 @@
 import type {
-  AuthProvider,
-  BuiltInToolKey,
-  CoreFeatureKey,
-  Gateway,
+	AuthProvider,
+	BuiltInToolKey,
+	CoreFeatureKey,
+	Gateway,
 } from "../types";
 
 type EnvVarName = string;
 
 export interface EnvRequirement {
-  description: string;
-  options: EnvVarName[][];
+	description: string;
+	options: EnvVarName[][];
 }
 
 export const gatewayEnvRequirements: Record<Gateway, EnvRequirement> = {
-  openrouter: {
-    options: [["OPENROUTER_API_KEY"]],
-    description: "OPENROUTER_API_KEY",
-  },
-  openai: {
-    options: [["OPENAI_API_KEY"]],
-    description: "OPENAI_API_KEY",
-  },
-  vercel: {
-    options: [["AI_GATEWAY_API_KEY"], ["VERCEL_OIDC_TOKEN"]],
-    description: "AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN",
-  },
-  "openai-compatible": {
-    options: [["OPENAI_COMPATIBLE_BASE_URL", "OPENAI_COMPATIBLE_API_KEY"]],
-    description: "OPENAI_COMPATIBLE_BASE_URL + OPENAI_COMPATIBLE_API_KEY",
-  },
+	openrouter: {
+		options: [["OPENROUTER_API_KEY"]],
+		description: "OPENROUTER_API_KEY",
+	},
+	openai: {
+		options: [["OPENAI_API_KEY"]],
+		description: "OPENAI_API_KEY",
+	},
+	vercel: {
+		options: [["AI_GATEWAY_API_KEY"], ["VERCEL_OIDC_TOKEN"]],
+		description: "AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN",
+	},
+	"openai-compatible": {
+		options: [["OPENAI_COMPATIBLE_BASE_URL", "OPENAI_COMPATIBLE_API_KEY"]],
+		description: "OPENAI_COMPATIBLE_BASE_URL + OPENAI_COMPATIBLE_API_KEY",
+	},
 };
 
 export const coreFeatureEnvRequirements: Partial<
-  Record<CoreFeatureKey, EnvRequirement>
+	Record<CoreFeatureKey, EnvRequirement>
 > = {
-  mcp: {
-    options: [["MCP_ENCRYPTION_KEY"]],
-    description: "MCP_ENCRYPTION_KEY",
-  },
-  attachments: {
-    options: [["BLOB_READ_WRITE_TOKEN"]],
-    description: "BLOB_READ_WRITE_TOKEN",
-  },
+	mcp: {
+		options: [["MCP_ENCRYPTION_KEY"]],
+		description: "MCP_ENCRYPTION_KEY",
+	},
+	attachments: {
+		options: [["BLOB_READ_WRITE_TOKEN"]],
+		description: "BLOB_READ_WRITE_TOKEN",
+	},
 };
 
-export const builtInToolEnvRequirements: Partial<
-  Record<BuiltInToolKey, EnvRequirement>
+export const builtInToolEnvRequirements: Record<
+	BuiltInToolKey,
+	EnvRequirement | undefined
 > = {
-  webSearch: {
-    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
-  },
-  urlRetrieval: {
-    options: [["FIRECRAWL_API_KEY"]],
-    description: "FIRECRAWL_API_KEY",
-  },
-  deepResearch: {
-    options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
-    description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
-  },
-  codeExecution: {
-    options: [
-      ["VERCEL_OIDC_TOKEN"],
-      ["VERCEL_TEAM_ID", "VERCEL_PROJECT_ID", "VERCEL_TOKEN"],
-    ],
-    description:
-      "VERCEL_OIDC_TOKEN or VERCEL_TEAM_ID + VERCEL_PROJECT_ID + VERCEL_TOKEN",
-  },
-  imageGeneration: {
-    options: [["BLOB_READ_WRITE_TOKEN"]],
-    description: "BLOB_READ_WRITE_TOKEN",
-  },
+	webSearch: {
+		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
+		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+	},
+	urlRetrieval: {
+		options: [["FIRECRAWL_API_KEY"]],
+		description: "FIRECRAWL_API_KEY",
+	},
+	deepResearch: {
+		options: [["TAVILY_API_KEY"], ["FIRECRAWL_API_KEY"]],
+		description: "TAVILY_API_KEY or FIRECRAWL_API_KEY",
+	},
+	codeExecution: {
+		options: [
+			["VERCEL_OIDC_TOKEN"],
+			["VERCEL_TEAM_ID", "VERCEL_PROJECT_ID", "VERCEL_TOKEN"],
+		],
+		description:
+			"VERCEL_OIDC_TOKEN or VERCEL_TEAM_ID + VERCEL_PROJECT_ID + VERCEL_TOKEN",
+	},
+	imageGeneration: {
+		options: [["BLOB_READ_WRITE_TOKEN"]],
+		description: "BLOB_READ_WRITE_TOKEN",
+	},
+	videoGeneration: {
+		options: [["BLOB_READ_WRITE_TOKEN"]],
+		description: "BLOB_READ_WRITE_TOKEN",
+	},
 };
 
 export const authEnvRequirements: Record<AuthProvider, EnvRequirement> = {
-  google: {
-    options: [["AUTH_GOOGLE_ID", "AUTH_GOOGLE_SECRET"]],
-    description: "AUTH_GOOGLE_ID + AUTH_GOOGLE_SECRET",
-  },
-  github: {
-    options: [["AUTH_GITHUB_ID", "AUTH_GITHUB_SECRET"]],
-    description: "AUTH_GITHUB_ID + AUTH_GITHUB_SECRET",
-  },
-  vercel: {
-    options: [["VERCEL_APP_CLIENT_ID", "VERCEL_APP_CLIENT_SECRET"]],
-    description: "VERCEL_APP_CLIENT_ID + VERCEL_APP_CLIENT_SECRET",
-  },
+	google: {
+		options: [["AUTH_GOOGLE_ID", "AUTH_GOOGLE_SECRET"]],
+		description: "AUTH_GOOGLE_ID + AUTH_GOOGLE_SECRET",
+	},
+	github: {
+		options: [["AUTH_GITHUB_ID", "AUTH_GITHUB_SECRET"]],
+		description: "AUTH_GITHUB_ID + AUTH_GITHUB_SECRET",
+	},
+	vercel: {
+		options: [["VERCEL_APP_CLIENT_ID", "VERCEL_APP_CLIENT_SECRET"]],
+		description: "VERCEL_APP_CLIENT_ID + VERCEL_APP_CLIENT_SECRET",
+	},
 };
 
 export const envVarDescriptions: Record<string, string> = {
-  AUTH_SECRET: "Secret used to sign auth sessions",
-  DATABASE_URL: "Database connection string",
-  OPENROUTER_API_KEY: "OpenRouter API key",
-  OPENAI_API_KEY: "OpenAI API key",
-  AI_GATEWAY_API_KEY: "Vercel AI Gateway API key",
-  VERCEL_OIDC_TOKEN: "OIDC token available in Vercel runtime",
-  OPENAI_COMPATIBLE_BASE_URL: "Base URL for OpenAI-compatible gateway",
-  OPENAI_COMPATIBLE_API_KEY: "API key for OpenAI-compatible gateway",
-  TAVILY_API_KEY: "Tavily API key for web search",
-  FIRECRAWL_API_KEY: "Firecrawl API key for search/retrieval",
-  MCP_ENCRYPTION_KEY: "Encryption key for MCP connector secrets",
-  BLOB_READ_WRITE_TOKEN: "Blob storage token for uploads and generated files",
-  VERCEL_TEAM_ID: "Vercel team id for sandbox execution",
-  VERCEL_PROJECT_ID: "Vercel project id for sandbox execution",
-  VERCEL_TOKEN: "Vercel token for sandbox execution",
-  AUTH_GOOGLE_ID: "Google OAuth client id",
-  AUTH_GOOGLE_SECRET: "Google OAuth client secret",
-  AUTH_GITHUB_ID: "GitHub OAuth client id",
-  AUTH_GITHUB_SECRET: "GitHub OAuth client secret",
-  VERCEL_APP_CLIENT_ID: "Vercel OAuth client id",
-  VERCEL_APP_CLIENT_SECRET: "Vercel OAuth client secret",
+	AUTH_SECRET: "Secret used to sign auth sessions",
+	DATABASE_URL: "Database connection string",
+	OPENROUTER_API_KEY: "OpenRouter API key",
+	OPENAI_API_KEY: "OpenAI API key",
+	AI_GATEWAY_API_KEY: "Vercel AI Gateway API key",
+	VERCEL_OIDC_TOKEN: "OIDC token available in Vercel runtime",
+	OPENAI_COMPATIBLE_BASE_URL: "Base URL for OpenAI-compatible gateway",
+	OPENAI_COMPATIBLE_API_KEY: "API key for OpenAI-compatible gateway",
+	TAVILY_API_KEY: "Tavily API key for web search",
+	FIRECRAWL_API_KEY: "Firecrawl API key for search/retrieval",
+	MCP_ENCRYPTION_KEY: "Encryption key for MCP connector secrets",
+	BLOB_READ_WRITE_TOKEN: "Blob storage token for uploads and generated files",
+	VERCEL_TEAM_ID: "Vercel team id for sandbox execution",
+	VERCEL_PROJECT_ID: "Vercel project id for sandbox execution",
+	VERCEL_TOKEN: "Vercel token for sandbox execution",
+	AUTH_GOOGLE_ID: "Google OAuth client id",
+	AUTH_GOOGLE_SECRET: "Google OAuth client secret",
+	AUTH_GITHUB_ID: "GitHub OAuth client id",
+	AUTH_GITHUB_SECRET: "GitHub OAuth client secret",
+	VERCEL_APP_CLIENT_ID: "Vercel OAuth client id",
+	VERCEL_APP_CLIENT_SECRET: "Vercel OAuth client secret",
 };

--- a/packages/cli/src/helpers/env-checklist.ts
+++ b/packages/cli/src/helpers/env-checklist.ts
@@ -1,14 +1,17 @@
 import {
   authEnvRequirements,
+  builtInToolEnvRequirements,
+  coreFeatureEnvRequirements,
   type EnvRequirement,
   envVarDescriptions,
-  featureEnvRequirements,
   gatewayEnvRequirements,
 } from "./config-requirements";
 import {
-  FEATURE_KEYS,
   type AuthProvider,
-  type FeatureKey,
+  BUILT_IN_TOOL_KEYS,
+  CORE_FEATURE_KEYS,
+  type BuiltInToolKey,
+  type CoreFeatureKey,
   type Gateway,
 } from "../types";
 
@@ -51,7 +54,8 @@ function requirementToEntries(requirement: EnvRequirement): EnvVarEntry[] {
 
 export function collectEnvChecklist(input: {
   gateway: Gateway;
-  features: Record<FeatureKey, boolean>;
+  coreFeatures: Record<CoreFeatureKey, boolean>;
+  builtInTools: Record<BuiltInToolKey, boolean>;
   auth: Record<AuthProvider, boolean>;
 }): EnvVarEntry[] {
   const entries: EnvVarEntry[] = [];
@@ -75,13 +79,28 @@ export function collectEnvChecklist(input: {
   const featureItems: EnvVarEntry[] = [];
   const seen = new Set<string>();
 
-  for (const feature of FEATURE_KEYS) {
-    if (!input.features[feature]) continue;
+  for (const feature of CORE_FEATURE_KEYS) {
+    if (!input.coreFeatures[feature]) continue;
     const requirement =
-      featureEnvRequirements[feature as keyof typeof featureEnvRequirements];
+      coreFeatureEnvRequirements[
+        feature as keyof typeof coreFeatureEnvRequirements
+      ];
     if (!requirement) continue;
 
-    // Deduplicate — e.g. webSearch and deepResearch both need TAVILY_API_KEY
+    // Deduplicate repeated env requirements across feature/tool selections.
+    if (seen.has(requirement.description)) continue;
+    seen.add(requirement.description);
+
+    featureItems.push(...requirementToEntries(requirement));
+  }
+
+  for (const tool of BUILT_IN_TOOL_KEYS) {
+    if (!input.builtInTools[tool]) continue;
+    const requirement =
+      builtInToolEnvRequirements[
+        tool as keyof typeof builtInToolEnvRequirements
+      ];
+    if (!requirement) continue;
     if (seen.has(requirement.description)) continue;
     seen.add(requirement.description);
 

--- a/packages/cli/src/helpers/prompts.ts
+++ b/packages/cli/src/helpers/prompts.ts
@@ -1,334 +1,343 @@
 import {
-  cancel,
-  confirm,
-  isCancel,
-  multiselect,
-  select,
-  text,
+	cancel,
+	confirm,
+	isCancel,
+	multiselect,
+	select,
+	text,
 } from "@clack/prompts";
 import type { RegistryIndexItem } from "../registry/fetch";
 import {
-  authEnvRequirements,
-  builtInToolEnvRequirements,
-  coreFeatureEnvRequirements,
-  gatewayEnvRequirements,
-} from "./config-requirements";
-import {
-  AUTH_PROVIDERS,
-  BUILT_IN_TOOL_KEYS,
-  CORE_FEATURE_KEYS,
-  DOCUMENT_TYPE_KEYS,
-  GATEWAYS,
-  type AuthProvider,
-  type BuiltInToolKey,
-  type CoreFeatureKey,
-  type DocumentTypeKey,
-  type Gateway,
+	AUTH_PROVIDERS,
+	type AuthProvider,
+	BUILT_IN_TOOL_KEYS,
+	type BuiltInToolKey,
+	CORE_FEATURE_KEYS,
+	type CoreFeatureKey,
+	DOCUMENT_TYPE_KEYS,
+	type DocumentTypeKey,
+	GATEWAYS,
+	type Gateway,
 } from "../types";
 import { highlighter } from "../utils/highlighter";
 import { logger } from "../utils/logger";
+import {
+	authEnvRequirements,
+	builtInToolEnvRequirements,
+	coreFeatureEnvRequirements,
+	gatewayEnvRequirements,
+} from "./config-requirements";
 
 const CORE_FEATURE_DEFAULTS: Record<CoreFeatureKey, boolean> = {
-  attachments: false,
-  parallelResponses: true,
-  documents: true,
-  mcp: false,
-  followupSuggestions: true,
+	attachments: false,
+	parallelResponses: true,
+	documents: true,
+	mcp: false,
+	followupSuggestions: true,
 };
 
 const DOCUMENT_TYPE_DEFAULTS: Record<DocumentTypeKey, boolean> = {
-  text: true,
-  code: true,
-  sheet: true,
+	text: true,
+	code: true,
+	sheet: true,
 };
 
 const BUILT_IN_TOOL_DEFAULTS: Record<BuiltInToolKey, boolean> = {
-  webSearch: false,
-  urlRetrieval: false,
-  deepResearch: false,
-  codeExecution: false,
-  imageGeneration: false,
-  videoGeneration: false,
+	webSearch: false,
+	urlRetrieval: false,
+	deepResearch: false,
+	codeExecution: false,
+	imageGeneration: false,
+	videoGeneration: false,
 };
 
 const AUTH_DEFAULTS: Record<AuthProvider, boolean> = {
-  google: false,
-  github: true,
-  vercel: false,
+	google: false,
+	github: true,
+	vercel: false,
 };
 
 const CORE_FEATURE_LABELS: Record<CoreFeatureKey, string> = {
-  attachments: "Attachments",
-  parallelResponses: "Parallel Responses",
-  documents: "Documents",
-  mcp: "MCP Tool Servers",
-  followupSuggestions: "Follow-up Suggestions",
+	attachments: "Attachments",
+	parallelResponses: "Parallel Responses",
+	documents: "Documents",
+	mcp: "MCP Tool Servers",
+	followupSuggestions: "Follow-up Suggestions",
 };
 
 const DOCUMENT_TYPE_LABELS: Record<DocumentTypeKey, string> = {
-  text: "Text Documents",
-  code: "Code Documents",
-  sheet: "Spreadsheet Documents",
+	text: "Text Documents",
+	code: "Code Documents",
+	sheet: "Spreadsheet Documents",
 };
 
 const DOCUMENT_TYPE_HINTS: Record<DocumentTypeKey, string> = {
-  text: "Notes, guides, markdown, and long-form writing",
-  code: "Code files and snippets",
-  sheet: "CSV-based tables and structured data",
+	text: "Notes, guides, markdown, and long-form writing",
+	code: "Code files and snippets",
+	sheet: "CSV-based tables and structured data",
 };
 
 const BUILT_IN_TOOL_LABELS: Record<BuiltInToolKey, string> = {
-  webSearch: "Web Search",
-  urlRetrieval: "URL Retrieval",
-  deepResearch: "Deep Research",
-  codeExecution: "Code Sandbox",
-  imageGeneration: "Image Generation",
-  videoGeneration: "Video Generation",
+	webSearch: "Web Search",
+	urlRetrieval: "URL Retrieval",
+	deepResearch: "Deep Research",
+	codeExecution: "Code Sandbox",
+	imageGeneration: "Image Generation",
+	videoGeneration: "Video Generation",
 };
 
 const BUILT_IN_TOOL_HINTS: Record<BuiltInToolKey, string> = {
-  webSearch: "Search the web from chat",
-  urlRetrieval: "Fetch structured content from a specific URL",
-  deepResearch: "Run multi-step web research and generate reports",
-  codeExecution: "Execute code in a sandboxed environment",
-  imageGeneration: "Generate images inside chat",
-  videoGeneration: "Generate videos inside chat",
+	webSearch: "Search the web from chat",
+	urlRetrieval: "Fetch structured content from a specific URL",
+	deepResearch: "Run multi-step web research and generate reports",
+	codeExecution: "Execute code in a sandboxed environment",
+	imageGeneration: "Generate images inside chat",
+	videoGeneration: "Generate videos inside chat",
 };
 
 const AUTH_LABELS: Record<AuthProvider, string> = {
-  google: "Google OAuth",
-  github: "GitHub OAuth",
-  vercel: "Vercel OAuth",
+	google: "Google OAuth",
+	github: "GitHub OAuth",
+	vercel: "Vercel OAuth",
 };
 
 function handleCancel(value: unknown): asserts value is never {
-  if (isCancel(value)) {
-    cancel("Operation cancelled.");
-    process.exit(1);
-  }
+	if (isCancel(value)) {
+		cancel("Operation cancelled.");
+		process.exit(1);
+	}
 }
 
 function toKebabCase(value: string | undefined): string {
-  return (value ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
+	return (value ?? "")
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
 }
 
 function toSelectionRecord<T extends string>(
-  keys: readonly T[],
-  selected: readonly string[]
+	keys: readonly T[],
+	selected: readonly string[],
 ): Record<T, boolean> {
-  return Object.fromEntries(
-    keys.map((key) => [key, selected.includes(key)])
-  ) as Record<T, boolean>;
+	return Object.fromEntries(
+		keys.map((key) => [key, selected.includes(key)]),
+	) as Record<T, boolean>;
 }
 
 export async function promptProjectName(
-  targetArg: string | undefined,
-  skipPrompt: boolean
+	targetArg: string | undefined,
+	skipPrompt: boolean,
 ): Promise<string> {
-  if (skipPrompt) {
-    return toKebabCase(targetArg ?? "my-chat-app") || "my-chat-app";
-  }
+	if (skipPrompt) {
+		return toKebabCase(targetArg ?? "my-chat-app") || "my-chat-app";
+	}
 
-  const name = await text({
-    message: "What is your project named?",
-    initialValue: targetArg ?? "my-chat-app",
-    validate: (value?: string) => {
-      const kebab = toKebabCase(value);
-      if (!kebab) return "Please enter a valid project name";
-    },
-  });
-  handleCancel(name);
+	const name = await text({
+		message: "What is your project named?",
+		initialValue: targetArg ?? "my-chat-app",
+		validate: (value?: string) => {
+			const kebab = toKebabCase(value);
+			if (!kebab) return "Please enter a valid project name";
+		},
+	});
+	handleCancel(name);
 
-  return toKebabCase(name) || "my-chat-app";
+	return toKebabCase(name) || "my-chat-app";
 }
 
 export async function promptGateway(skipPrompt: boolean): Promise<Gateway> {
-  if (skipPrompt) return "vercel";
+	if (skipPrompt) return "vercel";
 
-  const gateway = await select({
-    message: `Which ${highlighter.info("AI gateway")} would you like to use?`,
-    options: GATEWAYS.map((gw) => ({
-      value: gw,
-      label: gw,
-      hint: gatewayEnvRequirements[gw].description,
-    })),
-    initialValue: "vercel" as Gateway,
-  });
-  handleCancel(gateway);
+	const gateway = await select({
+		message: `Which ${highlighter.info("AI gateway")} would you like to use?`,
+		options: GATEWAYS.map((gw) => ({
+			value: gw,
+			label: gw,
+			hint: gatewayEnvRequirements[gw].description,
+		})),
+		initialValue: "vercel" as Gateway,
+	});
+	handleCancel(gateway);
 
-  return gateway;
+	return gateway;
 }
 
 export async function promptCoreFeatures(
-  skipPrompt: boolean
+	skipPrompt: boolean,
 ): Promise<Record<CoreFeatureKey, boolean>> {
-  if (skipPrompt) return { ...CORE_FEATURE_DEFAULTS };
+	if (skipPrompt) return { ...CORE_FEATURE_DEFAULTS };
 
-  const selected = await multiselect({
-    message: `Which ${highlighter.info("core features")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
-    options: CORE_FEATURE_KEYS.map((key) => ({
-      value: key,
-      label: CORE_FEATURE_LABELS[key],
-      hint:
-        key === "documents"
-          ? "Create, edit, and review documents in chat"
-          : coreFeatureEnvRequirements[
-              key as keyof typeof coreFeatureEnvRequirements
-            ]?.description,
-    })),
-    initialValues: CORE_FEATURE_KEYS.filter((key) => CORE_FEATURE_DEFAULTS[key]),
-    required: false,
-  });
-  handleCancel(selected);
+	const selected = await multiselect({
+		message: `Which ${highlighter.info("core features")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
+		options: CORE_FEATURE_KEYS.map((key) => ({
+			value: key,
+			label: CORE_FEATURE_LABELS[key],
+			hint:
+				key === "documents"
+					? "Create, edit, and review documents in chat"
+					: coreFeatureEnvRequirements[
+							key as keyof typeof coreFeatureEnvRequirements
+						]?.description,
+		})),
+		initialValues: CORE_FEATURE_KEYS.filter(
+			(key) => CORE_FEATURE_DEFAULTS[key],
+		),
+		required: false,
+	});
+	handleCancel(selected);
 
-  return toSelectionRecord(CORE_FEATURE_KEYS, selected as CoreFeatureKey[]);
+	return toSelectionRecord(CORE_FEATURE_KEYS, selected as CoreFeatureKey[]);
 }
 
 export async function promptDocumentTypes(
-  skipPrompt: boolean,
-  documentsEnabled: boolean
+	skipPrompt: boolean,
+	documentsEnabled: boolean,
 ): Promise<Record<DocumentTypeKey, boolean>> {
-  if (!documentsEnabled) {
-    return toSelectionRecord(DOCUMENT_TYPE_KEYS, []);
-  }
+	if (!documentsEnabled) {
+		return toSelectionRecord(DOCUMENT_TYPE_KEYS, []);
+	}
 
-  if (skipPrompt) return { ...DOCUMENT_TYPE_DEFAULTS };
+	if (skipPrompt) return { ...DOCUMENT_TYPE_DEFAULTS };
 
-  const selected = await multiselect({
-    message: `Which ${highlighter.info("document types")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
-    options: DOCUMENT_TYPE_KEYS.map((key) => ({
-      value: key,
-      label: DOCUMENT_TYPE_LABELS[key],
-      hint: DOCUMENT_TYPE_HINTS[key],
-    })),
-    initialValues: DOCUMENT_TYPE_KEYS.filter((key) => DOCUMENT_TYPE_DEFAULTS[key]),
-    required: false,
-  });
-  handleCancel(selected);
+	const selected = await multiselect({
+		message: `Which ${highlighter.info("document types")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
+		options: DOCUMENT_TYPE_KEYS.map((key) => ({
+			value: key,
+			label: DOCUMENT_TYPE_LABELS[key],
+			hint: DOCUMENT_TYPE_HINTS[key],
+		})),
+		initialValues: DOCUMENT_TYPE_KEYS.filter(
+			(key) => DOCUMENT_TYPE_DEFAULTS[key],
+		),
+		required: false,
+	});
+	handleCancel(selected);
 
-  return toSelectionRecord(DOCUMENT_TYPE_KEYS, selected as DocumentTypeKey[]);
+	return toSelectionRecord(DOCUMENT_TYPE_KEYS, selected as DocumentTypeKey[]);
 }
 
 export async function promptAssistantTools(
-  registryItems: RegistryIndexItem[],
-  skipPrompt: boolean
+	registryItems: RegistryIndexItem[],
+	skipPrompt: boolean,
 ): Promise<{
-  builtInTools: Record<BuiltInToolKey, boolean>;
-  installableTools: string[];
+	builtInTools: Record<BuiltInToolKey, boolean>;
+	installableTools: string[];
 }> {
-  const installableItems = registryItems.filter((item) => !item.hidden);
+	const installableItems = registryItems.filter((item) => !item.hidden);
 
-  if (skipPrompt) {
-    return {
-      builtInTools: { ...BUILT_IN_TOOL_DEFAULTS },
-      installableTools: [],
-    };
-  }
+	if (skipPrompt) {
+		return {
+			builtInTools: { ...BUILT_IN_TOOL_DEFAULTS },
+			installableTools: [],
+		};
+	}
 
-  const selected = await multiselect({
-    message: `Which ${highlighter.info("assistant tools")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
-    options: [
-      ...BUILT_IN_TOOL_KEYS.map((key) => ({
-        value: key,
-        label: BUILT_IN_TOOL_LABELS[key],
-        hint:
-          builtInToolEnvRequirements[
-            key as keyof typeof builtInToolEnvRequirements
-          ]?.description ?? BUILT_IN_TOOL_HINTS[key],
-      })),
-      ...installableItems.map((item) => ({
-        value: item.name,
-        label: item.name,
-        hint: item.description,
-      })),
-    ],
-    initialValues: BUILT_IN_TOOL_KEYS.filter((key) => BUILT_IN_TOOL_DEFAULTS[key]),
-    required: false,
-  });
-  handleCancel(selected);
+	const selected = await multiselect({
+		message: `Which ${highlighter.info("assistant tools")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
+		options: [
+			...BUILT_IN_TOOL_KEYS.map((key) => ({
+				value: key,
+				label: BUILT_IN_TOOL_LABELS[key],
+				hint:
+					builtInToolEnvRequirements[
+						key as keyof typeof builtInToolEnvRequirements
+					]?.description ?? BUILT_IN_TOOL_HINTS[key],
+			})),
+			...installableItems.map((item) => ({
+				value: item.name,
+				label: item.name,
+				hint: item.description,
+			})),
+		],
+		initialValues: BUILT_IN_TOOL_KEYS.filter(
+			(key) => BUILT_IN_TOOL_DEFAULTS[key],
+		),
+		required: false,
+	});
+	handleCancel(selected);
 
-  const selectedValues = selected as string[];
-  const builtInTools = toSelectionRecord(
-    BUILT_IN_TOOL_KEYS,
-    selectedValues.filter((value): value is BuiltInToolKey =>
-      (BUILT_IN_TOOL_KEYS as readonly string[]).includes(value)
-    )
-  );
+	const selectedValues = selected as string[];
+	const builtInTools = toSelectionRecord(
+		BUILT_IN_TOOL_KEYS,
+		selectedValues.filter((value): value is BuiltInToolKey =>
+			(BUILT_IN_TOOL_KEYS as readonly string[]).includes(value),
+		),
+	);
+	if (builtInTools.deepResearch) {
+		builtInTools.webSearch = true;
+	}
 
-  return {
-    builtInTools,
-    installableTools: selectedValues.filter(
-      (value) => !(BUILT_IN_TOOL_KEYS as readonly string[]).includes(value)
-    ),
-  };
+	return {
+		builtInTools,
+		installableTools: selectedValues.filter(
+			(value) => !(BUILT_IN_TOOL_KEYS as readonly string[]).includes(value),
+		),
+	};
 }
 
 export async function promptAuth(
-  skipPrompt: boolean
+	skipPrompt: boolean,
 ): Promise<Record<AuthProvider, boolean>> {
-  if (skipPrompt) return { ...AUTH_DEFAULTS };
+	if (skipPrompt) return { ...AUTH_DEFAULTS };
 
-  const defaultProviders = AUTH_PROVIDERS.filter((p) => AUTH_DEFAULTS[p]);
+	const defaultProviders = AUTH_PROVIDERS.filter((p) => AUTH_DEFAULTS[p]);
 
-  let selectedProviders: AuthProvider[] = [];
+	let selectedProviders: AuthProvider[] = [];
 
-  while (selectedProviders.length === 0) {
-    const selected = await multiselect({
-      message: `Which ${highlighter.info("auth providers")} would you like to enable? ${highlighter.warn("(at least one required)")} ${highlighter.dim("(space to toggle, enter to submit)")}`,
-      options: AUTH_PROVIDERS.map((p) => ({
-        value: p,
-        label: AUTH_LABELS[p],
-        hint: authEnvRequirements[p].description,
-      })),
-      initialValues: defaultProviders,
-      required: false,
-    });
-    handleCancel(selected);
+	while (selectedProviders.length === 0) {
+		const selected = await multiselect({
+			message: `Which ${highlighter.info("auth providers")} would you like to enable? ${highlighter.warn("(at least one required)")} ${highlighter.dim("(space to toggle, enter to submit)")}`,
+			options: AUTH_PROVIDERS.map((p) => ({
+				value: p,
+				label: AUTH_LABELS[p],
+				hint: authEnvRequirements[p].description,
+			})),
+			initialValues: defaultProviders,
+			required: false,
+		});
+		handleCancel(selected);
 
-    selectedProviders = selected as AuthProvider[];
-    if (selectedProviders.length === 0) {
-      logger.warn("At least one auth provider is required. Please select one.");
-    }
-  }
+		selectedProviders = selected as AuthProvider[];
+		if (selectedProviders.length === 0) {
+			logger.warn("At least one auth provider is required. Please select one.");
+		}
+	}
 
-  return toSelectionRecord(AUTH_PROVIDERS, selectedProviders);
+	return toSelectionRecord(AUTH_PROVIDERS, selectedProviders);
 }
 
 export async function promptElectron(
-  skipPrompt: boolean,
-  explicitChoice?: boolean
+	skipPrompt: boolean,
+	explicitChoice?: boolean,
 ): Promise<boolean> {
-  if (typeof explicitChoice === "boolean") {
-    return explicitChoice;
-  }
+	if (typeof explicitChoice === "boolean") {
+		return explicitChoice;
+	}
 
-  if (skipPrompt) return false;
+	if (skipPrompt) return false;
 
-  const wantsElectron = await confirm({
-    message: `Include an ${highlighter.info("Electron")} desktop app?`,
-    initialValue: false,
-  });
-  handleCancel(wantsElectron);
+	const wantsElectron = await confirm({
+		message: `Include an ${highlighter.info("Electron")} desktop app?`,
+		initialValue: false,
+	});
+	handleCancel(wantsElectron);
 
-  return wantsElectron;
+	return wantsElectron;
 }
 
 export async function promptInstall(
-  packageManager: string,
-  skipPrompt: boolean
+	packageManager: string,
+	skipPrompt: boolean,
 ): Promise<boolean> {
-  if (skipPrompt) return true;
+	if (skipPrompt) return true;
 
-  const install = await confirm({
-    message: `Install dependencies with ${highlighter.info(packageManager)}?`,
-    initialValue: true,
-  });
-  handleCancel(install);
+	const install = await confirm({
+		message: `Install dependencies with ${highlighter.info(packageManager)}?`,
+		initialValue: true,
+	});
+	handleCancel(install);
 
-  return install;
+	return install;
 }

--- a/packages/cli/src/helpers/prompts.ts
+++ b/packages/cli/src/helpers/prompts.ts
@@ -1,68 +1,111 @@
 import {
-	cancel,
-	confirm,
-	isCancel,
-	multiselect,
-	select,
-	text,
+  cancel,
+  confirm,
+  isCancel,
+  multiselect,
+  select,
+  text,
 } from "@clack/prompts";
+import type { RegistryIndexItem } from "../registry/fetch";
 import {
   authEnvRequirements,
-  featureEnvRequirements,
+  builtInToolEnvRequirements,
+  coreFeatureEnvRequirements,
   gatewayEnvRequirements,
 } from "./config-requirements";
 import {
   AUTH_PROVIDERS,
-  FEATURE_KEYS,
+  BUILT_IN_TOOL_KEYS,
+  CORE_FEATURE_KEYS,
+  DOCUMENT_TYPE_KEYS,
   GATEWAYS,
   type AuthProvider,
-  type FeatureKey,
+  type BuiltInToolKey,
+  type CoreFeatureKey,
+  type DocumentTypeKey,
   type Gateway,
 } from "../types";
 import { highlighter } from "../utils/highlighter";
 import { logger } from "../utils/logger";
 
-const FEATURE_DEFAULTS: Record<FeatureKey, boolean> = {
-	sandbox: false,
-	webSearch: false,
-	urlRetrieval: false,
-	deepResearch: false,
-	mcp: false,
-	imageGeneration: false,
-	attachments: false,
-	followupSuggestions: true,
+const CORE_FEATURE_DEFAULTS: Record<CoreFeatureKey, boolean> = {
+  attachments: false,
   parallelResponses: true,
+  documents: true,
+  mcp: false,
+  followupSuggestions: true,
+};
+
+const DOCUMENT_TYPE_DEFAULTS: Record<DocumentTypeKey, boolean> = {
+  text: true,
+  code: true,
+  sheet: true,
+};
+
+const BUILT_IN_TOOL_DEFAULTS: Record<BuiltInToolKey, boolean> = {
+  webSearch: false,
+  urlRetrieval: false,
+  deepResearch: false,
+  codeExecution: false,
+  imageGeneration: false,
+  videoGeneration: false,
 };
 
 const AUTH_DEFAULTS: Record<AuthProvider, boolean> = {
-	google: false,
-	github: true,
-	vercel: false,
+  google: false,
+  github: true,
+  vercel: false,
 };
 
-const FEATURE_LABELS: Record<FeatureKey, string> = {
-	sandbox: "Code Sandbox",
-	webSearch: "Web Search",
-	urlRetrieval: "URL Retrieval",
-	deepResearch: "Deep Research",
-	mcp: "MCP Tool Servers",
-	imageGeneration: "Image Generation",
-	attachments: "File Attachments",
-	followupSuggestions: "Follow-up Suggestions",
+const CORE_FEATURE_LABELS: Record<CoreFeatureKey, string> = {
+  attachments: "Attachments",
   parallelResponses: "Parallel Responses",
+  documents: "Documents",
+  mcp: "MCP Tool Servers",
+  followupSuggestions: "Follow-up Suggestions",
+};
+
+const DOCUMENT_TYPE_LABELS: Record<DocumentTypeKey, string> = {
+  text: "Text Documents",
+  code: "Code Documents",
+  sheet: "Spreadsheet Documents",
+};
+
+const DOCUMENT_TYPE_HINTS: Record<DocumentTypeKey, string> = {
+  text: "Notes, guides, markdown, and long-form writing",
+  code: "Code files and snippets",
+  sheet: "CSV-based tables and structured data",
+};
+
+const BUILT_IN_TOOL_LABELS: Record<BuiltInToolKey, string> = {
+  webSearch: "Web Search",
+  urlRetrieval: "URL Retrieval",
+  deepResearch: "Deep Research",
+  codeExecution: "Code Sandbox",
+  imageGeneration: "Image Generation",
+  videoGeneration: "Video Generation",
+};
+
+const BUILT_IN_TOOL_HINTS: Record<BuiltInToolKey, string> = {
+  webSearch: "Search the web from chat",
+  urlRetrieval: "Fetch structured content from a specific URL",
+  deepResearch: "Run multi-step web research and generate reports",
+  codeExecution: "Execute code in a sandboxed environment",
+  imageGeneration: "Generate images inside chat",
+  videoGeneration: "Generate videos inside chat",
 };
 
 const AUTH_LABELS: Record<AuthProvider, string> = {
-	google: "Google OAuth",
-	github: "GitHub OAuth",
-	vercel: "Vercel OAuth",
+  google: "Google OAuth",
+  github: "GitHub OAuth",
+  vercel: "Vercel OAuth",
 };
 
 function handleCancel(value: unknown): asserts value is never {
-	if (isCancel(value)) {
-		cancel("Operation cancelled.");
-		process.exit(1);
-	}
+  if (isCancel(value)) {
+    cancel("Operation cancelled.");
+    process.exit(1);
+  }
 }
 
 function toKebabCase(value: string | undefined): string {
@@ -74,12 +117,22 @@ function toKebabCase(value: string | undefined): string {
     .replace(/^-|-$/g, "");
 }
 
+function toSelectionRecord<T extends string>(
+  keys: readonly T[],
+  selected: readonly string[]
+): Record<T, boolean> {
+  return Object.fromEntries(
+    keys.map((key) => [key, selected.includes(key)])
+  ) as Record<T, boolean>;
+}
+
 export async function promptProjectName(
-	targetArg: string | undefined,
-	skipPrompt: boolean,
+  targetArg: string | undefined,
+  skipPrompt: boolean
 ): Promise<string> {
-	if (skipPrompt)
-		return toKebabCase(targetArg ?? "my-chat-app") || "my-chat-app";
+  if (skipPrompt) {
+    return toKebabCase(targetArg ?? "my-chat-app") || "my-chat-app";
+  }
 
   const name = await text({
     message: "What is your project named?",
@@ -91,11 +144,11 @@ export async function promptProjectName(
   });
   handleCancel(name);
 
-	return toKebabCase(name) || "my-chat-app";
+  return toKebabCase(name) || "my-chat-app";
 }
 
 export async function promptGateway(skipPrompt: boolean): Promise<Gateway> {
-	if (skipPrompt) return "vercel";
+  if (skipPrompt) return "vercel";
 
   const gateway = await select({
     message: `Which ${highlighter.info("AI gateway")} would you like to use?`,
@@ -108,52 +161,121 @@ export async function promptGateway(skipPrompt: boolean): Promise<Gateway> {
   });
   handleCancel(gateway);
 
-	return gateway;
+  return gateway;
 }
 
-export async function promptFeatures(
-	skipPrompt: boolean,
-): Promise<Record<FeatureKey, boolean>> {
-	if (skipPrompt) return { ...FEATURE_DEFAULTS };
+export async function promptCoreFeatures(
+  skipPrompt: boolean
+): Promise<Record<CoreFeatureKey, boolean>> {
+  if (skipPrompt) return { ...CORE_FEATURE_DEFAULTS };
 
-	const defaultFeatures = FEATURE_KEYS.filter((key) => FEATURE_DEFAULTS[key]);
+  const selected = await multiselect({
+    message: `Which ${highlighter.info("core features")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
+    options: CORE_FEATURE_KEYS.map((key) => ({
+      value: key,
+      label: CORE_FEATURE_LABELS[key],
+      hint:
+        key === "documents"
+          ? "Create, edit, and review documents in chat"
+          : coreFeatureEnvRequirements[
+              key as keyof typeof coreFeatureEnvRequirements
+            ]?.description,
+    })),
+    initialValues: CORE_FEATURE_KEYS.filter((key) => CORE_FEATURE_DEFAULTS[key]),
+    required: false,
+  });
+  handleCancel(selected);
 
-	const selectedFeatures = await multiselect({
-		message: `Which ${highlighter.info("features")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
-		options: FEATURE_KEYS.map((key) => ({
-			value: key,
-			label: FEATURE_LABELS[key],
-			hint: featureEnvRequirements[key as keyof typeof featureEnvRequirements]
-				?.description,
-		})),
-		initialValues: defaultFeatures,
-		required: false,
-	});
-	handleCancel(selectedFeatures);
+  return toSelectionRecord(CORE_FEATURE_KEYS, selected as CoreFeatureKey[]);
+}
 
-	const features: Record<FeatureKey, boolean> = { ...FEATURE_DEFAULTS };
-	for (const key of FEATURE_KEYS) {
-		features[key] = false;
-	}
-	for (const key of selectedFeatures as FeatureKey[]) {
-		features[key] = true;
-	}
+export async function promptDocumentTypes(
+  skipPrompt: boolean,
+  documentsEnabled: boolean
+): Promise<Record<DocumentTypeKey, boolean>> {
+  if (!documentsEnabled) {
+    return toSelectionRecord(DOCUMENT_TYPE_KEYS, []);
+  }
 
-	if (features.deepResearch) {
-		features.webSearch = true;
-	}
+  if (skipPrompt) return { ...DOCUMENT_TYPE_DEFAULTS };
 
-	return features;
+  const selected = await multiselect({
+    message: `Which ${highlighter.info("document types")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
+    options: DOCUMENT_TYPE_KEYS.map((key) => ({
+      value: key,
+      label: DOCUMENT_TYPE_LABELS[key],
+      hint: DOCUMENT_TYPE_HINTS[key],
+    })),
+    initialValues: DOCUMENT_TYPE_KEYS.filter((key) => DOCUMENT_TYPE_DEFAULTS[key]),
+    required: false,
+  });
+  handleCancel(selected);
+
+  return toSelectionRecord(DOCUMENT_TYPE_KEYS, selected as DocumentTypeKey[]);
+}
+
+export async function promptAssistantTools(
+  registryItems: RegistryIndexItem[],
+  skipPrompt: boolean
+): Promise<{
+  builtInTools: Record<BuiltInToolKey, boolean>;
+  installableTools: string[];
+}> {
+  const installableItems = registryItems.filter((item) => !item.hidden);
+
+  if (skipPrompt) {
+    return {
+      builtInTools: { ...BUILT_IN_TOOL_DEFAULTS },
+      installableTools: [],
+    };
+  }
+
+  const selected = await multiselect({
+    message: `Which ${highlighter.info("assistant tools")} would you like to enable? ${highlighter.dim("(space to toggle, enter to submit)")}`,
+    options: [
+      ...BUILT_IN_TOOL_KEYS.map((key) => ({
+        value: key,
+        label: BUILT_IN_TOOL_LABELS[key],
+        hint:
+          builtInToolEnvRequirements[
+            key as keyof typeof builtInToolEnvRequirements
+          ]?.description ?? BUILT_IN_TOOL_HINTS[key],
+      })),
+      ...installableItems.map((item) => ({
+        value: item.name,
+        label: item.name,
+        hint: item.description,
+      })),
+    ],
+    initialValues: BUILT_IN_TOOL_KEYS.filter((key) => BUILT_IN_TOOL_DEFAULTS[key]),
+    required: false,
+  });
+  handleCancel(selected);
+
+  const selectedValues = selected as string[];
+  const builtInTools = toSelectionRecord(
+    BUILT_IN_TOOL_KEYS,
+    selectedValues.filter((value): value is BuiltInToolKey =>
+      (BUILT_IN_TOOL_KEYS as readonly string[]).includes(value)
+    )
+  );
+
+  return {
+    builtInTools,
+    installableTools: selectedValues.filter(
+      (value) => !(BUILT_IN_TOOL_KEYS as readonly string[]).includes(value)
+    ),
+  };
 }
 
 export async function promptAuth(
-	skipPrompt: boolean,
+  skipPrompt: boolean
 ): Promise<Record<AuthProvider, boolean>> {
-	if (skipPrompt) return { ...AUTH_DEFAULTS };
+  if (skipPrompt) return { ...AUTH_DEFAULTS };
 
   const defaultProviders = AUTH_PROVIDERS.filter((p) => AUTH_DEFAULTS[p]);
 
-	let selectedProviders: AuthProvider[] = [];
+  let selectedProviders: AuthProvider[] = [];
 
   while (selectedProviders.length === 0) {
     const selected = await multiselect({
@@ -168,54 +290,45 @@ export async function promptAuth(
     });
     handleCancel(selected);
 
-		selectedProviders = selected as AuthProvider[];
-		if (selectedProviders.length === 0) {
-			logger.warn("At least one auth provider is required. Please select one.");
-		}
-	}
+    selectedProviders = selected as AuthProvider[];
+    if (selectedProviders.length === 0) {
+      logger.warn("At least one auth provider is required. Please select one.");
+    }
+  }
 
-	const auth: Record<AuthProvider, boolean> = {
-		google: false,
-		github: false,
-		vercel: false,
-	};
-	for (const p of selectedProviders) {
-		auth[p] = true;
-	}
-
-	return auth;
+  return toSelectionRecord(AUTH_PROVIDERS, selectedProviders);
 }
 
 export async function promptElectron(
-	skipPrompt: boolean,
-	explicitChoice?: boolean,
+  skipPrompt: boolean,
+  explicitChoice?: boolean
 ): Promise<boolean> {
-	if (typeof explicitChoice === "boolean") {
-		return explicitChoice;
-	}
+  if (typeof explicitChoice === "boolean") {
+    return explicitChoice;
+  }
 
-	if (skipPrompt) return false;
+  if (skipPrompt) return false;
 
-	const wantsElectron = await confirm({
-		message: `Include an ${highlighter.info("Electron")} desktop app?`,
-		initialValue: false,
-	});
-	handleCancel(wantsElectron);
+  const wantsElectron = await confirm({
+    message: `Include an ${highlighter.info("Electron")} desktop app?`,
+    initialValue: false,
+  });
+  handleCancel(wantsElectron);
 
-	return wantsElectron;
+  return wantsElectron;
 }
 
 export async function promptInstall(
-	packageManager: string,
-	skipPrompt: boolean,
+  packageManager: string,
+  skipPrompt: boolean
 ): Promise<boolean> {
-	if (skipPrompt) return true;
+  if (skipPrompt) return true;
 
-	const install = await confirm({
-		message: `Install dependencies with ${highlighter.info(packageManager)}?`,
-		initialValue: true,
-	});
-	handleCancel(install);
+  const install = await confirm({
+    message: `Install dependencies with ${highlighter.info(packageManager)}?`,
+    initialValue: true,
+  });
+  handleCancel(install);
 
-	return install;
+  return install;
 }

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
 import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
 import { readFile, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -10,235 +10,249 @@ import { scaffoldElectron, scaffoldFromTemplate } from "./scaffold";
 const tempDirs: string[] = [];
 
 async function makeTempDir(name: string): Promise<string> {
-  const dir = join(tmpdir(), `chat-js-cli-${name}-${crypto.randomUUID()}`);
-  tempDirs.push(dir);
-  return dir;
+	const dir = join(tmpdir(), `chat-js-cli-${name}-${crypto.randomUUID()}`);
+	tempDirs.push(dir);
+	return dir;
 }
 
 function getCliPackageRoot(): string {
-  return resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+	return resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 }
 
 afterEach(async () => {
-  await Promise.all(
-    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
-  );
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+	);
 });
 
 describe("buildConfigTs", () => {
-  it("writes desktopApp.enabled=false for web-only scaffolds", () => {
-    const output = buildConfigTs({
-      appName: "My Chat",
-      appPrefix: "my-chat",
-      appUrl: "http://localhost:3000",
-      withElectron: false,
-      gateway: "vercel",
-      coreFeatures: {
-        attachments: false,
-        parallelResponses: true,
-        documents: true,
-        mcp: false,
-        followupSuggestions: true,
-      },
-      documentTypes: {
-        text: true,
-        code: true,
-        sheet: true,
-      },
-      builtInTools: {
-        webSearch: false,
-        urlRetrieval: false,
-        deepResearch: false,
-        codeExecution: false,
-        imageGeneration: false,
-        videoGeneration: false,
-      },
-      auth: {
-        google: false,
-        github: true,
-        vercel: false,
-      },
-    });
+	it("writes desktopApp.enabled=false for web-only scaffolds", () => {
+		const output = buildConfigTs({
+			appName: "My Chat",
+			appPrefix: "my-chat",
+			appUrl: "http://localhost:3000",
+			withElectron: false,
+			gateway: "vercel",
+			coreFeatures: {
+				attachments: false,
+				parallelResponses: true,
+				documents: true,
+				mcp: false,
+				followupSuggestions: true,
+			},
+			documentTypes: {
+				text: true,
+				code: true,
+				sheet: true,
+			},
+			builtInTools: {
+				webSearch: false,
+				urlRetrieval: false,
+				deepResearch: false,
+				codeExecution: false,
+				imageGeneration: false,
+				videoGeneration: false,
+			},
+			auth: {
+				google: false,
+				github: true,
+				vercel: false,
+			},
+		});
 
-    expect(output).toMatch(/desktopApp:\s*{\s*enabled:\s*false,/m);
-  });
-  it("writes desktopApp.enabled=true for Electron scaffolds", () => {
-    const output = buildConfigTs({
-      appName: "My Chat",
-      appPrefix: "my-chat",
-      appUrl: "http://localhost:3000",
-      withElectron: true,
-      gateway: "vercel",
-      coreFeatures: {
-        attachments: false,
-        parallelResponses: true,
-        documents: true,
-        mcp: false,
-        followupSuggestions: true,
-      },
-      documentTypes: {
-        text: true,
-        code: true,
-        sheet: true,
-      },
-      builtInTools: {
-        webSearch: false,
-        urlRetrieval: false,
-        deepResearch: false,
-        codeExecution: false,
-        imageGeneration: false,
-        videoGeneration: false,
-      },
-      auth: {
-        google: false,
-        github: true,
-        vercel: false,
-      },
-    });
+		expect(output).toMatch(/desktopApp:\s*{\s*enabled:\s*false,/m);
+		expect(output).toContain("parallelResponses: true");
+		expect(output).toContain("documents: {");
+		expect(output).toContain("text: true");
+		expect(output).toContain("code: true");
+		expect(output).toContain("sheet: true");
+		expect(output).toContain("codeExecution: {");
+		expect(output).toContain("enabled: false");
+	});
+	it("writes desktopApp.enabled=true for Electron scaffolds", () => {
+		const output = buildConfigTs({
+			appName: "My Chat",
+			appPrefix: "my-chat",
+			appUrl: "http://localhost:3000",
+			withElectron: true,
+			gateway: "vercel",
+			coreFeatures: {
+				attachments: false,
+				parallelResponses: true,
+				documents: true,
+				mcp: false,
+				followupSuggestions: true,
+			},
+			documentTypes: {
+				text: true,
+				code: true,
+				sheet: true,
+			},
+			builtInTools: {
+				webSearch: false,
+				urlRetrieval: false,
+				deepResearch: false,
+				codeExecution: false,
+				imageGeneration: false,
+				videoGeneration: false,
+			},
+			auth: {
+				google: false,
+				github: true,
+				vercel: false,
+			},
+		});
 
-    expect(output).toMatch(/desktopApp:\s*{\s*enabled:\s*true,/m);
-  });
+		expect(output).toMatch(/desktopApp:\s*{\s*enabled:\s*true,/m);
+		expect(output).toContain("parallelResponses: true");
+		expect(output).toContain("documents: {");
+		expect(output).toContain("text: true");
+		expect(output).toContain("code: true");
+		expect(output).toContain("sheet: true");
+		expect(output).toContain("video: {");
+		expect(output).toContain("enabled: false");
+	});
 });
 
 describe("scaffoldFromTemplate", () => {
-  it("writes a standalone-safe root package.json", async () => {
-    const destination = await makeTempDir("chat-app");
+	it("writes a standalone-safe root package.json", async () => {
+		const destination = await makeTempDir("chat-app");
 
-    await scaffoldFromTemplate(destination);
+		await scaffoldFromTemplate(destination);
 
-    const packageJson = JSON.parse(
-      await readFile(join(destination, "package.json"), "utf8")
-    ) as {
-      packageManager?: string;
-      dependencies: Record<string, string>;
-      overrides?: Record<string, string>;
-    };
+		const packageJson = JSON.parse(
+			await readFile(join(destination, "package.json"), "utf8"),
+		) as {
+			packageManager?: string;
+			dependencies: Record<string, string>;
+			overrides?: Record<string, string>;
+		};
 
-    expect(packageJson.packageManager).toBe("bun@1.3.1");
-    expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
-    expect(packageJson.dependencies["@better-auth/electron"]).toBe("1.5.6");
-    expect(packageJson.dependencies["better-auth"]).toBe("1.5.6");
-    expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
-  });
+		expect(packageJson.packageManager).toBe("bun@1.3.1");
+		expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
+		expect(packageJson.dependencies["@better-auth/electron"]).toBe("1.5.6");
+		expect(packageJson.dependencies["better-auth"]).toBe("1.5.6");
+		expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
+	});
 
-  it("rewrites the generated web app to be npm-friendly", async () => {
-    const destination = await makeTempDir("chat-app-npm");
+	it("rewrites the generated web app to be npm-friendly", async () => {
+		const destination = await makeTempDir("chat-app-npm");
 
-    await scaffoldFromTemplate(destination, { packageManager: "npm" });
+		await scaffoldFromTemplate(destination, { packageManager: "npm" });
 
-    const packageJson = JSON.parse(
-      await readFile(join(destination, "package.json"), "utf8")
-    ) as {
-      packageManager?: string;
-      scripts: Record<string, string>;
-    };
+		const packageJson = JSON.parse(
+			await readFile(join(destination, "package.json"), "utf8"),
+		) as {
+			packageManager?: string;
+			scripts: Record<string, string>;
+		};
 
-    expect(packageJson.packageManager).toBeUndefined();
-    for (const script of Object.values(packageJson.scripts)) {
-      expect(script).not.toContain("bun ");
-      expect(script).not.toContain("bunx");
-    }
+		expect(packageJson.packageManager).toBeUndefined();
+		for (const script of Object.values(packageJson.scripts)) {
+			expect(script).not.toContain("bun ");
+			expect(script).not.toContain("bunx");
+		}
 
-    expect(
-      await readFile(join(destination, "playwright.config.ts"), "utf8")
-    ).toContain('command: "npm run dev"');
-    expect(
-      await readFile(join(destination, "scripts", "check-env.ts"), "utf8")
-    ).toContain("npm run fetch:models");
-    expect(
-      await readFile(
-        join(destination, "lib", "ai", "gateways", "fallback-models.ts"),
-        "utf8"
-      )
-    ).toContain("npm run fetch:models");
-    expect(
-      await readFile(join(destination, "scripts", "with-db.sh"), "utf8")
-    ).not.toContain("bun");
-    expect(
-      await readFile(join(destination, "scripts", "db-branch-use.sh"), "utf8")
-    ).not.toContain("bun");
-  });
+		expect(
+			await readFile(join(destination, "playwright.config.ts"), "utf8"),
+		).toContain('command: "npm run dev"');
+		expect(
+			await readFile(join(destination, "scripts", "check-env.ts"), "utf8"),
+		).toContain("npm run fetch:models");
+		expect(
+			await readFile(
+				join(destination, "lib", "ai", "gateways", "fallback-models.ts"),
+				"utf8",
+			),
+		).toContain("npm run fetch:models");
+		expect(
+			await readFile(join(destination, "scripts", "with-db.sh"), "utf8"),
+		).not.toContain("bun");
+		expect(
+			await readFile(join(destination, "scripts", "db-branch-use.sh"), "utf8"),
+		).not.toContain("bun");
+	});
 
-  it("falls back to repo source apps when synced templates are missing", async () => {
-    const projectDir = await makeTempDir("chat-app-fallback");
-    const templatesDir = join(getCliPackageRoot(), "templates");
-    const backupDir = join(
-      tmpdir(),
-      `chat-js-cli-templates-${crypto.randomUUID()}`
-    );
+	it("falls back to repo source apps when synced templates are missing", async () => {
+		const projectDir = await makeTempDir("chat-app-fallback");
+		const templatesDir = join(getCliPackageRoot(), "templates");
+		const backupDir = join(
+			tmpdir(),
+			`chat-js-cli-templates-${crypto.randomUUID()}`,
+		);
 
-    if (existsSync(templatesDir)) {
-      await rename(templatesDir, backupDir);
-    }
+		if (existsSync(templatesDir)) {
+			await rename(templatesDir, backupDir);
+		}
 
-    try {
-      await scaffoldFromTemplate(projectDir, { packageManager: "npm" });
-      await scaffoldElectron(projectDir, {
-        projectName: "my-chat-app",
-        packageManager: "npm",
-      });
+		try {
+			await scaffoldFromTemplate(projectDir, { packageManager: "npm" });
+			await scaffoldElectron(projectDir, {
+				projectName: "my-chat-app",
+				packageManager: "npm",
+			});
 
-      const packageJson = JSON.parse(
-        await readFile(join(projectDir, "package.json"), "utf8")
-      ) as {
-        dependencies: Record<string, string>;
-      };
-      const electronPackageJson = JSON.parse(
-        await readFile(join(projectDir, "electron", "package.json"), "utf8")
-      ) as {
-        devDependencies: Record<string, string>;
-      };
+			const packageJson = JSON.parse(
+				await readFile(join(projectDir, "package.json"), "utf8"),
+			) as {
+				dependencies: Record<string, string>;
+			};
+			const electronPackageJson = JSON.parse(
+				await readFile(join(projectDir, "electron", "package.json"), "utf8"),
+			) as {
+				devDependencies: Record<string, string>;
+			};
 
-      expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
-      expect(electronPackageJson.devDependencies["@better-auth/electron"]).toBe(
-        "1.5.6"
-      );
-    } finally {
-      if (existsSync(backupDir)) {
-        await rename(backupDir, templatesDir);
-      }
-    }
-  });
+			expect(packageJson.dependencies["@better-auth/core"]).toBe("1.5.6");
+			expect(electronPackageJson.devDependencies["@better-auth/electron"]).toBe(
+				"1.5.6",
+			);
+		} finally {
+			if (existsSync(backupDir)) {
+				await rename(backupDir, templatesDir);
+			}
+		}
+	});
 });
 
 describe("scaffoldElectron", () => {
-  it("pins Better Auth versions in the generated electron app", async () => {
-    const projectDir = await makeTempDir("electron");
+	it("pins Better Auth versions in the generated electron app", async () => {
+		const projectDir = await makeTempDir("electron");
 
-    await scaffoldFromTemplate(projectDir, { packageManager: "npm" });
-    await scaffoldElectron(projectDir, {
-      projectName: "my-chat-app",
-      packageManager: "npm",
-    });
+		await scaffoldFromTemplate(projectDir, { packageManager: "npm" });
+		await scaffoldElectron(projectDir, {
+			projectName: "my-chat-app",
+			packageManager: "npm",
+		});
 
-    const packageJson = JSON.parse(
-      await readFile(join(projectDir, "electron", "package.json"), "utf8")
-    ) as {
-      packageManager?: string;
-      devDependencies: Record<string, string>;
-      scripts: Record<string, string>;
-      overrides?: Record<string, string>;
-    };
+		const packageJson = JSON.parse(
+			await readFile(join(projectDir, "electron", "package.json"), "utf8"),
+		) as {
+			packageManager?: string;
+			devDependencies: Record<string, string>;
+			scripts: Record<string, string>;
+			overrides?: Record<string, string>;
+		};
 
-    expect(packageJson.packageManager).toBeUndefined();
-    expect(packageJson.devDependencies["@better-auth/electron"]).toBe("1.5.6");
-    expect(packageJson.devDependencies["better-auth"]).toBe("1.5.6");
-    expect(packageJson.devDependencies.esbuild).toBeDefined();
-    const rootPackageJson = JSON.parse(
-      await readFile(join(projectDir, "package.json"), "utf8")
-    ) as {
-      devDependencies: Record<string, string>;
-    };
-    expect(packageJson.devDependencies.tsx).toBe(
-      rootPackageJson.devDependencies.tsx
-    );
-    for (const script of Object.values(packageJson.scripts)) {
-      expect(script).not.toContain("bun ");
-      expect(script).not.toContain("bunx");
-    }
-    expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
-    expect(
-      await readFile(join(projectDir, "electron", "README.md"), "utf8")
-    ).not.toContain("bun ");
-  });
+		expect(packageJson.packageManager).toBeUndefined();
+		expect(packageJson.devDependencies["@better-auth/electron"]).toBe("1.5.6");
+		expect(packageJson.devDependencies["better-auth"]).toBe("1.5.6");
+		expect(packageJson.devDependencies.esbuild).toBeDefined();
+		const rootPackageJson = JSON.parse(
+			await readFile(join(projectDir, "package.json"), "utf8"),
+		) as {
+			devDependencies: Record<string, string>;
+		};
+		expect(packageJson.devDependencies.tsx).toBe(
+			rootPackageJson.devDependencies.tsx,
+		);
+		for (const script of Object.values(packageJson.scripts)) {
+			expect(script).not.toContain("bun ");
+			expect(script).not.toContain("bunx");
+		}
+		expect(packageJson.overrides?.["@better-auth/core"]).toBe("1.5.6");
+		expect(
+			await readFile(join(projectDir, "electron", "README.md"), "utf8"),
+		).not.toContain("bun ");
+	});
 });

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -33,16 +33,25 @@ describe("buildConfigTs", () => {
       appUrl: "http://localhost:3000",
       withElectron: false,
       gateway: "vercel",
-      features: {
-        sandbox: false,
+      coreFeatures: {
+        attachments: false,
+        parallelResponses: true,
+        documents: true,
+        mcp: false,
+        followupSuggestions: true,
+      },
+      documentTypes: {
+        text: true,
+        code: true,
+        sheet: true,
+      },
+      builtInTools: {
         webSearch: false,
         urlRetrieval: false,
         deepResearch: false,
-        mcp: false,
+        codeExecution: false,
         imageGeneration: false,
-        attachments: false,
-        followupSuggestions: true,
-        parallelResponses: true,
+        videoGeneration: false,
       },
       auth: {
         google: false,
@@ -60,16 +69,25 @@ describe("buildConfigTs", () => {
       appUrl: "http://localhost:3000",
       withElectron: true,
       gateway: "vercel",
-      features: {
-        sandbox: false,
+      coreFeatures: {
+        attachments: false,
+        parallelResponses: true,
+        documents: true,
+        mcp: false,
+        followupSuggestions: true,
+      },
+      documentTypes: {
+        text: true,
+        code: true,
+        sheet: true,
+      },
+      builtInTools: {
         webSearch: false,
         urlRetrieval: false,
         deepResearch: false,
-        mcp: false,
+        codeExecution: false,
         imageGeneration: false,
-        attachments: false,
-        followupSuggestions: true,
-        parallelResponses: true,
+        videoGeneration: false,
       },
       auth: {
         google: false,

--- a/packages/cli/src/registry/fetch.ts
+++ b/packages/cli/src/registry/fetch.ts
@@ -1,9 +1,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { registryToolItemSchema, type RegistryToolItem } from "./schema";
+import {
+  registryIndexItemSchema,
+  registryToolItemSchema,
+  type RegistryIndexItem,
+  type RegistryToolItem,
+} from "./schema";
 
 export type { RegistryToolItem } from "./schema";
 export type { RegistryToolItemFile } from "./schema";
+export type { RegistryIndexItem } from "./schema";
 
 export const DEFAULT_REGISTRY_URL =
   "https://registry.chatjs.dev/items/{name}.json";
@@ -12,41 +18,63 @@ export function getRegistryUrl(override?: string): string {
   return override ?? process.env.CHATJS_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
 }
 
+function getRegistryIndexUrl(registryUrl?: string): string {
+  const template = getRegistryUrl(registryUrl);
+  if (template.includes("{name}")) {
+    return template.replace(/items\/\{name\}\.json$/, "index.json");
+  }
+  return new URL("../index.json", template).toString();
+}
+
+async function fetchJson(source: string): Promise<unknown> {
+  const isLocalPath = source.startsWith(".") || path.isAbsolute(source);
+  const filePath = source.startsWith(".")
+    ? path.resolve(process.cwd(), source)
+    : source;
+
+  if (isLocalPath) {
+    const content = await fs.readFile(filePath, "utf8").catch(() => {
+      throw new Error(`Registry resource not found at ${filePath}`);
+    });
+    return JSON.parse(content);
+  }
+
+  const res = await fetch(filePath).catch(() => {
+    throw new Error(`Could not reach registry. Check your internet connection.`);
+  });
+
+  if (res.status === 404) {
+    throw new Error(`Registry resource not found: ${filePath}`);
+  }
+  if (!res.ok) {
+    throw new Error(`Registry fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json();
+}
+
+export async function fetchRegistryIndex(
+  registryUrl?: string
+): Promise<RegistryIndexItem[]> {
+  const raw = await fetchJson(getRegistryIndexUrl(registryUrl));
+  return registryIndexItemSchema.array().parse(raw);
+}
+
 export async function fetchRegistryItem(
   name: string,
   registryUrl?: string
 ): Promise<RegistryToolItem> {
   const template = getRegistryUrl(registryUrl);
   const resolved = template.replace("{name}", encodeURIComponent(name));
-  const isLocalPath =
-    resolved.startsWith(".") || path.isAbsolute(resolved);
-
-  // Resolve relative paths against process.cwd() so they work regardless of
-  // where the CLI was invoked from.
-  const filePath = resolved.startsWith(".")
-    ? path.resolve(process.cwd(), resolved)
-    : resolved;
-
-  let raw: unknown;
-
-  if (isLocalPath) {
-    // Local file path — useful during development with --registry flag
-    const content = await fs.readFile(filePath, "utf8").catch(() => {
-      throw new Error(`Tool "${name}" not found at ${filePath}`);
-    });
-    raw = JSON.parse(content);
-  } else {
-    const res = await fetch(filePath).catch(() => {
-      throw new Error(
-        `Could not reach registry. Check your internet connection.`
-      );
-    });
-    if (res.status === 404)
+  const raw = await fetchJson(resolved).catch((error: unknown) => {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Registry resource not found")
+    ) {
       throw new Error(`Tool "${name}" not found in registry.`);
-    if (!res.ok)
-      throw new Error(`Registry fetch failed: ${res.status} ${res.statusText}`);
-    raw = await res.json();
-  }
+    }
+    throw error;
+  });
 
   return registryToolItemSchema.parse(raw);
 }

--- a/packages/cli/src/registry/fetch.ts
+++ b/packages/cli/src/registry/fetch.ts
@@ -1,80 +1,89 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  registryIndexItemSchema,
-  registryToolItemSchema,
-  type RegistryIndexItem,
-  type RegistryToolItem,
+	type RegistryIndexItem,
+	type RegistryToolItem,
+	registryIndexItemSchema,
+	registryToolItemSchema,
 } from "./schema";
 
-export type { RegistryToolItem } from "./schema";
-export type { RegistryToolItemFile } from "./schema";
-export type { RegistryIndexItem } from "./schema";
+export type {
+	RegistryIndexItem,
+	RegistryToolItem,
+	RegistryToolItemFile,
+} from "./schema";
 
 export const DEFAULT_REGISTRY_URL =
-  "https://registry.chatjs.dev/items/{name}.json";
+	"https://registry.chatjs.dev/items/{name}.json";
 
 export function getRegistryUrl(override?: string): string {
-  return override ?? process.env.CHATJS_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
+	return override ?? process.env.CHATJS_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
 }
 
 function getRegistryIndexUrl(registryUrl?: string): string {
-  const template = getRegistryUrl(registryUrl);
-  if (template.includes("{name}")) {
-    return template.replace(/items\/\{name\}\.json$/, "index.json");
-  }
-  return new URL("../index.json", template).toString();
+	const template = getRegistryUrl(registryUrl);
+	if (template.includes("{name}")) {
+		return template.replace(/(\{name\}\.json|\{name\})$/, "index.json");
+	}
+
+	if (template.startsWith(".") || path.isAbsolute(template)) {
+		return path.join(path.dirname(template), "index.json");
+	}
+
+	return new URL("../index.json", template).toString();
 }
 
 async function fetchJson(source: string): Promise<unknown> {
-  const isLocalPath = source.startsWith(".") || path.isAbsolute(source);
-  const filePath = source.startsWith(".")
-    ? path.resolve(process.cwd(), source)
-    : source;
+	const isLocalPath = source.startsWith(".") || path.isAbsolute(source);
+	const filePath = source.startsWith(".")
+		? path.resolve(process.cwd(), source)
+		: source;
 
-  if (isLocalPath) {
-    const content = await fs.readFile(filePath, "utf8").catch(() => {
-      throw new Error(`Registry resource not found at ${filePath}`);
-    });
-    return JSON.parse(content);
-  }
+	if (isLocalPath) {
+		const content = await fs.readFile(filePath, "utf8").catch(() => {
+			throw new Error(`Registry resource not found at ${filePath}`);
+		});
+		return JSON.parse(content);
+	}
 
-  const res = await fetch(filePath).catch(() => {
-    throw new Error(`Could not reach registry. Check your internet connection.`);
-  });
+	const res = await fetch(filePath).catch(() => {
+		throw new Error(
+			`Could not reach registry. Check your internet connection.`,
+		);
+	});
 
-  if (res.status === 404) {
-    throw new Error(`Registry resource not found: ${filePath}`);
-  }
-  if (!res.ok) {
-    throw new Error(`Registry fetch failed: ${res.status} ${res.statusText}`);
-  }
+	if (res.status === 404) {
+		throw new Error(`Registry resource not found: ${filePath}`);
+	}
+	if (!res.ok) {
+		throw new Error(`Registry fetch failed: ${res.status} ${res.statusText}`);
+	}
 
-  return res.json();
+	return res.json();
 }
 
 export async function fetchRegistryIndex(
-  registryUrl?: string
+	registryUrl?: string,
 ): Promise<RegistryIndexItem[]> {
-  const raw = await fetchJson(getRegistryIndexUrl(registryUrl));
-  return registryIndexItemSchema.array().parse(raw);
+	const raw = await fetchJson(getRegistryIndexUrl(registryUrl));
+	return registryIndexItemSchema.array().parse(raw);
 }
 
 export async function fetchRegistryItem(
-  name: string,
-  registryUrl?: string
+	name: string,
+	registryUrl?: string,
 ): Promise<RegistryToolItem> {
-  const template = getRegistryUrl(registryUrl);
-  const resolved = template.replace("{name}", encodeURIComponent(name));
-  const raw = await fetchJson(resolved).catch((error: unknown) => {
-    if (
-      error instanceof Error &&
-      error.message.startsWith("Registry resource not found")
-    ) {
-      throw new Error(`Tool "${name}" not found in registry.`);
-    }
-    throw error;
-  });
+	const template = getRegistryUrl(registryUrl);
+	const resolved = template.replace("{name}", encodeURIComponent(name));
+	const raw = await fetchJson(resolved).catch((error: unknown) => {
+		if (
+			error instanceof Error &&
+			error.message.startsWith("Registry resource not found")
+		) {
+			throw new Error(`Tool "${name}" not found in registry.`);
+		}
+		throw error;
+	});
 
-  return registryToolItemSchema.parse(raw);
+	return registryToolItemSchema.parse(raw);
 }

--- a/packages/cli/src/registry/schema.ts
+++ b/packages/cli/src/registry/schema.ts
@@ -15,6 +15,7 @@ export const registryToolFileSchema = z.object({
 export const registryToolItemSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
+  hidden: z.boolean().optional(),
   dependencies: z.array(z.string()).optional(),
   devDependencies: z.array(z.string()).optional(),
   registryDependencies: z.array(z.string()).optional(),
@@ -22,6 +23,13 @@ export const registryToolItemSchema = z.object({
   files: z.array(registryToolFileSchema),
 });
 
+export const registryIndexItemSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  hidden: z.boolean().optional(),
+});
+
 export type RegistryToolItem = z.infer<typeof registryToolItemSchema>;
 export type RegistryToolItemFile = z.infer<typeof registryToolFileSchema>;
 export type EnvRequirement = z.infer<typeof envRequirementSchema>;
+export type RegistryIndexItem = z.infer<typeof registryIndexItemSchema>;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,16 +13,27 @@ export const AUTH_PROVIDERS = ["google", "github", "vercel"] as const;
 
 export type AuthProvider = (typeof AUTH_PROVIDERS)[number];
 
-export const FEATURE_KEYS = [
-  "sandbox",
+export const CORE_FEATURE_KEYS = [
+  "attachments",
+  "parallelResponses",
+  "documents",
+  "mcp",
+  "followupSuggestions",
+] as const;
+
+export type CoreFeatureKey = (typeof CORE_FEATURE_KEYS)[number];
+
+export const DOCUMENT_TYPE_KEYS = ["text", "code", "sheet"] as const;
+
+export type DocumentTypeKey = (typeof DOCUMENT_TYPE_KEYS)[number];
+
+export const BUILT_IN_TOOL_KEYS = [
   "webSearch",
   "urlRetrieval",
   "deepResearch",
-  "mcp",
+  "codeExecution",
   "imageGeneration",
-  "attachments",
-  "followupSuggestions",
-  "parallelResponses",
+  "videoGeneration",
 ] as const;
 
-export type FeatureKey = (typeof FEATURE_KEYS)[number];
+export type BuiltInToolKey = (typeof BUILT_IN_TOOL_KEYS)[number];

--- a/packages/cli/src/utils/install-deps.ts
+++ b/packages/cli/src/utils/install-deps.ts
@@ -1,33 +1,37 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { PackageManager } from "../types";
 import { inferPackageManager } from "./get-package-manager";
 import { runCommand } from "./run-command";
 
 async function updatePackageJsonDependencies(
-  deps: string[],
-  devDeps: string[],
-  cwd: string
+	deps: string[],
+	devDeps: string[],
+	cwd: string,
 ): Promise<void> {
-  const packageJsonPath = path.join(cwd, "package.json");
-  const packageJson = JSON.parse(
-    await fs.readFile(packageJsonPath, "utf8")
-  ) as {
-    dependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-  };
+	const packageJsonPath = path.join(cwd, "package.json");
+	const packageJson = JSON.parse(
+		await fs.readFile(packageJsonPath, "utf8"),
+	) as {
+		dependencies?: Record<string, string>;
+		devDependencies?: Record<string, string>;
+	};
 
-  packageJson.dependencies ??= {};
-  packageJson.devDependencies ??= {};
+	packageJson.dependencies ??= {};
+	packageJson.devDependencies ??= {};
 
-  for (const dependency of deps) {
-    packageJson.dependencies[dependency] ??= "latest";
-  }
+	for (const dependency of deps) {
+		packageJson.dependencies[dependency] ??= "latest";
+	}
 
-  for (const dependency of devDeps) {
-    packageJson.devDependencies[dependency] ??= "latest";
-  }
+	for (const dependency of devDeps) {
+		packageJson.devDependencies[dependency] ??= "latest";
+	}
 
-  await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+	await fs.writeFile(
+		packageJsonPath,
+		`${JSON.stringify(packageJson, null, 2)}\n`,
+	);
 }
 
 /**
@@ -35,35 +39,40 @@ async function updatePackageJsonDependencies(
  * If installNow is false, only update package.json.
  */
 export async function installDependencies(
-  deps: string[],
-  devDeps: string[],
-  cwd: string,
-  installNow = true
+	deps: string[],
+	devDeps: string[],
+	cwd: string,
+	installNow = true,
+	packageManager?: PackageManager,
 ): Promise<void> {
-  const dependencies = Array.from(new Set(deps));
-  const developmentDependencies = Array.from(new Set(devDeps));
+	const dependencies = Array.from(new Set(deps));
+	const developmentDependencies = Array.from(new Set(devDeps));
 
-  if (!dependencies.length && !developmentDependencies.length) {
-    return;
-  }
+	if (!dependencies.length && !developmentDependencies.length) {
+		return;
+	}
 
-  if (!installNow) {
-    await updatePackageJsonDependencies(dependencies, developmentDependencies, cwd);
-    return;
-  }
+	if (!installNow) {
+		await updatePackageJsonDependencies(
+			dependencies,
+			developmentDependencies,
+			cwd,
+		);
+		return;
+	}
 
-  const pm = inferPackageManager(cwd);
-  if (dependencies.length) {
-    const args =
-      pm === "yarn" ? ["add", ...dependencies] : ["add", ...dependencies];
-    await runCommand(pm, args, cwd);
-  }
+	const pm = packageManager ?? inferPackageManager(cwd);
+	if (dependencies.length) {
+		const args =
+			pm === "yarn" ? ["add", ...dependencies] : ["add", ...dependencies];
+		await runCommand(pm, args, cwd);
+	}
 
-  if (developmentDependencies.length) {
-    const args =
-      pm === "npm"
-        ? ["install", "-D", ...developmentDependencies]
-        : ["add", "-D", ...developmentDependencies];
-    await runCommand(pm, args, cwd);
-  }
+	if (developmentDependencies.length) {
+		const args =
+			pm === "npm"
+				? ["install", "-D", ...developmentDependencies]
+				: ["add", "-D", ...developmentDependencies];
+		await runCommand(pm, args, cwd);
+	}
 }

--- a/packages/cli/src/utils/install-deps.ts
+++ b/packages/cli/src/utils/install-deps.ts
@@ -1,14 +1,44 @@
-import { runCommand } from "./run-command";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { inferPackageManager } from "./get-package-manager";
+import { runCommand } from "./run-command";
+
+async function updatePackageJsonDependencies(
+  deps: string[],
+  devDeps: string[],
+  cwd: string
+): Promise<void> {
+  const packageJsonPath = path.join(cwd, "package.json");
+  const packageJson = JSON.parse(
+    await fs.readFile(packageJsonPath, "utf8")
+  ) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+
+  packageJson.dependencies ??= {};
+  packageJson.devDependencies ??= {};
+
+  for (const dependency of deps) {
+    packageJson.dependencies[dependency] ??= "latest";
+  }
+
+  for (const dependency of devDeps) {
+    packageJson.devDependencies[dependency] ??= "latest";
+  }
+
+  await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
 
 /**
  * Install npm dependencies in `cwd` using the detected package manager.
- * No-ops if `deps` is empty.
+ * If installNow is false, only update package.json.
  */
 export async function installDependencies(
   deps: string[],
   devDeps: string[],
-  cwd: string
+  cwd: string,
+  installNow = true
 ): Promise<void> {
   const dependencies = Array.from(new Set(deps));
   const developmentDependencies = Array.from(new Set(devDeps));
@@ -17,9 +47,15 @@ export async function installDependencies(
     return;
   }
 
+  if (!installNow) {
+    await updatePackageJsonDependencies(dependencies, developmentDependencies, cwd);
+    return;
+  }
+
   const pm = inferPackageManager(cwd);
   if (dependencies.length) {
-    const args = pm === "yarn" ? ["add", ...dependencies] : ["add", ...dependencies];
+    const args =
+      pm === "yarn" ? ["add", ...dependencies] : ["add", ...dependencies];
     await runCommand(pm, args, cwd);
   }
 

--- a/packages/cli/src/utils/install-registry-tools.ts
+++ b/packages/cli/src/utils/install-registry-tools.ts
@@ -3,191 +3,206 @@ import path from "node:path";
 import { log } from "@clack/prompts";
 import { resolveRegistryItems } from "../registry/resolve";
 import type { EnvRequirement } from "../registry/schema";
-import { createEmptyToolsTemplate, createEmptyUiTemplate, injectTool } from "./inject-tool";
+import type { PackageManager } from "../types";
+import {
+	createEmptyToolsTemplate,
+	createEmptyUiTemplate,
+	injectTool,
+} from "./inject-tool";
 import { installDependencies } from "./install-deps";
 import { spinner } from "./spinner";
 import { writeToolFiles } from "./write-files";
 
 function isRequirementSatisfied(
-  requirement: EnvRequirement,
-  env: NodeJS.ProcessEnv
+	requirement: EnvRequirement,
+	env: NodeJS.ProcessEnv,
 ): boolean {
-  return requirement.options.some((option) =>
-    option.every((name) => Boolean(env[name]))
-  );
+	return requirement.options.some((option) =>
+		option.every((name) => Boolean(env[name])),
+	);
 }
 
 function formatRequirementDescription(requirement: EnvRequirement): string {
-  return (
-    requirement.description ??
-    requirement.options.map((option) => option.join(" + ")).join(" or ")
-  );
+	return (
+		requirement.description ??
+		requirement.options.map((option) => option.join(" + ")).join(" or ")
+	);
 }
 
 export async function installRegistryTools({
-  tools,
-  cwd,
-  toolsDir,
-  toolsAlias,
-  overwrite = false,
-  registryUrl,
-  installDependenciesNow = true,
+	tools,
+	cwd,
+	toolsDir,
+	toolsAlias,
+	overwrite = false,
+	registryUrl,
+	installDependenciesNow = true,
+	packageManager,
+	confirmOverwrite,
 }: {
-  tools: string[];
-  cwd: string;
-  toolsDir: string;
-  toolsAlias: string;
-  overwrite?: boolean;
-  registryUrl?: string;
-  installDependenciesNow?: boolean;
+	tools: string[];
+	cwd: string;
+	toolsDir: string;
+	toolsAlias: string;
+	overwrite?: boolean;
+	registryUrl?: string;
+	installDependenciesNow?: boolean;
+	packageManager?: PackageManager;
+	confirmOverwrite?: (existingFiles: string[]) => Promise<boolean>;
 }): Promise<void> {
-  if (tools.length === 0) {
-    return;
-  }
+	if (tools.length === 0) {
+		return;
+	}
 
-  const toolsIndexPath = path.join(toolsDir, "tools.ts");
-  const uiIndexPath = path.join(toolsDir, "ui.ts");
-  const processedItems = new Set<string>();
+	const toolsIndexPath = path.join(toolsDir, "tools.ts");
+	const uiIndexPath = path.join(toolsDir, "ui.ts");
 
-  for (const name of tools) {
-    log.step(`Installing ${name}`);
+	const fetchSpinner = spinner(
+		tools.length === 1 ? `Fetching ${tools[0]}...` : "Fetching tools...",
+	);
+	fetchSpinner.start();
+	let resolution: Awaited<ReturnType<typeof resolveRegistryItems>>;
+	try {
+		resolution = await resolveRegistryItems(tools, registryUrl);
+		fetchSpinner.succeed(
+			tools.length === 1
+				? `Fetched ${tools[0]}`
+				: `Fetched ${tools.length} tools`,
+		);
+	} catch (err) {
+		fetchSpinner.fail("Failed to fetch tools");
+		throw err;
+	}
 
-    const fetchSpinner = spinner(`Fetching ${name}...`);
-    fetchSpinner.start();
-    let resolution: Awaited<ReturnType<typeof resolveRegistryItems>>;
-    try {
-      resolution = await resolveRegistryItems([name], registryUrl);
-      fetchSpinner.succeed(`Fetched ${name}`);
-    } catch (err) {
-      fetchSpinner.fail(`Failed to fetch ${name}`);
-      throw err;
-    }
+	const filesToWrite = resolution.files;
+	const dependencies = resolution.dependencies;
+	const devDependencies = resolution.devDependencies;
+	const missingEnvRequirements = resolution.items.flatMap((item) =>
+		(item.envRequirements ?? [])
+			.filter(
+				(requirement) => !isRequirementSatisfied(requirement, process.env),
+			)
+			.map((requirement) => ({
+				tool: item.name,
+				requirement: formatRequirementDescription(requirement),
+			})),
+	);
 
-    const itemsToInstall = resolution.items.filter((item) => {
-      if (processedItems.has(item.name)) {
-        return false;
-      }
-      processedItems.add(item.name);
-      return true;
-    });
+	let effectiveOverwrite = overwrite;
+	const writeSpinner = spinner("Writing files...");
+	writeSpinner.start();
+	const initialWrite = await writeToolFiles(filesToWrite, {
+		overwrite: effectiveOverwrite,
+		toolsDir,
+		toolsAlias,
+	});
 
-    const filesToWrite = itemsToInstall.flatMap((item) => item.files);
-    const dependencies = Array.from(
-      new Set(itemsToInstall.flatMap((item) => item.dependencies ?? []))
-    );
-    const devDependencies = Array.from(
-      new Set(itemsToInstall.flatMap((item) => item.devDependencies ?? []))
-    );
-    const missingEnvRequirements = itemsToInstall.flatMap((item) =>
-      (item.envRequirements ?? [])
-        .filter((requirement) => !isRequirementSatisfied(requirement, process.env))
-        .map((requirement) => ({
-          tool: item.name,
-          requirement: formatRequirementDescription(requirement),
-        }))
-    );
-    const mainItem = resolution.items.find((item) => item.name === name);
+	if (initialWrite.existing.length > 0 && !effectiveOverwrite) {
+		writeSpinner.stop();
+		const shouldOverwrite = confirmOverwrite
+			? await confirmOverwrite(initialWrite.existing)
+			: false;
+		if (!shouldOverwrite) {
+			throw new Error(
+				`Tool install would overwrite existing files. Re-run with overwrite enabled.`,
+			);
+		}
+		effectiveOverwrite = true;
+	}
 
-    try {
-      const writeSpinner = spinner("Writing files...");
-      writeSpinner.start();
-      const { written, existing } = await writeToolFiles(filesToWrite, {
-        overwrite,
-        toolsDir,
-        toolsAlias,
-      });
-      if (existing.length > 0 && !overwrite) {
-        writeSpinner.fail(
-          `Refusing to overwrite existing tool files: ${existing
-            .map((file) => path.relative(cwd, file))
-            .join(", ")}`
-        );
-        throw new Error(
-          `Tool install would overwrite existing files. Re-run with overwrite enabled.`
-        );
-      }
-      writeSpinner.succeed(
-        written.length > 0
-          ? `Wrote ${written.map((file) => path.relative(cwd, file)).join(", ")}`
-          : `No file changes needed for ${name}`
-      );
-    } catch (err) {
-      log.error("Failed to write files");
-      throw err;
-    }
+	let writtenFiles = initialWrite.written;
+	if (effectiveOverwrite && initialWrite.existing.length > 0) {
+		writeSpinner.start();
+		const secondWrite = await writeToolFiles(filesToWrite, {
+			overwrite: true,
+			toolsDir,
+			toolsAlias,
+		});
+		writtenFiles = secondWrite.written;
+	}
+	writeSpinner.succeed(
+		writtenFiles.length > 0
+			? `Wrote ${writtenFiles.map((file) => path.relative(cwd, file)).join(", ")}`
+			: `No file changes needed for ${tools.join(", ")}`,
+	);
 
-    if (dependencies.length > 0 || devDependencies.length > 0) {
-      const depsSpinner = spinner(
-        installDependenciesNow
-          ? "Installing dependencies..."
-          : "Updating package.json dependencies..."
-      );
-      depsSpinner.start();
-      try {
-        await installDependencies(
-          dependencies,
-          devDependencies,
-          cwd,
-          installDependenciesNow
-        );
-        const installed = [
-          ...dependencies,
-          ...devDependencies.map((dep) => `${dep} (dev)`),
-        ];
-        depsSpinner.succeed(
-          `${installDependenciesNow ? "Installed" : "Recorded"}: ${installed.join(", ")}`
-        );
-      } catch (err) {
-        depsSpinner.fail(
-          installDependenciesNow
-            ? "Failed to install dependencies"
-            : "Failed to update package.json dependencies"
-        );
-        throw err;
-      }
-    }
+	if (dependencies.length > 0 || devDependencies.length > 0) {
+		const depsSpinner = spinner(
+			installDependenciesNow
+				? "Installing dependencies..."
+				: "Updating package.json dependencies...",
+		);
+		depsSpinner.start();
+		try {
+			await installDependencies(
+				dependencies,
+				devDependencies,
+				cwd,
+				installDependenciesNow,
+				packageManager,
+			);
+			const installed = [
+				...dependencies,
+				...devDependencies.map((dep) => `${dep} (dev)`),
+			];
+			depsSpinner.succeed(
+				`${installDependenciesNow ? "Installed" : "Recorded"}: ${installed.join(", ")}`,
+			);
+		} catch (err) {
+			depsSpinner.fail(
+				installDependenciesNow
+					? "Failed to install dependencies"
+					: "Failed to update package.json dependencies",
+			);
+			throw err;
+		}
+	}
 
-    if (missingEnvRequirements.length > 0) {
-      const details = missingEnvRequirements
-        .map(({ tool, requirement }) => `${tool}: ${requirement}`)
-        .join(", ");
-      log.warn(`Missing env vars for installed tools: ${details}`);
-    }
+	if (missingEnvRequirements.length > 0) {
+		const details = missingEnvRequirements
+			.map(({ tool, requirement }) => `${tool}: ${requirement}`)
+			.join(", ");
+		log.warn(`Missing env vars for installed tools: ${details}`);
+	}
 
-    const injectSpinner = spinner("Updating tool registry index...");
-    injectSpinner.start();
-    try {
-      let toolsSource: string;
-      let uiSource: string;
-      try {
-        toolsSource = await fs.readFile(toolsIndexPath, "utf8");
-      } catch {
-        toolsSource = createEmptyToolsTemplate();
-      }
-      try {
-        uiSource = await fs.readFile(uiIndexPath, "utf8");
-      } catch {
-        uiSource = createEmptyUiTemplate();
-      }
-      const shouldInject =
-        mainItem?.files.some(
-          (file) => file.type === "tool" || file.type === "renderer"
-        ) ?? false;
-      const updated = shouldInject
-        ? injectTool({
-            toolsSource,
-            uiSource,
-            name,
-            toolsAlias,
-          })
-        : { toolsSource, uiSource };
-      await fs.mkdir(path.dirname(toolsIndexPath), { recursive: true });
-      await fs.writeFile(toolsIndexPath, updated.toolsSource, "utf8");
-      await fs.writeFile(uiIndexPath, updated.uiSource, "utf8");
-      injectSpinner.succeed("Updated tool registry index");
-    } catch (err) {
-      injectSpinner.fail("Failed to update tool registry index");
-      throw err;
-    }
-  }
+	const injectSpinner = spinner("Updating tool registry index...");
+	injectSpinner.start();
+	try {
+		let toolsSource: string;
+		let uiSource: string;
+		try {
+			toolsSource = await fs.readFile(toolsIndexPath, "utf8");
+		} catch {
+			toolsSource = createEmptyToolsTemplate();
+		}
+		try {
+			uiSource = await fs.readFile(uiIndexPath, "utf8");
+		} catch {
+			uiSource = createEmptyUiTemplate();
+		}
+
+		let updated = { toolsSource, uiSource };
+		for (const name of tools) {
+			const mainItem = resolution.items.find((item) => item.name === name);
+			const shouldInject =
+				mainItem?.files.some(
+					(file) => file.type === "tool" || file.type === "renderer",
+				) ?? false;
+			if (!shouldInject) continue;
+			updated = injectTool({
+				toolsSource: updated.toolsSource,
+				uiSource: updated.uiSource,
+				name,
+				toolsAlias,
+			});
+		}
+
+		await fs.mkdir(path.dirname(toolsIndexPath), { recursive: true });
+		await fs.writeFile(toolsIndexPath, updated.toolsSource, "utf8");
+		await fs.writeFile(uiIndexPath, updated.uiSource, "utf8");
+		injectSpinner.succeed("Updated tool registry index");
+	} catch (err) {
+		injectSpinner.fail("Failed to update tool registry index");
+		throw err;
+	}
 }

--- a/packages/cli/src/utils/install-registry-tools.ts
+++ b/packages/cli/src/utils/install-registry-tools.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { log } from "@clack/prompts";
+import { resolveRegistryItems } from "../registry/resolve";
+import type { EnvRequirement } from "../registry/schema";
+import { createEmptyToolsTemplate, createEmptyUiTemplate, injectTool } from "./inject-tool";
+import { installDependencies } from "./install-deps";
+import { spinner } from "./spinner";
+import { writeToolFiles } from "./write-files";
+
+function isRequirementSatisfied(
+  requirement: EnvRequirement,
+  env: NodeJS.ProcessEnv
+): boolean {
+  return requirement.options.some((option) =>
+    option.every((name) => Boolean(env[name]))
+  );
+}
+
+function formatRequirementDescription(requirement: EnvRequirement): string {
+  return (
+    requirement.description ??
+    requirement.options.map((option) => option.join(" + ")).join(" or ")
+  );
+}
+
+export async function installRegistryTools({
+  tools,
+  cwd,
+  toolsDir,
+  toolsAlias,
+  overwrite = false,
+  registryUrl,
+  installDependenciesNow = true,
+}: {
+  tools: string[];
+  cwd: string;
+  toolsDir: string;
+  toolsAlias: string;
+  overwrite?: boolean;
+  registryUrl?: string;
+  installDependenciesNow?: boolean;
+}): Promise<void> {
+  if (tools.length === 0) {
+    return;
+  }
+
+  const toolsIndexPath = path.join(toolsDir, "tools.ts");
+  const uiIndexPath = path.join(toolsDir, "ui.ts");
+  const processedItems = new Set<string>();
+
+  for (const name of tools) {
+    log.step(`Installing ${name}`);
+
+    const fetchSpinner = spinner(`Fetching ${name}...`);
+    fetchSpinner.start();
+    let resolution: Awaited<ReturnType<typeof resolveRegistryItems>>;
+    try {
+      resolution = await resolveRegistryItems([name], registryUrl);
+      fetchSpinner.succeed(`Fetched ${name}`);
+    } catch (err) {
+      fetchSpinner.fail(`Failed to fetch ${name}`);
+      throw err;
+    }
+
+    const itemsToInstall = resolution.items.filter((item) => {
+      if (processedItems.has(item.name)) {
+        return false;
+      }
+      processedItems.add(item.name);
+      return true;
+    });
+
+    const filesToWrite = itemsToInstall.flatMap((item) => item.files);
+    const dependencies = Array.from(
+      new Set(itemsToInstall.flatMap((item) => item.dependencies ?? []))
+    );
+    const devDependencies = Array.from(
+      new Set(itemsToInstall.flatMap((item) => item.devDependencies ?? []))
+    );
+    const missingEnvRequirements = itemsToInstall.flatMap((item) =>
+      (item.envRequirements ?? [])
+        .filter((requirement) => !isRequirementSatisfied(requirement, process.env))
+        .map((requirement) => ({
+          tool: item.name,
+          requirement: formatRequirementDescription(requirement),
+        }))
+    );
+    const mainItem = resolution.items.find((item) => item.name === name);
+
+    try {
+      const writeSpinner = spinner("Writing files...");
+      writeSpinner.start();
+      const { written, existing } = await writeToolFiles(filesToWrite, {
+        overwrite,
+        toolsDir,
+        toolsAlias,
+      });
+      if (existing.length > 0 && !overwrite) {
+        writeSpinner.fail(
+          `Refusing to overwrite existing tool files: ${existing
+            .map((file) => path.relative(cwd, file))
+            .join(", ")}`
+        );
+        throw new Error(
+          `Tool install would overwrite existing files. Re-run with overwrite enabled.`
+        );
+      }
+      writeSpinner.succeed(
+        written.length > 0
+          ? `Wrote ${written.map((file) => path.relative(cwd, file)).join(", ")}`
+          : `No file changes needed for ${name}`
+      );
+    } catch (err) {
+      log.error("Failed to write files");
+      throw err;
+    }
+
+    if (dependencies.length > 0 || devDependencies.length > 0) {
+      const depsSpinner = spinner(
+        installDependenciesNow
+          ? "Installing dependencies..."
+          : "Updating package.json dependencies..."
+      );
+      depsSpinner.start();
+      try {
+        await installDependencies(
+          dependencies,
+          devDependencies,
+          cwd,
+          installDependenciesNow
+        );
+        const installed = [
+          ...dependencies,
+          ...devDependencies.map((dep) => `${dep} (dev)`),
+        ];
+        depsSpinner.succeed(
+          `${installDependenciesNow ? "Installed" : "Recorded"}: ${installed.join(", ")}`
+        );
+      } catch (err) {
+        depsSpinner.fail(
+          installDependenciesNow
+            ? "Failed to install dependencies"
+            : "Failed to update package.json dependencies"
+        );
+        throw err;
+      }
+    }
+
+    if (missingEnvRequirements.length > 0) {
+      const details = missingEnvRequirements
+        .map(({ tool, requirement }) => `${tool}: ${requirement}`)
+        .join(", ");
+      log.warn(`Missing env vars for installed tools: ${details}`);
+    }
+
+    const injectSpinner = spinner("Updating tool registry index...");
+    injectSpinner.start();
+    try {
+      let toolsSource: string;
+      let uiSource: string;
+      try {
+        toolsSource = await fs.readFile(toolsIndexPath, "utf8");
+      } catch {
+        toolsSource = createEmptyToolsTemplate();
+      }
+      try {
+        uiSource = await fs.readFile(uiIndexPath, "utf8");
+      } catch {
+        uiSource = createEmptyUiTemplate();
+      }
+      const shouldInject =
+        mainItem?.files.some(
+          (file) => file.type === "tool" || file.type === "renderer"
+        ) ?? false;
+      const updated = shouldInject
+        ? injectTool({
+            toolsSource,
+            uiSource,
+            name,
+            toolsAlias,
+          })
+        : { toolsSource, uiSource };
+      await fs.mkdir(path.dirname(toolsIndexPath), { recursive: true });
+      await fs.writeFile(toolsIndexPath, updated.toolsSource, "utf8");
+      await fs.writeFile(uiIndexPath, updated.uiSource, "utf8");
+      injectSpinner.succeed("Updated tool registry index");
+    } catch (err) {
+      injectSpinner.fail("Failed to update tool registry index");
+      throw err;
+    }
+  }
+}

--- a/packages/registry/build.ts
+++ b/packages/registry/build.ts
@@ -116,6 +116,7 @@ function getImportPackage(spec: string): string | null {
 
 type Meta = {
   description: string;
+  hidden?: boolean;
   extraDependencies?: string[];
   devDependencies?: string[];
   registryDependencies?: string[];
@@ -143,7 +144,7 @@ async function main(): Promise<void> {
     if (stat.isDirectory()) dirs.push(entry);
   }
 
-  const index: { name: string; description: string }[] = [];
+  const index: Array<{ name: string; description: string; hidden?: boolean }> = [];
 
   for (const name of dirs) {
     const dir = path.join(srcDir, name);
@@ -220,6 +221,7 @@ async function main(): Promise<void> {
     const item = {
       name,
       description: meta.description,
+      ...(meta.hidden ? { hidden: true } : {}),
       ...(dependencies.length > 0 ? { dependencies } : {}),
       ...(meta.devDependencies?.length
         ? { devDependencies: [...new Set(meta.devDependencies)].sort() }
@@ -240,7 +242,11 @@ async function main(): Promise<void> {
       JSON.stringify(item, null, 2) + "\n"
     );
 
-    index.push({ name, description: meta.description });
+    index.push({
+      name,
+      description: meta.description,
+      ...(meta.hidden ? { hidden: true } : {}),
+    });
     console.log(
       `  built ${name} (deps: ${dependencies.join(", ") || "none"})`
     );

--- a/packages/registry/index.json
+++ b/packages/registry/index.json
@@ -5,7 +5,8 @@
   },
   {
     "name": "toolkit-renderer",
-    "description": "Shared renderer helpers for installable ChatJS tools"
+    "description": "Shared renderer helpers for installable ChatJS tools",
+    "hidden": true
   },
   {
     "name": "word-count",

--- a/packages/registry/items/toolkit-renderer.json
+++ b/packages/registry/items/toolkit-renderer.json
@@ -1,6 +1,7 @@
 {
   "name": "toolkit-renderer",
   "description": "Shared renderer helpers for installable ChatJS tools",
+  "hidden": true,
   "dependencies": [
     "ai",
     "react"

--- a/packages/registry/src/toolkit-renderer/meta.json
+++ b/packages/registry/src/toolkit-renderer/meta.json
@@ -1,5 +1,6 @@
 {
   "description": "Shared renderer helpers for installable ChatJS tools",
+  "hidden": true,
   "extraDependencies": ["ai"],
   "registryDependencies": [],
   "files": [


### PR DESCRIPTION
## Summary
- split `chat-js create` into core features, document types, and assistant tools prompts
- move built-in tools like web search, deep research, sandbox, image, and video into the assistant tools selection flow
- add document config and runtime gating for text, code, and spreadsheet document support
- reuse shared registry install logic from both `create` and `add`
- hide internal registry-only items like `toolkit-renderer` from installable tool selection

## Testing
- `bun test packages/cli/src --timeout 60000`
- `bun test apps/chat/lib --timeout 60000`
- `bun x tsc -p apps/chat/tsconfig.json --noEmit`

## Summary by Sourcery

Restructure the ChatJS CLI scaffolding and configuration to separate core features, document types, and assistant tools, while centralizing registry tool installation and tightening env/config gating for tools and documents.

New Features:
- Add separate prompts in `chat-js create` for core features, document types, and assistant tools, including support for loading installable tools from a registry index and a new `--registry` flag.
- Introduce document type configuration (text, code, spreadsheet) and runtime gating so document-related tools are only registered when enabled in config.
- Expose built-in assistant tools (web search, URL retrieval, deep research, code execution, image, video) as configurable options in the scaffold flow and config schema.
- Add support for a registry index with optional hidden entries to drive assistant-tool selection without exposing internal-only items.

Enhancements:
- Refine generated `chat.config.ts` structure to distinguish core features from AI tools, with explicit tool-specific config and descriptions for env requirements.
- Update env checklist and requirement mapping to reflect the new separation between core features and built-in tools and to deduplicate shared env vars across them.
- Extend AI config, schema, and gateway model defaults in the app to include document tool configuration and types.
- Refactor CLI registry handling by extracting shared tool-install logic into `installRegistryTools`, reusing it from both `create` and `add`, and enhancing dependency installation to optionally only update package.json.
- Improve registry fetching to support an index endpoint, shared JSON fetch logic, and richer index item metadata including hidden flags, which are omitted from user-facing prompts.
- Adjust platform tool registration so document tools are conditionally exposed based on the new document enablement and type flags.

Tests:
- Update CLI config builder tests to cover the new core feature, document type, and built-in tool configuration inputs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the scaffold to separate core features, document types, and assistant tools, with per-type document gating in config and runtime. Added a registry index picker (with hidden items filtered) and unified tool installation used by both `create` and `add`.

- New Features
  - `chat-js create` now prompts in three steps: core features, document types (`text`, `code`, `sheet`), then assistant tools (built-in + registry); supports `--registry` and installs selected registry tools.
  - Added `ai.tools.documents` with per-type toggles enforced in platform tool wiring; `readDocument` and create/edit tools are only exposed when enabled.
  - Defaults enable documents for all gateways; registry index supports `hidden` items (e.g. `toolkit-renderer` is hidden and excluded).
  - Env checklist separates core features from built-in tools and dedupes shared env vars.

- Refactors
  - Introduced `install-registry-tools` and reused it in `create` and `add` to fetch registry items, write files, inject indices, and manage deps (can update package.json without installing); warns on missing env vars.
  - Config builder now emits `ai.tools.*` (mcp, documents, webSearch, urlRetrieval, deepResearch, codeExecution, image, video, followupSuggestions); schemas, defaults, and tests updated.
  - Registry fetching adds an index endpoint with shared JSON fetch and improved errors; `create` filters hidden items.
  - Runtime tools are conditionally registered based on documents enabled and selected types.

<sup>Written for commit 451253d6155809c921480ca43625fc63afefad68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document tools can be enabled/disabled and configured per type (text, code, sheet).
  * Registry items can be marked hidden to exclude them from normal selection.

* **Configuration & Setup**
  * CLI setup prompts split into core features, document types, and assistant tools.
  * Generated project config now includes a dedicated AI tools section and finer-grained tool/tooling flags.

* **Tooling & CLI**
  * Registry-driven tool install flow added with index fetching, selective file installation, env checks, and optional dependency deferral.

* **Tests**
  * Config generation tests updated for the new config shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->