### PR TITLE
Fix #120: fix: browser back/forward navigation serves stale chat mess...

### DIFF
--- a/apps/chat/providers/chat-id-provider.tsx
+++ b/apps/chat/providers/chat-id-provider.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import {
   createContext,
   type ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -28,7 +29,19 @@ interface ChatIdContextType {
 const ChatIdContext = createContext<ChatIdContextType | undefined>(undefined);
 
 export function ChatIdProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
   const pathname = usePathname();
+
+  // On browser back/forward (popstate), force Next.js to re-fetch the RSC
+  // payload so initialMessages are never served from a stale RSC cache.
+  useEffect(() => {
+    const handlePopState = () => {
+      router.refresh();
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [router]);
+
   const [{ provisionalChatId, confirmedChatId }, setChatIdState] = useState<{
     provisionalChatId: string;
     confirmedChatId: string | null;

--- a/apps/chat/providers/chat-id-provider.tsx
+++ b/apps/chat/providers/chat-id-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   createContext,
   type ReactNode,


### PR DESCRIPTION
Closes #120

## Motivation

Browser back/forward navigation in Next.js App Router can serve a cached RSC payload, meaning `initialMessages` passed as props to `ChatSystem` may be stale at the moment the component remounts. While `MessageTreeSync` eventually triggers a server refetch, there is a visible flash of stale messages before that sync completes.

## Changes

**`apps/chat/providers/chat-id-provider.tsx`**

- Imports `useRouter` alongside the existing `usePathname` import.
- Adds a `useEffect` in `ChatIdProvider` that registers a `popstate` event listener on `window`. When a `popstate` event fires (browser back/forward), `router.refresh()` is called to force Next.js to discard the cached RSC payload and re-fetch the current route from the server, ensuring `initialMessages` are always fresh on navigation.
- The effect cleans up the listener on unmount and re-registers if `router` identity changes.

No changes to `ChatSystem`, `MessageTreeSync`, or any provider keying logic — the fix is fully contained to `ChatIdProvider`.

## Testing

Manual verification steps:
1. Open a chat and send several messages.
2. Navigate to a different chat (new URL).
3. Press the browser back button — confirm the previous chat renders its correct messages with no stale flash.
4. Press the browser forward button — confirm the second chat renders its correct messages immediately.
5. Confirm the chat input clears correctly on each navigation.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

## Summary by Sourcery

Bug Fixes:
- Force a router refresh on browser popstate events so chat views no longer display stale initial messages when navigating with the back/forward buttons.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale chat messages when using browser back/forward by refreshing the route on `popstate` so RSC data is re-fetched. Removes the flash of old `initialMessages` and keeps chats accurate. Fixes #120.

- **Bug Fixes**
  - In `ChatIdProvider`, listen for `popstate` and call `router.refresh()` from `next/navigation` to bypass cached RSC payloads.
  - Clean up the event listener on unmount.

- **Refactors**
  - Sort `next/navigation` imports to satisfy Biome rules.

<sup>Written for commit e4b9a85b0c55d528b89469c3adc422180de17d68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat state synchronization when using browser back/forward navigation: the app now detects history navigation and refreshes chat data to keep conversations and UI consistent during navigation history interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->