### PR TITLE
Enhance provisional chat routing by introducing `getProvisionalChatHref` function for dynamic URL generation based on chat context

### DIFF
--- a/apps/chat/lib/start-provisional-chat.ts
+++ b/apps/chat/lib/start-provisional-chat.ts
@@ -1,7 +1,8 @@
 "use client";
 
+import type { Route } from "next";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import type { ChatMessage } from "@/lib/ai/types";
 import {
   createChatBootstrapEntry,
@@ -13,11 +14,50 @@ import type { ParallelRequestSpec } from "@/lib/draft-chat-submission";
 import { useModelChange } from "@/providers/default-model-provider";
 import { useSession } from "@/providers/session-provider";
 
+function getProvisionalChatHref({
+  chatId,
+  projectId,
+  source,
+}: {
+  chatId: string;
+  projectId: string | null;
+  source: "home" | "project";
+}) {
+  if (source === "project") {
+    return projectId ? (`/project/${projectId}/chat/${chatId}` as Route) : null;
+  }
+
+  return `/chat/${chatId}` as Route;
+}
+
 export function useStartProvisionalChat(chatId: string) {
   const router = useRouter();
   const currentRoute = useCurrentChatRoute();
   const changeModel = useModelChange();
   const { data: session } = useSession();
+
+  useEffect(() => {
+    if (!(session?.user && currentRoute.type === "provisional")) {
+      return;
+    }
+
+    const href = getProvisionalChatHref({
+      chatId,
+      projectId: currentRoute.projectId,
+      source: currentRoute.source,
+    });
+
+    if (href) {
+      router.prefetch(href);
+    }
+  }, [
+    chatId,
+    currentRoute.projectId,
+    currentRoute.source,
+    currentRoute.type,
+    router,
+    session?.user,
+  ]);
 
   return useCallback(
     ({
@@ -47,11 +87,21 @@ export function useStartProvisionalChat(chatId: string) {
         })
       );
 
-      if (currentRoute.source === "project" && currentRoute.projectId) {
-        router.push(`/project/${currentRoute.projectId}/chat/${chatId}`);
+      const href = getProvisionalChatHref({
+        chatId,
+        projectId: currentRoute.projectId,
+        source: currentRoute.source,
+      });
+
+      if (!href) {
+        return false;
+      }
+
+      router.push(href);
+
+      if (currentRoute.source === "project") {
         resetDraftChatId(currentRoute.projectId);
       } else {
-        router.push(`/chat/${chatId}`);
         resetDraftChatId();
       }
 


### PR DESCRIPTION
## Summary by Sourcery

Prefetch provisional chat routes and centralize URL generation for provisional chat navigation.

Enhancements:
- Add a utility to derive provisional chat URLs based on chat context and source.
- Prefetch target chat routes when a provisional chat is available to improve navigation responsiveness.
- Simplify provisional chat navigation by reusing the shared URL helper and tightening draft chat reset behavior when navigation cannot occur.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `getProvisionalChatHref` to generate chat URLs based on context and prefetches target routes in `useStartProvisionalChat` to make provisional chat navigation faster and more reliable.

- New Features
  - Added `getProvisionalChatHref` to build home/project chat URLs and return `null` when a project URL can’t be formed.
  - Prefetches the target chat route in `useStartProvisionalChat` when a provisional chat is active and the user is signed in.
  - Uses the shared helper for navigation, aborts when the URL is unavailable, and tightens when draft chat state is reset.

<sup>Written for commit 0894022b0d97a624d718ace6020f61fda0e83e25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added route prefetching for provisional chat navigation to improve responsiveness.

* **Bug Fixes**
  * Improved provisional chat routing to correctly handle project-scoped and home routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->