### PR TITLE
Remember last auth provider in chat app

### DIFF
--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import authClient from "@/lib/auth-client";
 import { config } from "@/lib/config";
 import {
+  getEnabledSocialAuthProviders,
   isSocialAuthProvider,
   type SocialAuthProvider,
   type SocialAuthSignInOptions,
@@ -50,11 +51,25 @@ function VercelIcon({ className }: { className?: string }) {
 }
 
 type AuthProviderDefinition = {
-  enabled: boolean;
   icon: ComponentType<{ className?: string }>;
   id: SocialAuthProvider;
   label: string;
 };
+
+const AUTH_PROVIDER_METADATA = {
+  github: {
+    icon: Github,
+    label: "GitHub",
+  },
+  google: {
+    icon: GoogleIcon,
+    label: "Google",
+  },
+  vercel: {
+    icon: VercelIcon,
+    label: "Vercel",
+  },
+} satisfies Record<SocialAuthProvider, Omit<AuthProviderDefinition, "id">>;
 
 export function SocialAuthProviders({
   callbackURL,
@@ -75,29 +90,15 @@ export function SocialAuthProviders({
     useState<SocialAuthProvider | null>(null);
 
   const providers = useMemo<AuthProviderDefinition[]>(() => {
-    const providerDefinitions = [
-      {
-        enabled: config.authentication.google,
-        icon: GoogleIcon,
-        id: "google",
-        label: "Google",
-      },
-      {
-        enabled: config.authentication.github,
-        icon: Github,
-        id: "github",
-        label: "GitHub",
-      },
-      {
-        enabled: config.authentication.vercel,
-        icon: VercelIcon,
-        id: "vercel",
-        label: "Vercel",
-      },
-    ] satisfies AuthProviderDefinition[];
+    const providerDefinitions = getEnabledSocialAuthProviders(
+      config.authentication
+    ).map((id) => ({
+      id,
+      ...AUTH_PROVIDER_METADATA[id],
+    }));
 
     return sortSocialAuthProvidersByLastUsed(
-      providerDefinitions.filter(({ enabled }) => enabled),
+      providerDefinitions,
       lastUsedProvider
     );
   }, [lastUsedProvider]);

--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Github } from "lucide-react";
 import type { ComponentType } from "react";
 import { useEffect, useMemo, useState } from "react";
-import { Github } from "lucide-react";
 import { toast } from "sonner";
 import { ElectronBrowserSignIn } from "@/components/electron-auth-ui";
 import { Badge } from "@/components/ui/badge";
@@ -11,9 +11,9 @@ import authClient from "@/lib/auth-client";
 import { config } from "@/lib/config";
 import {
   isSocialAuthProvider,
-  sortSocialAuthProvidersByLastUsed,
   type SocialAuthProvider,
   type SocialAuthSignInOptions,
+  sortSocialAuthProvidersByLastUsed,
 } from "@/lib/social-auth";
 
 function GoogleIcon({ className }: { className?: string }) {
@@ -144,18 +144,19 @@ export function SocialAuthProviders({
 
         return (
           <Button
-            className="w-full justify-between"
+            className="relative w-full"
             key={id}
             onClick={() => signIn(id)}
             type="button"
             variant="outline"
           >
-            <span className="flex items-center">
-              <Icon className="mr-2 h-4 w-4" />
-              Continue with {label}
-            </span>
+            <Icon className="mr-2 h-4 w-4" />
+            Continue with {label}
             {isLastUsed ? (
-              <Badge className="ml-3 shrink-0" variant="secondary">
+              <Badge
+                className="absolute top-0 right-2 h-5 -translate-y-1/2 px-1.5 text-[10px]"
+                variant="default"
+              >
                 Last used
               </Badge>
             ) : null}

--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -2,7 +2,7 @@
 
 import { Github } from "lucide-react";
 import type { ComponentType } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ElectronBrowserSignIn } from "@/components/electron-auth-ui";
 import { Badge } from "@/components/ui/badge";
@@ -86,8 +86,10 @@ export function SocialAuthProviders({
   query?: Record<string, string>;
   signInOptions?: SocialAuthSignInOptions;
 } = {}) {
-  const [lastUsedProvider, setLastUsedProvider] =
-    useState<SocialAuthProvider | null>(null);
+  const [lastUsedProvider] = useState<SocialAuthProvider | null>(() => {
+    const remembered = authClient.getLastUsedLoginMethod();
+    return isSocialAuthProvider(remembered) ? remembered : null;
+  });
 
   const providers = useMemo<AuthProviderDefinition[]>(() => {
     const providerDefinitions = getEnabledSocialAuthProviders(
@@ -102,11 +104,6 @@ export function SocialAuthProviders({
       lastUsedProvider
     );
   }, [lastUsedProvider]);
-
-  const [lastUsedProvider, setLastUsedProvider] = useState<SocialAuthProvider | null>(() => {
-    const remembered = authClient.getLastUsedLoginMethod();
-    return isSocialAuthProvider(remembered) ? remembered : null;
-  });
 
   // In the Electron app, use the @better-auth/electron bridges exposed by
   // setupRenderer() in the preload script. requestAuth() opens the sign-in

--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -74,33 +74,33 @@ export function SocialAuthProviders({
   const [lastUsedProvider, setLastUsedProvider] =
     useState<SocialAuthProvider | null>(null);
 
-  const providers = useMemo<AuthProviderDefinition[]>(
-    () =>
-      sortSocialAuthProvidersByLastUsed(
-        [
-          {
-            enabled: config.authentication.google,
-            icon: GoogleIcon,
-            id: "google",
-            label: "Google",
-          },
-          {
-            enabled: config.authentication.github,
-            icon: Github,
-            id: "github",
-            label: "GitHub",
-          },
-          {
-            enabled: config.authentication.vercel,
-            icon: VercelIcon,
-            id: "vercel",
-            label: "Vercel",
-          },
-        ].filter(({ enabled }) => enabled),
-        lastUsedProvider
-      ),
-    [lastUsedProvider]
-  );
+  const providers = useMemo<AuthProviderDefinition[]>(() => {
+    const providerDefinitions = [
+      {
+        enabled: config.authentication.google,
+        icon: GoogleIcon,
+        id: "google",
+        label: "Google",
+      },
+      {
+        enabled: config.authentication.github,
+        icon: Github,
+        id: "github",
+        label: "GitHub",
+      },
+      {
+        enabled: config.authentication.vercel,
+        icon: VercelIcon,
+        id: "vercel",
+        label: "Vercel",
+      },
+    ] satisfies AuthProviderDefinition[];
+
+    return sortSocialAuthProvidersByLastUsed(
+      providerDefinitions.filter(({ enabled }) => enabled),
+      lastUsedProvider
+    );
+  }, [lastUsedProvider]);
 
   useEffect(() => {
     const rememberedProvider = authClient.getLastUsedLoginMethod();

--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -103,12 +103,10 @@ export function SocialAuthProviders({
     );
   }, [lastUsedProvider]);
 
-  useEffect(() => {
-    const rememberedProvider = authClient.getLastUsedLoginMethod();
-    setLastUsedProvider(
-      isSocialAuthProvider(rememberedProvider) ? rememberedProvider : null
-    );
-  }, []);
+  const [lastUsedProvider, setLastUsedProvider] = useState<SocialAuthProvider | null>(() => {
+    const remembered = authClient.getLastUsedLoginMethod();
+    return isSocialAuthProvider(remembered) ? remembered : null;
+  });
 
   // In the Electron app, use the @better-auth/electron bridges exposed by
   // setupRenderer() in the preload script. requestAuth() opens the sign-in

--- a/apps/chat/components/auth-providers.tsx
+++ b/apps/chat/components/auth-providers.tsx
@@ -1,12 +1,20 @@
 "use client";
 
+import type { ComponentType } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Github } from "lucide-react";
 import { toast } from "sonner";
 import { ElectronBrowserSignIn } from "@/components/electron-auth-ui";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import authClient from "@/lib/auth-client";
 import { config } from "@/lib/config";
-import type { SocialAuthSignInOptions } from "@/lib/social-auth";
+import {
+  isSocialAuthProvider,
+  sortSocialAuthProvidersByLastUsed,
+  type SocialAuthProvider,
+  type SocialAuthSignInOptions,
+} from "@/lib/social-auth";
 
 function GoogleIcon({ className }: { className?: string }) {
   return (
@@ -41,6 +49,13 @@ function VercelIcon({ className }: { className?: string }) {
   );
 }
 
+type AuthProviderDefinition = {
+  enabled: boolean;
+  icon: ComponentType<{ className?: string }>;
+  id: SocialAuthProvider;
+  label: string;
+};
+
 export function SocialAuthProviders({
   callbackURL,
   electronBrowserLabel,
@@ -56,6 +71,44 @@ export function SocialAuthProviders({
   query?: Record<string, string>;
   signInOptions?: SocialAuthSignInOptions;
 } = {}) {
+  const [lastUsedProvider, setLastUsedProvider] =
+    useState<SocialAuthProvider | null>(null);
+
+  const providers = useMemo<AuthProviderDefinition[]>(
+    () =>
+      sortSocialAuthProvidersByLastUsed(
+        [
+          {
+            enabled: config.authentication.google,
+            icon: GoogleIcon,
+            id: "google",
+            label: "Google",
+          },
+          {
+            enabled: config.authentication.github,
+            icon: Github,
+            id: "github",
+            label: "GitHub",
+          },
+          {
+            enabled: config.authentication.vercel,
+            icon: VercelIcon,
+            id: "vercel",
+            label: "Vercel",
+          },
+        ].filter(({ enabled }) => enabled),
+        lastUsedProvider
+      ),
+    [lastUsedProvider]
+  );
+
+  useEffect(() => {
+    const rememberedProvider = authClient.getLastUsedLoginMethod();
+    setLastUsedProvider(
+      isSocialAuthProvider(rememberedProvider) ? rememberedProvider : null
+    );
+  }, []);
+
   // In the Electron app, use the @better-auth/electron bridges exposed by
   // setupRenderer() in the preload script. requestAuth() opens the sign-in
   // URL in the user's default browser with the proper PKCE params.
@@ -63,7 +116,7 @@ export function SocialAuthProviders({
     return <ElectronBrowserSignIn buttonLabel={electronBrowserLabel} />;
   }
 
-  async function signIn(provider: "google" | "github" | "vercel") {
+  async function signIn(provider: SocialAuthProvider) {
     try {
       const result = await authClient.signIn.social({
         provider,
@@ -86,39 +139,29 @@ export function SocialAuthProviders({
 
   return (
     <div className="space-y-2">
-      {config.authentication.google ? (
-        <Button
-          className="w-full"
-          onClick={() => signIn("google")}
-          type="button"
-          variant="outline"
-        >
-          <GoogleIcon className="mr-2 h-4 w-4" />
-          Continue with Google
-        </Button>
-      ) : null}
-      {config.authentication.github ? (
-        <Button
-          className="w-full"
-          onClick={() => signIn("github")}
-          type="button"
-          variant="outline"
-        >
-          <Github className="mr-2 h-4 w-4" />
-          Continue with GitHub
-        </Button>
-      ) : null}
-      {config.authentication.vercel ? (
-        <Button
-          className="w-full"
-          onClick={() => signIn("vercel")}
-          type="button"
-          variant="outline"
-        >
-          <VercelIcon className="mr-2 h-4 w-4" />
-          Continue with Vercel
-        </Button>
-      ) : null}
+      {providers.map(({ icon: Icon, id, label }) => {
+        const isLastUsed = id === lastUsedProvider;
+
+        return (
+          <Button
+            className="w-full justify-between"
+            key={id}
+            onClick={() => signIn(id)}
+            type="button"
+            variant="outline"
+          >
+            <span className="flex items-center">
+              <Icon className="mr-2 h-4 w-4" />
+              Continue with {label}
+            </span>
+            {isLastUsed ? (
+              <Badge className="ml-3 shrink-0" variant="secondary">
+                Last used
+              </Badge>
+            ) : null}
+          </Button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/chat/lib/auth-client.ts
+++ b/apps/chat/lib/auth-client.ts
@@ -1,4 +1,5 @@
 import { electronProxyClient } from "@better-auth/electron/proxy";
+import { lastLoginMethodClient } from "better-auth/client/plugins";
 import { nextCookies } from "better-auth/next-js";
 import { createAuthClient } from "better-auth/react";
 import { config } from "@/lib/config";
@@ -14,6 +15,7 @@ import {
 const authClient = createAuthClient({
   plugins: [
     nextCookies(),
+    lastLoginMethodClient(),
     ...(config.desktopApp.enabled
       ? [
           electronProxyClient({

--- a/apps/chat/lib/auth.ts
+++ b/apps/chat/lib/auth.ts
@@ -2,6 +2,7 @@ import { electron } from "@better-auth/electron";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
+import { lastLoginMethod } from "better-auth/plugins";
 import { env } from "@/lib/env";
 import { config } from "./config";
 import { db } from "./db/client";
@@ -68,6 +69,7 @@ export const auth = betterAuth({
     return { google, github, vercel } as const;
   })(),
   plugins: [
+    lastLoginMethod(),
     nextCookies(),
     ...(config.desktopApp.enabled
       ? [

--- a/apps/chat/lib/social-auth.test.ts
+++ b/apps/chat/lib/social-auth.test.ts
@@ -27,9 +27,7 @@ describe("sortSocialAuthProvidersByLastUsed", () => {
 
   it("moves the remembered provider to the front", () => {
     expect(
-      sortSocialAuthProvidersByLastUsed(providers, "github").map(
-        ({ id }) => id
-      )
+      sortSocialAuthProvidersByLastUsed(providers, "github").map(({ id }) => id)
     ).toEqual(["github", "google", "vercel"]);
   });
 

--- a/apps/chat/lib/social-auth.test.ts
+++ b/apps/chat/lib/social-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getEnabledSocialAuthProviders,
   isSocialAuthProvider,
   sortSocialAuthProvidersByLastUsed,
 } from "./social-auth";
@@ -37,5 +38,27 @@ describe("sortSocialAuthProvidersByLastUsed", () => {
         ({ id }) => id
       )
     ).toEqual(["google", "github", "vercel"]);
+  });
+});
+
+describe("getEnabledSocialAuthProviders", () => {
+  it("derives enabled providers from authentication config", () => {
+    expect(
+      getEnabledSocialAuthProviders({
+        github: true,
+        google: false,
+        vercel: true,
+      })
+    ).toEqual(["github", "vercel"]);
+  });
+
+  it("returns providers in config order", () => {
+    expect(
+      getEnabledSocialAuthProviders({
+        github: true,
+        google: true,
+        vercel: false,
+      })
+    ).toEqual(["google", "github"]);
   });
 });

--- a/apps/chat/lib/social-auth.test.ts
+++ b/apps/chat/lib/social-auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSocialAuthProvider,
+  sortSocialAuthProvidersByLastUsed,
+} from "./social-auth";
+
+describe("isSocialAuthProvider", () => {
+  it("accepts configured social auth providers", () => {
+    expect(isSocialAuthProvider("google")).toBe(true);
+    expect(isSocialAuthProvider("github")).toBe(true);
+    expect(isSocialAuthProvider("vercel")).toBe(true);
+  });
+
+  it("rejects unknown provider ids", () => {
+    expect(isSocialAuthProvider("discord")).toBe(false);
+    expect(isSocialAuthProvider(null)).toBe(false);
+    expect(isSocialAuthProvider(undefined)).toBe(false);
+  });
+});
+
+describe("sortSocialAuthProvidersByLastUsed", () => {
+  const providers = [
+    { id: "google" as const, label: "Google" },
+    { id: "github" as const, label: "GitHub" },
+    { id: "vercel" as const, label: "Vercel" },
+  ];
+
+  it("moves the remembered provider to the front", () => {
+    expect(
+      sortSocialAuthProvidersByLastUsed(providers, "github").map(
+        ({ id }) => id
+      )
+    ).toEqual(["github", "google", "vercel"]);
+  });
+
+  it("keeps the original order for unknown remembered providers", () => {
+    expect(
+      sortSocialAuthProvidersByLastUsed(providers, "discord").map(
+        ({ id }) => id
+      )
+    ).toEqual(["google", "github", "vercel"]);
+  });
+});

--- a/apps/chat/lib/social-auth.ts
+++ b/apps/chat/lib/social-auth.ts
@@ -3,3 +3,27 @@ export type SocialAuthSignInOptions = {
   errorCallbackURL?: string;
   newUserCallbackURL?: string;
 };
+
+export type SocialAuthProvider = "google" | "github" | "vercel";
+
+export function isSocialAuthProvider(
+  value: string | null | undefined
+): value is SocialAuthProvider {
+  return value === "google" || value === "github" || value === "vercel";
+}
+
+export function sortSocialAuthProvidersByLastUsed<
+  TProvider extends { id: SocialAuthProvider },
+>(
+  providers: readonly TProvider[],
+  lastUsedProvider: string | null | undefined
+): TProvider[] {
+  if (!isSocialAuthProvider(lastUsedProvider)) {
+    return [...providers];
+  }
+
+  return [
+    ...providers.filter(({ id }) => id === lastUsedProvider),
+    ...providers.filter(({ id }) => id !== lastUsedProvider),
+  ];
+}

--- a/apps/chat/lib/social-auth.ts
+++ b/apps/chat/lib/social-auth.ts
@@ -1,15 +1,34 @@
+import {
+  AUTHENTICATION_DEFAULTS,
+  type AuthenticationConfig,
+} from "./config-schema";
+
 export type SocialAuthSignInOptions = {
   disableRedirect?: boolean;
   errorCallbackURL?: string;
   newUserCallbackURL?: string;
 };
 
-export type SocialAuthProvider = "google" | "github" | "vercel";
+export type SocialAuthProvider = keyof AuthenticationConfig;
+
+const SOCIAL_AUTH_PROVIDER_IDS = Object.keys(
+  AUTHENTICATION_DEFAULTS
+) as SocialAuthProvider[];
+
+const SOCIAL_AUTH_PROVIDER_ID_SET = new Set<string>(SOCIAL_AUTH_PROVIDER_IDS);
 
 export function isSocialAuthProvider(
   value: string | null | undefined
 ): value is SocialAuthProvider {
-  return value === "google" || value === "github" || value === "vercel";
+  return typeof value === "string" && SOCIAL_AUTH_PROVIDER_ID_SET.has(value);
+}
+
+export function getEnabledSocialAuthProviders(
+  authentication: AuthenticationConfig
+): SocialAuthProvider[] {
+  return SOCIAL_AUTH_PROVIDER_IDS.filter(
+    (provider) => authentication[provider]
+  );
 }
 
 export function sortSocialAuthProvidersByLastUsed<


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enable Better Auth's `lastLoginMethod` plugin on the chat auth server and client
- remember the last social auth provider used in `app/chat` and surface it by reordering the provider list and adding a `Last used` badge on login/register
- add a focused unit test for provider validation and ordering

## Research
- Better Auth already has a built-in `lastLoginMethod` / `lastLoginMethodClient` plugin pair for this exact use case, storing the last auth method in a readable cookie by default
- package version `better-auth@1.5.6` already exports both plugins, so no dependency bump or DB migration was needed

## Testing
- `npx --yes bun@1.3.1 run --cwd "/workspace/apps/chat" vitest run lib/social-auth.test.ts`
- `npx --yes bun@1.3.1 run --cwd "/workspace/apps/chat" test:types`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e147974-f361-4544-b5d3-7e96c439428a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e147974-f361-4544-b5d3-7e96c439428a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Remember and surface the last-used social auth provider in the chat app login flow.

New Features:
- Track the last-used social auth provider via Better Auth's lastLoginMethod plugins on both server and client.
- Reorder available social auth providers based on the remembered provider and display a "Last used" badge in the chat auth UI.
- Define a typed SocialAuthProvider model and helper utilities for validating providers and sorting them by last-used.

Tests:
- Add unit tests for social auth provider validation and last-used-based sorting behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remembers the last-used social login in the chat app and surfaces it with a “Last used” badge by reordering provider buttons. Refactors provider button styles; Electron sign-in flow is unchanged.

- **New Features**
  - Enable `lastLoginMethod()` on the server and `lastLoginMethodClient()` on the client (`better-auth`) to persist and read the last-used provider.
  - Build the provider list from `config.authentication`, keep config order, then sort by the remembered provider and show a “Last used” badge.
  - Add typed `SocialAuthProvider`, `isSocialAuthProvider`, and helpers (`getEnabledSocialAuthProviders`, `sortSocialAuthProvidersByLastUsed`); restrict sign-in to valid providers and add unit tests.

<sup>Written for commit 6ccb8a8ba94e77c6d6e1b56e1a2bc47b64fc9878. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in buttons now show a "Last used" badge and reorder to surface your most recently used authentication method.
  * Your last-used authentication method is remembered across sessions for faster sign-in.

* **Tests**
  * Added comprehensive test coverage for authentication provider utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->