### PR TITLE
Update release workflow to use RELEASE_TOKEN instead of GITHUB_TOKEN for improved security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,5 @@ jobs:
           title: "chore: version releases"
           commit: "chore: version releases"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch the release workflow authentication from the default GITHUB_TOKEN to a custom RELEASE_TOKEN secret for release publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the release workflow to use a dedicated `RELEASE_TOKEN` secret instead of the default `GITHUB_TOKEN` to improve security and bypass default token limitations when publishing releases.

- **Migration**
  - Create a PAT with `repo` scope and add it as the `RELEASE_TOKEN` repository (or org) secret before merging.

<sup>Written for commit e3fc3709ecad8e14792c0235920751d299b41a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

