### PR TITLE
Refactor chat components to replace `@ai-sdk-tools/store` with `@/lib/stores/base`

### DIFF
--- a/apps/chat/components/artifact-panel.tsx
+++ b/apps/chat/components/artifact-panel.tsx
@@ -1,8 +1,3 @@
-import {
-  useChatActions,
-  useChatStatus,
-  useChatStoreApi,
-} from "@ai-sdk-tools/store";
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDistance } from "date-fns";
 import type { Dispatch, SetStateAction } from "react";
@@ -22,6 +17,11 @@ import {
 } from "@/lib/artifacts/sheet/client";
 import { textArtifact } from "@/lib/artifacts/text/client";
 import type { Document } from "@/lib/db/schema";
+import {
+  useChatActions,
+  useChatStatus,
+  useChatStoreApi,
+} from "@/lib/stores/base";
 import { cn } from "@/lib/utils";
 import { useTRPC } from "@/trpc/react";
 import {

--- a/apps/chat/components/assistant-message.tsx
+++ b/apps/chat/components/assistant-message.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { useChatId, useChatStatus } from "@ai-sdk-tools/store";
 import { memo } from "react";
 import { config } from "@/lib/config";
+import { useChatId, useChatStatus } from "@/lib/stores/base";
 import { useMessageMetadataById } from "@/lib/stores/hooks-base";
 import { Message, MessageContent } from "./ai-elements/message";
 import { FollowUpSuggestionsParts } from "./followup-suggestions";

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useChat } from "@ai-sdk-tools/store";
 import { useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport } from "ai";
 import { useEffect, useRef, useState } from "react";
@@ -23,6 +22,7 @@ import {
   addPendingAssistantMessages,
   markParallelRequestSpecsFailed,
 } from "@/lib/parallel-chat-requests";
+import { useChat } from "@/lib/stores/base";
 import {
   useAddMessageToTree,
   useThreadInitialMessages,

--- a/apps/chat/components/chat/chat-content.tsx
+++ b/apps/chat/components/chat/chat-content.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useChatStatus } from "@ai-sdk-tools/store";
 import { memo } from "react";
 import { MessagesPane } from "@/components/messages-pane";
 import { ProjectHome } from "@/components/project-home";
+import { useChatStatus } from "@/lib/stores/base";
 import { useMessageIds } from "@/lib/stores/hooks-base";
 import { cn } from "@/lib/utils";
 import { ChatWelcome } from "./chat-welcome";

--- a/apps/chat/components/chat/use-chat-votes.ts
+++ b/apps/chat/components/chat/use-chat-votes.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useChatId } from "@ai-sdk-tools/store";
 import { useQuery } from "@tanstack/react-query";
 import { useChatBootstrap } from "@/lib/chat-bootstrap";
+import { useChatId } from "@/lib/stores/base";
 import { useMessageIds } from "@/lib/stores/hooks-base";
 import { useSession } from "@/providers/session-provider";
 import { useTRPC } from "@/trpc/react";

--- a/apps/chat/components/create-artifact.tsx
+++ b/apps/chat/components/create-artifact.tsx
@@ -1,9 +1,9 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
-import type { useChatStoreApi } from "@ai-sdk-tools/store";
 import type { QueryClient } from "@tanstack/react-query";
 import type { DataUIPart } from "ai";
 import type { ComponentType, Dispatch, ReactNode, SetStateAction } from "react";
 import type { ChatMessage, CustomUIDataTypes } from "@/lib/ai/types";
+import type { useChatStoreApi } from "@/lib/stores/base";
 import type { useTRPC } from "@/trpc/react";
 import type { UIArtifact } from "./artifact-panel";
 

--- a/apps/chat/components/feedback-actions.tsx
+++ b/apps/chat/components/feedback-actions.tsx
@@ -1,9 +1,9 @@
-import { useMessageById } from "@ai-sdk-tools/store";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { toast } from "sonner";
 import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
 import type { Vote } from "@/lib/db/schema";
+import { useMessageById } from "@/lib/stores/base";
 import { useSession } from "@/providers/session-provider";
 import { useTRPC } from "@/trpc/react";
 import { MessageAction as Action } from "./ai-elements/message";

--- a/apps/chat/components/followup-suggestions.tsx
+++ b/apps/chat/components/followup-suggestions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useChatStoreApi } from "@ai-sdk-tools/store";
 import { PlusIcon } from "lucide-react";
 import { useCallback } from "react";
 import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
 import type { ChatMessage, UiToolName } from "@/lib/ai/types";
+import { useChatStoreApi } from "@/lib/stores/base";
 import { useMessageIds } from "@/lib/stores/hooks-base";
 import {
   useMessagePartByPartIdx,

--- a/apps/chat/components/message-actions.tsx
+++ b/apps/chat/components/message-actions.tsx
@@ -1,4 +1,3 @@
-import { useChatStoreApi } from "@ai-sdk-tools/store";
 import { Copy, Pencil, PencilOff } from "lucide-react";
 import { memo } from "react";
 import { toast } from "sonner";
@@ -8,6 +7,7 @@ import {
   MessageActions as Actions,
 } from "@/components/ai-elements/message";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useChatStoreApi } from "@/lib/stores/base";
 import { useMessageRoleById } from "@/lib/stores/hooks-base";
 import { useChatVotes } from "./chat/use-chat-votes";
 import { FeedbackActions } from "./feedback-actions";

--- a/apps/chat/components/message-editor.tsx
+++ b/apps/chat/components/message-editor.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { useChatStatus } from "@ai-sdk-tools/store";
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 import type { ModelId } from "@/lib/ai/app-models";
 import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
+import { useChatStatus } from "@/lib/stores/base";
 import {
   getAttachmentsFromMessage,
   getTextContentFromMessage,

--- a/apps/chat/components/messages.tsx
+++ b/apps/chat/components/messages.tsx
@@ -1,10 +1,10 @@
-import { useChatId, useChatStatus } from "@ai-sdk-tools/store";
 import { memo } from "react";
 import {
   Conversation,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
 import { ConversationContent } from "@/components/ai-elements/extra/conversation-content-scroll-area";
+import { useChatId, useChatStatus } from "@/lib/stores/base";
 import { useMessageIds } from "@/lib/stores/hooks-base";
 import { cn } from "@/lib/utils";
 import { Greeting } from "./greeting";

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -1,6 +1,5 @@
 "use client";
 import type { UseChatHelpers } from "@ai-sdk/react";
-import { useChatActions, useChatStoreApi } from "@ai-sdk-tools/store";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CameraIcon, FileIcon, ImageIcon, PlusIcon } from "lucide-react";
 import type React from "react";
@@ -46,6 +45,7 @@ import {
   runParallelRequestSpecs,
 } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
+import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
 import { useLastMessageId } from "@/lib/stores/hooks-base";
 import { useAddMessageToTree } from "@/lib/stores/hooks-threads";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMessageById } from "@ai-sdk-tools/store";
 import { LoaderCircle } from "lucide-react";
 import { memo, useMemo } from "react";
 import { Button } from "@/components/ui/button";
@@ -11,6 +10,7 @@ import {
   expandSelectedModelValue,
   getPrimarySelectedModelId,
 } from "@/lib/ai/types";
+import { useMessageById } from "@/lib/stores/base";
 import { useParallelGroupInfo } from "@/lib/stores/hooks-threads";
 import { cn } from "@/lib/utils";
 import { useChatInput } from "@/providers/chat-input-provider";

--- a/apps/chat/components/partial-message-loading.tsx
+++ b/apps/chat/components/partial-message-loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useChatStatus } from "@ai-sdk-tools/store";
+import { useChatStatus } from "@/lib/stores/base";
 import { useMessageMetadataById } from "@/lib/stores/hooks-base";
 import { Skeleton } from "./ui/skeleton";
 

--- a/apps/chat/components/response-error-message.tsx
+++ b/apps/chat/components/response-error-message.tsx
@@ -1,6 +1,6 @@
-import { useChatActions, useChatStoreApi } from "@ai-sdk-tools/store";
 import { RefreshCcwIcon } from "lucide-react";
 import type { ChatMessage } from "@/lib/ai/types";
+import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
 import { Button } from "./ui/button";
 
 export function ResponseErrorMessage() {

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -1,13 +1,13 @@
-import {
-  useChatActions,
-  useChatStatus,
-  useChatStoreApi,
-} from "@ai-sdk-tools/store";
 import { RefreshCcw } from "lucide-react";
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { Action } from "@/components/ai-elements/actions";
 import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
+import {
+  useChatActions,
+  useChatStatus,
+  useChatStoreApi,
+} from "@/lib/stores/base";
 
 export function RetryButton({
   messageId,

--- a/apps/chat/components/suggested-actions.tsx
+++ b/apps/chat/components/suggested-actions.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useChatActions } from "@ai-sdk-tools/store";
 import {
   Code2Icon,
   GraduationCapIcon,
@@ -17,6 +16,7 @@ import type { ChatMessage } from "@/lib/ai/types";
 import { buildDraftChatSubmission } from "@/lib/draft-chat-submission";
 import { createParallelRequestBody } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
+import { useChatActions } from "@/lib/stores/base";
 import { cn } from "@/lib/utils";
 
 interface SuggestedActionsProps {

--- a/apps/chat/components/toolbar.tsx
+++ b/apps/chat/components/toolbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 import type { UseChatHelpers } from "@ai-sdk/react";
-import { useChatActions, type useChatStoreApi } from "@ai-sdk-tools/store";
 import { ArrowUp, Square } from "lucide-react";
 import {
   AnimatePresence,
@@ -27,6 +26,7 @@ import {
 } from "@/components/ui/tooltip";
 import type { ChatMessage } from "@/lib/ai/types";
 import type { ArtifactKind } from "@/lib/artifacts/artifact-kind";
+import { useChatActions, type useChatStoreApi } from "@/lib/stores/base";
 import { cn } from "@/lib/utils";
 import { useChatInput } from "@/providers/chat-input-provider";
 import { artifactDefinitions } from "./artifact-panel";

--- a/apps/chat/components/user-message.tsx
+++ b/apps/chat/components/user-message.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { useChatId, useMessageById } from "@ai-sdk-tools/store";
 import { memo, useState } from "react";
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import type { ChatMessage } from "@/lib/ai/types";
+import { useChatId, useMessageById } from "@/lib/stores/base";
 import { cn, getAttachmentsFromMessage } from "@/lib/utils";
 import { AttachmentList } from "./attachment-list";
 import { ImageModal } from "./image-modal";

--- a/apps/chat/hooks/use-complete-data-part.ts
+++ b/apps/chat/hooks/use-complete-data-part.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import { useChatActions, useChatStoreApi } from "@ai-sdk-tools/store";
 import { useEffect } from "react";
 import { useDataStream } from "@/components/data-stream-provider";
 import type { ChatMessage } from "@/lib/ai/types";
+import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
 
 // Completes the first received data part into a concrete message (e.g. data-appendMessage).
 export function useCompleteDataPart() {

--- a/apps/chat/hooks/use-navigate-to-message.ts
+++ b/apps/chat/hooks/use-navigate-to-message.ts
@@ -1,8 +1,8 @@
-import { useChatActions } from "@ai-sdk-tools/store";
 import { useCallback } from "react";
 import { useDataStream } from "@/components/data-stream-provider";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ChatMessage } from "@/lib/ai/types";
+import { useChatActions } from "@/lib/stores/base";
 import { useSwitchToMessage } from "@/lib/stores/hooks-threads";
 
 export function useNavigateToMessage() {

--- a/apps/chat/hooks/use-navigate-to-sibling.ts
+++ b/apps/chat/hooks/use-navigate-to-sibling.ts
@@ -1,8 +1,8 @@
-import { useChatActions } from "@ai-sdk-tools/store";
 import { useCallback } from "react";
 import { useDataStream } from "@/components/data-stream-provider";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ChatMessage } from "@/lib/ai/types";
+import { useChatActions } from "@/lib/stores/base";
 import { useSwitchToSibling } from "@/lib/stores/hooks-threads";
 
 /**

--- a/apps/chat/lib/stores/base/README.md
+++ b/apps/chat/lib/stores/base/README.md
@@ -1,0 +1,5 @@
+# Chat Store Base
+
+This folder vendors the `packages/store` source from `~/Code/ai-sdk-tools`.
+
+Import this boundary through `@/lib/stores/base`. Chat-specific extensions live one level up in `apps/chat/lib/stores`.

--- a/apps/chat/lib/stores/base/README.md
+++ b/apps/chat/lib/stores/base/README.md
@@ -1,5 +1,5 @@
 # Chat Store Base
 
-This folder vendors the `packages/store` source from `~/Code/ai-sdk-tools`.
+This folder vendors the `packages/store` source from the upstream `ai-sdk-tools` repository.
 
 Import this boundary through `@/lib/stores/base`. Chat-specific extensions live one level up in `apps/chat/lib/stores`.

--- a/apps/chat/lib/stores/base/debug.ts
+++ b/apps/chat/lib/stores/base/debug.ts
@@ -53,6 +53,10 @@ class DebugLogger {
   setLevel(level: LogLevel): void {
     this.level = level;
   }
+
+  setPrefix(prefix: string): void {
+    this.prefix = prefix;
+  }
 }
 
 // Create default logger instance
@@ -65,6 +69,9 @@ export function configureDebug(options: DebugOptions): void {
   }
   if (options.level !== undefined) {
     debug.setLevel(options.level);
+  }
+  if (options.prefix !== undefined) {
+    debug.setPrefix(options.prefix);
   }
 }
 

--- a/apps/chat/lib/stores/base/debug.ts
+++ b/apps/chat/lib/stores/base/debug.ts
@@ -1,0 +1,72 @@
+// biome-ignore-all lint: vendored chat store base.
+
+type LogLevel = "log" | "warn" | "error";
+
+interface DebugOptions {
+  enabled?: boolean;
+  level?: LogLevel;
+  prefix?: string;
+}
+
+class DebugLogger {
+  private enabled: boolean;
+  private prefix: string;
+  private level: LogLevel;
+
+  constructor(options: DebugOptions = {}) {
+    this.enabled = options.enabled ?? process.env.DEBUG === "true";
+    this.prefix = options.prefix ?? "[Store]";
+    this.level = options.level ?? "warn";
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    if (!this.enabled) {
+      return false;
+    }
+
+    const levels = ["log", "warn", "error"];
+    return levels.indexOf(level) >= levels.indexOf(this.level);
+  }
+
+  log(...args: any[]): void {
+    if (this.shouldLog("log")) {
+      console.log(this.prefix, ...args);
+    }
+  }
+
+  warn(...args: any[]): void {
+    if (this.shouldLog("warn")) {
+      console.warn(this.prefix, ...args);
+    }
+  }
+
+  error(...args: any[]): void {
+    if (this.shouldLog("error")) {
+      console.error(this.prefix, ...args);
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+}
+
+// Create default logger instance
+export const debug = new DebugLogger();
+
+// Export for external configuration
+export function configureDebug(options: DebugOptions): void {
+  if (options.enabled !== undefined) {
+    debug.setEnabled(options.enabled);
+  }
+  if (options.level !== undefined) {
+    debug.setLevel(options.level);
+  }
+}
+
+// Export the class for custom loggers
+export { DebugLogger };

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -324,6 +324,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             return;
           }
 
+          currentState._messageIndex.update(messages);
           set({
             messages,
             _memoizedSelectors: new Map(), // Clear memoized selectors
@@ -359,6 +360,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
       setNewChat: (id, messages) => {
         markLastAction("chat:setNewChat");
         batchUpdates(() => {
+          get()._messageIndex.update(messages);
           set({
             messages,
             status: "ready",
@@ -374,10 +376,14 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         markLastAction("chat:pushMessage");
         batchUpdates(() => {
           const currentState = get();
-          set((state) => ({
-            messages: [...state.messages, message],
-            _memoizedSelectors: new Map(),
-          }));
+          set((state) => {
+            const messages = [...state.messages, message];
+            state._messageIndex.update(messages);
+            return {
+              messages,
+              _memoizedSelectors: new Map(),
+            };
+          });
 
           // During streaming, update immediately for smooth text rendering
           if (currentState.status === "streaming") {
@@ -399,10 +405,14 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
       popMessage: () => {
         markLastAction("chat:popMessage");
         batchUpdates(() => {
-          set((state) => ({
-            messages: state.messages.slice(0, -1),
-            _memoizedSelectors: new Map(),
-          }));
+          set((state) => {
+            const messages = state.messages.slice(0, -1);
+            state._messageIndex.update(messages);
+            return {
+              messages,
+              _memoizedSelectors: new Map(),
+            };
+          });
           throttledMessagesUpdater?.();
         });
       },
@@ -414,6 +424,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
           set((state) => {
             const newMessages = [...state.messages];
             newMessages[index] = structuredClone(message);
+            state._messageIndex.update(newMessages);
             return {
               messages: newMessages,
               _memoizedSelectors: new Map(),
@@ -442,15 +453,14 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         batchUpdates(() => {
           const currentState = get();
           set((state) => {
-            const index = state.messages.findIndex(
-              (currentMessage) => currentMessage.id === id
-            );
-            if (index === -1) {
+            const index = state._messageIndex.getIndexById(id);
+            if (index === undefined) {
               return state;
             }
 
             const newMessages = [...state.messages];
             newMessages[index] = structuredClone(message);
+            state._messageIndex.update(newMessages);
             return {
               messages: newMessages,
               _memoizedSelectors: new Map(),
@@ -477,6 +487,9 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
       _syncState: (newState) => {
         markLastAction("chat:_syncState");
         batchUpdates(() => {
+          if (newState.messages) {
+            get()._messageIndex.update(newState.messages);
+          }
           set(
             {
               ...newState,

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -118,7 +118,7 @@ function startFreezeDetector({
   }
 }
 
-if (typeof window !== "undefined") {
+if (typeof window !== "undefined" && process.env.NODE_ENV !== "production") {
   startFreezeDetector({ thresholdMs: 80 });
 }
 
@@ -150,15 +150,7 @@ function enhancedThrottle<T extends (...args: any[]) => void>(
       }
       previous = now;
 
-      // Use requestIdleCallback if available for better performance
-      if (
-        typeof window !== "undefined" &&
-        (window as any).requestIdleCallback
-      ) {
-        (window as any).requestIdleCallback(execute, { timeout: 50 });
-      } else {
-        execute();
-      }
+      execute();
     } else if (!timeout) {
       timeout = setTimeout(() => {
         previous = Date.now();
@@ -293,8 +285,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
             try {
               cb();
             } catch (err) {
-              // eslint-disable-next-line no-console
-              console.warn("[chat-store-base] throttled effect error", err);
+              debug.warn("[chat-store-base] throttled effect error", err);
             }
           });
         });
@@ -451,8 +442,10 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         batchUpdates(() => {
           const currentState = get();
           set((state) => {
-            const index = state._messageIndex.getIndexById(id);
-            if (index === undefined) {
+            const index = state.messages.findIndex(
+              (currentMessage) => currentMessage.id === id
+            );
+            if (index === -1) {
               return state;
             }
 
@@ -576,12 +569,11 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         const state = get();
         const cached = state._memoizedSelectors.get(key);
 
-        // Fast dependency comparison using length + JSON for complex objects
+        // Reference-equality dep check, matching React dependency semantics.
         if (
           cached &&
           cached.deps.length === deps.length &&
-          (deps.length === 0 ||
-            JSON.stringify(cached.deps) === JSON.stringify(deps))
+          cached.deps.every((dep, index) => Object.is(dep, deps[index]))
         ) {
           return cached.result;
         }
@@ -762,13 +754,7 @@ export const useMessageById = <TMessage extends UIMessage = UIMessage>(
 ) => {
   return useChatStore(
     useCallback(
-      (state: StoreState<TMessage>) => {
-        const message = state.getMessageById(messageId);
-        if (!message) {
-          throw new Error(`Message not found for id: ${messageId}`);
-        }
-        return message;
-      },
+      (state: StoreState<TMessage>) => state.getMessageById(messageId),
       [messageId]
     )
   );
@@ -880,7 +866,7 @@ export const useSelector = <TMessage extends UIMessage = UIMessage, T = any>(
           () => selector(state.getThrottledMessages()),
           [state.getMessageCount(), ...deps]
         ),
-      [key, selector, deps]
+      [key, selector, ...deps]
     )
   );
 };

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -1,0 +1,886 @@
+// biome-ignore-all lint: vendored chat store base.
+
+"use client";
+
+import type { UIMessage, UseChatHelpers } from "@ai-sdk/react";
+import type { ChatStatus } from "ai";
+import * as React from "react";
+import { createContext, useCallback, useContext, useRef } from "react";
+import { useStore } from "zustand";
+import { devtools, subscribeWithSelector } from "zustand/middleware";
+import { useShallow } from "zustand/shallow";
+import { createStore, type StateCreator } from "zustand/vanilla";
+import { debug } from "./debug";
+
+// --- Performance monitoring and batching ---
+let __freezeDetectorStarted = false;
+let __freezeRafId = 0;
+let __freezeLastTs = 0;
+let __lastActionLabel: string | undefined;
+let __clearLastActionTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Batched updates queue with priority
+const __updateQueue: Array<{ callback: () => void; priority: number }> = [];
+let __batchedUpdateScheduled = false;
+
+function markLastAction(label: string) {
+  __lastActionLabel = label;
+  if (typeof window !== "undefined") {
+    if (__clearLastActionTimer) {
+      clearTimeout(__clearLastActionTimer);
+    }
+    __clearLastActionTimer = setTimeout(() => {
+      if (__lastActionLabel === label) {
+        __lastActionLabel = undefined;
+      }
+    }, 250);
+  }
+}
+
+function batchUpdates(callback: () => void, priority = 0) {
+  if (typeof window === "undefined") {
+    callback();
+    return;
+  }
+
+  __updateQueue.push({ callback, priority });
+
+  if (!__batchedUpdateScheduled) {
+    __batchedUpdateScheduled = true;
+
+    // Use scheduler if available, otherwise fallback to rAF
+    const scheduler = (window as any).scheduler;
+    const schedule = scheduler?.postTask
+      ? scheduler.postTask.bind(scheduler)
+      : window.requestAnimationFrame?.bind(window) ||
+        ((fn: () => void) => setTimeout(fn, 0));
+
+    schedule(() => {
+      const updates = __updateQueue.splice(0);
+      __batchedUpdateScheduled = false;
+
+      // Sort by priority (higher priority first) and execute
+      updates.sort((a, b) => b.priority - a.priority);
+      updates.forEach((update) => {
+        update.callback();
+      });
+    });
+  }
+}
+
+function startFreezeDetector({
+  thresholdMs = 80,
+}: {
+  thresholdMs?: number;
+} = {}): void {
+  if (typeof window === "undefined" || __freezeDetectorStarted) {
+    return;
+  }
+  __freezeDetectorStarted = true;
+  __freezeLastTs = performance.now();
+
+  const tick = (now: number) => {
+    const expected = __freezeLastTs + 16.7;
+    const blockedMs = now - expected;
+    if (blockedMs > thresholdMs) {
+      debug.warn(
+        "[Freeze]",
+        `${Math.round(blockedMs)}ms`,
+        "lastAction=",
+        __lastActionLabel
+      );
+    }
+    __freezeLastTs = now;
+    if (
+      typeof window !== "undefined" &&
+      typeof window.requestAnimationFrame === "function"
+    ) {
+      __freezeRafId = window.requestAnimationFrame(tick);
+    }
+  };
+
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    __freezeRafId = window.requestAnimationFrame(tick);
+  }
+
+  if (
+    typeof window !== "undefined" &&
+    typeof window.addEventListener === "function"
+  ) {
+    window.addEventListener("beforeunload", () => {
+      if (__freezeRafId && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(__freezeRafId);
+      }
+    });
+  }
+}
+
+if (typeof window !== "undefined") {
+  startFreezeDetector({ thresholdMs: 80 });
+}
+
+// Enhanced throttle with requestIdleCallback support
+function enhancedThrottle<T extends (...args: any[]) => void>(
+  func: T,
+  wait: number
+): T {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let previous = 0;
+  let pendingArgs: Parameters<T> | null = null;
+
+  const execute = () => {
+    if (pendingArgs) {
+      func.apply(null, pendingArgs);
+      pendingArgs = null;
+    }
+  };
+
+  return ((...args: Parameters<T>) => {
+    const now = Date.now();
+    const remaining = wait - (now - previous);
+    pendingArgs = args;
+
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      previous = now;
+
+      // Use requestIdleCallback if available for better performance
+      if (
+        typeof window !== "undefined" &&
+        (window as any).requestIdleCallback
+      ) {
+        (window as any).requestIdleCallback(execute, { timeout: 50 });
+      } else {
+        execute();
+      }
+    } else if (!timeout) {
+      timeout = setTimeout(() => {
+        previous = Date.now();
+        timeout = null;
+
+        if (
+          typeof window !== "undefined" &&
+          (window as any).requestIdleCallback
+        ) {
+          (window as any).requestIdleCallback(execute, { timeout: 50 });
+        } else {
+          execute();
+        }
+      }, remaining);
+    }
+  }) as T;
+}
+
+// Message indexing for O(1) lookups
+class MessageIndex<TMessage extends UIMessage> {
+  private idToMessage = new Map<string, TMessage>();
+  private idToIndex = new Map<string, number>();
+
+  update(messages: TMessage[]) {
+    this.idToMessage.clear();
+    this.idToIndex.clear();
+
+    messages.forEach((message, index) => {
+      this.idToMessage.set(message.id, message);
+      this.idToIndex.set(message.id, index);
+    });
+  }
+
+  getById(id: string): TMessage | undefined {
+    return this.idToMessage.get(id);
+  }
+
+  getIndexById(id: string): number | undefined {
+    return this.idToIndex.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.idToMessage.has(id);
+  }
+}
+
+export interface StoreState<TMessage extends UIMessage = UIMessage> {
+  _memoizedSelectors: Map<string, { result: any; deps: any[] }>;
+  _messageIndex: MessageIndex<TMessage>;
+
+  // Internal sync method
+  _syncState: (newState: Partial<StoreState<TMessage>>) => void;
+
+  // Performance optimizations
+  _throttledMessages: TMessage[] | null;
+
+  // Transient data parts (not persisted in messages)
+  _transientDataParts: Map<string, any>;
+  addToolResult?: UseChatHelpers<TMessage>["addToolResult"];
+  clearError?: UseChatHelpers<TMessage>["clearError"];
+  clearTransientDataParts: () => void;
+  error: Error | undefined;
+  getInternalMessages: () => TMessage[];
+
+  // Optimized getters
+  getLastMessageId: () => string | null;
+
+  // Memoized complex selectors
+  getMemoizedSelector: <T>(key: string, selector: () => T, deps: any[]) => T;
+  getMessageById: (id: string) => TMessage | undefined;
+  getMessageCount: () => number;
+  getMessageIds: () => string[];
+  getMessageIndexById: (id: string) => number | undefined;
+  getMessagesSlice: (start: number, end?: number) => TMessage[];
+  getThrottledMessages: () => TMessage[];
+  getTransientDataPart: (type: string) => any;
+  id: string | undefined;
+  messages: TMessage[];
+  popMessage: () => void;
+  pushMessage: (message: TMessage) => void;
+  regenerate?: UseChatHelpers<TMessage>["regenerate"];
+
+  // Effects
+  registerThrottledMessagesEffect: (effect: () => void) => () => void;
+  removeTransientDataPart: (type: string) => void;
+  replaceMessage: (index: number, message: TMessage) => void;
+  replaceMessageById: (id: string, message: TMessage) => void;
+
+  // Reset method
+  reset: () => void;
+  resumeStream?: UseChatHelpers<TMessage>["resumeStream"];
+
+  // Chat helpers
+  sendMessage?: UseChatHelpers<TMessage>["sendMessage"];
+  setError: (error: Error | undefined) => void;
+
+  // Actions with batching
+  setId: (id: string | undefined) => void;
+  setMessages: (messages: TMessage[]) => void;
+  setNewChat: (id: string, messages: TMessage[]) => void;
+  setStatus: (status: ChatStatus) => void;
+
+  // Transient data methods
+  setTransientDataPart: (type: string, data: any) => void;
+  status: ChatStatus;
+  stop?: UseChatHelpers<TMessage>["stop"];
+}
+
+const MESSAGES_THROTTLE_MS = 16; // ~60fps for smooth streaming
+
+export function createChatStoreCreator<TMessage extends UIMessage>(
+  initialMessages: TMessage[] = []
+): StateCreator<StoreState<TMessage>, [], []> {
+  let throttledMessagesUpdater: (() => void) | null = null;
+  const messageIndex = new MessageIndex<TMessage>();
+  const throttledEffects = new Set<() => void>();
+
+  messageIndex.update(initialMessages);
+  return (set, get) => {
+    if (!throttledMessagesUpdater) {
+      throttledMessagesUpdater = enhancedThrottle(() => {
+        batchUpdates(() => {
+          const state = get();
+          const newThrottledMessages = [...state.messages];
+          state._messageIndex.update(newThrottledMessages);
+
+          set({
+            _throttledMessages: newThrottledMessages,
+          });
+
+          throttledEffects.forEach((cb) => {
+            try {
+              cb();
+            } catch (err) {
+              // eslint-disable-next-line no-console
+              console.warn("[chat-store-base] throttled effect error", err);
+            }
+          });
+        });
+      }, MESSAGES_THROTTLE_MS);
+    }
+
+    return {
+      id: undefined,
+      messages: initialMessages,
+      status: "ready" as const,
+      error: undefined,
+      _throttledMessages: [...initialMessages],
+      _messageIndex: messageIndex,
+      _memoizedSelectors: new Map(),
+      _transientDataParts: new Map(),
+
+      // Chat helpers
+      sendMessage: undefined,
+      regenerate: undefined,
+      stop: undefined,
+      resumeStream: undefined,
+      addToolResult: undefined,
+      clearError: undefined,
+
+      setId: (id) => {
+        markLastAction("chat:setId");
+        batchUpdates(() => set({ id }));
+      },
+
+      setMessages: (messages) => {
+        markLastAction("chat:setMessages");
+        batchUpdates(() => {
+          // Avoid unnecessary work if messages haven't changed
+          const currentState = get();
+          if (messages === currentState.messages) {
+            return;
+          }
+
+          set({
+            messages,
+            _memoizedSelectors: new Map(), // Clear memoized selectors
+          });
+
+          // During streaming, update immediately for smooth text rendering
+          if (currentState.status === "streaming") {
+            batchUpdates(() => {
+              const state = get();
+              const newThrottledMessages = [...state.messages];
+              state._messageIndex.update(newThrottledMessages);
+
+              set({
+                _throttledMessages: newThrottledMessages,
+              });
+            }, 1); // High priority for streaming updates
+          } else {
+            throttledMessagesUpdater?.();
+          }
+        });
+      },
+
+      setStatus: (status) => {
+        markLastAction("chat:setStatus");
+        batchUpdates(() => set({ status }));
+      },
+
+      setError: (error) => {
+        markLastAction("chat:setError");
+        batchUpdates(() => set({ error }));
+      },
+
+      setNewChat: (id, messages) => {
+        markLastAction("chat:setNewChat");
+        batchUpdates(() => {
+          set({
+            messages,
+            status: "ready",
+            error: undefined,
+            id,
+            _memoizedSelectors: new Map(),
+          });
+          throttledMessagesUpdater?.();
+        });
+      },
+
+      pushMessage: (message) => {
+        markLastAction("chat:pushMessage");
+        batchUpdates(() => {
+          const currentState = get();
+          set((state) => ({
+            messages: [...state.messages, message],
+            _memoizedSelectors: new Map(),
+          }));
+
+          // During streaming, update immediately for smooth text rendering
+          if (currentState.status === "streaming") {
+            batchUpdates(() => {
+              const state = get();
+              const newThrottledMessages = [...state.messages];
+              state._messageIndex.update(newThrottledMessages);
+
+              set({
+                _throttledMessages: newThrottledMessages,
+              });
+            }, 1); // High priority for streaming updates
+          } else {
+            throttledMessagesUpdater?.();
+          }
+        });
+      },
+
+      popMessage: () => {
+        markLastAction("chat:popMessage");
+        batchUpdates(() => {
+          set((state) => ({
+            messages: state.messages.slice(0, -1),
+            _memoizedSelectors: new Map(),
+          }));
+          throttledMessagesUpdater?.();
+        });
+      },
+
+      replaceMessage: (index, message) => {
+        markLastAction("chat:replaceMessage");
+        batchUpdates(() => {
+          const currentState = get();
+          set((state) => {
+            const newMessages = [...state.messages];
+            newMessages[index] = structuredClone(message);
+            return {
+              messages: newMessages,
+              _memoizedSelectors: new Map(),
+            };
+          });
+
+          // During streaming, update immediately for smooth text rendering
+          if (currentState.status === "streaming") {
+            batchUpdates(() => {
+              const state = get();
+              const newThrottledMessages = [...state.messages];
+              state._messageIndex.update(newThrottledMessages);
+
+              set({
+                _throttledMessages: newThrottledMessages,
+              });
+            }, 1); // High priority for streaming updates
+          } else {
+            throttledMessagesUpdater?.();
+          }
+        });
+      },
+
+      replaceMessageById: (id, message) => {
+        markLastAction("chat:replaceMessageById");
+        batchUpdates(() => {
+          const currentState = get();
+          set((state) => {
+            const index = state._messageIndex.getIndexById(id);
+            if (index === undefined) {
+              return state;
+            }
+
+            const newMessages = [...state.messages];
+            newMessages[index] = structuredClone(message);
+            return {
+              messages: newMessages,
+              _memoizedSelectors: new Map(),
+            };
+          });
+
+          // During streaming, update immediately for smooth text rendering
+          if (currentState.status === "streaming") {
+            batchUpdates(() => {
+              const state = get();
+              const newThrottledMessages = [...state.messages];
+              state._messageIndex.update(newThrottledMessages);
+
+              set({
+                _throttledMessages: newThrottledMessages,
+              });
+            }, 1); // High priority for streaming updates
+          } else {
+            throttledMessagesUpdater?.();
+          }
+        });
+      },
+
+      _syncState: (newState) => {
+        markLastAction("chat:_syncState");
+        batchUpdates(() => {
+          set(
+            {
+              ...newState,
+              _memoizedSelectors: new Map(), // Clear memoized selectors on sync
+            },
+            false
+            // 'syncFromUseChat',
+          );
+          if (newState.messages) {
+            throttledMessagesUpdater?.();
+          }
+        });
+      },
+
+      reset: () => {
+        markLastAction("chat:reset");
+        batchUpdates(() => {
+          const state = get();
+          const newMessageIndex = new MessageIndex<TMessage>();
+          newMessageIndex.update([]);
+
+          // Also clear messages via setMessages if available (to sync with chat helpers)
+          if (state.setMessages) {
+            state.setMessages([]);
+          }
+
+          set({
+            id: undefined,
+            messages: [],
+            status: "ready" as const,
+            error: undefined,
+            _throttledMessages: [],
+            _messageIndex: newMessageIndex,
+            _memoizedSelectors: new Map(),
+            _transientDataParts: new Map(),
+          });
+        });
+      },
+
+      // Optimized getters
+      getLastMessageId: () => {
+        const state = get();
+        return state.messages.length > 0
+          ? state.messages[state.messages.length - 1].id
+          : null;
+      },
+
+      getMessageIds: () => {
+        const state = get();
+        return (state._throttledMessages || state.messages).map((m) => m.id);
+      },
+
+      getThrottledMessages: () => {
+        const state = get();
+        return state._throttledMessages || state.messages;
+      },
+
+      getInternalMessages: () => {
+        const state = get();
+        return state.messages;
+      },
+
+      getMessageById: (id) => {
+        const state = get();
+        return state._messageIndex.getById(id);
+      },
+
+      getMessageIndexById: (id) => {
+        const state = get();
+        return state._messageIndex.getIndexById(id);
+      },
+
+      getMessagesSlice: (start, end) => {
+        const state = get();
+        const messages = state._throttledMessages || state.messages;
+        return messages.slice(start, end);
+      },
+
+      getMessageCount: () => {
+        const state = get();
+        const messages = state._throttledMessages || state.messages;
+        return messages.length;
+      },
+
+      getMemoizedSelector: <T>(
+        key: string,
+        selector: () => T,
+        deps: any[]
+      ): T => {
+        const state = get();
+        const cached = state._memoizedSelectors.get(key);
+
+        // Fast dependency comparison using length + JSON for complex objects
+        if (
+          cached &&
+          cached.deps.length === deps.length &&
+          (deps.length === 0 ||
+            JSON.stringify(cached.deps) === JSON.stringify(deps))
+        ) {
+          return cached.result;
+        }
+
+        const result = selector();
+        state._memoizedSelectors.set(key, { result, deps: [...deps] });
+        return result;
+      },
+
+      // Effects
+      registerThrottledMessagesEffect: (effect: () => void) => {
+        throttledEffects.add(effect);
+        return () => {
+          throttledEffects.delete(effect);
+        };
+      },
+
+      // Transient data methods
+      setTransientDataPart: (type, data) => {
+        markLastAction("chat:setTransientDataPart");
+        batchUpdates(() => {
+          set((state) => {
+            const newTransientDataParts = new Map(state._transientDataParts);
+            newTransientDataParts.set(type, data);
+            return { _transientDataParts: newTransientDataParts };
+          });
+        });
+      },
+
+      getTransientDataPart: (type) => {
+        const state = get();
+        return state._transientDataParts.get(type);
+      },
+
+      removeTransientDataPart: (type) => {
+        markLastAction("chat:removeTransientDataPart");
+        batchUpdates(() => {
+          set((state) => {
+            const newTransientDataParts = new Map(state._transientDataParts);
+            newTransientDataParts.delete(type);
+            return { _transientDataParts: newTransientDataParts };
+          });
+        });
+      },
+
+      clearTransientDataParts: () => {
+        markLastAction("chat:clearTransientDataParts");
+        batchUpdates(() => set({ _transientDataParts: new Map() }));
+      },
+    };
+  };
+}
+
+export function createChatStore<TMessage extends UIMessage = UIMessage>(
+  initialMessages: TMessage[] = []
+) {
+  return createStore<StoreState<TMessage>>()(
+    devtools(
+      subscribeWithSelector(createChatStoreCreator<TMessage>(initialMessages)),
+      { name: "chat-store" }
+    )
+  );
+}
+
+type ChatStoreApi<TMessage extends UIMessage = UIMessage> = ReturnType<
+  typeof createChatStore<TMessage>
+>;
+
+export const ChatStoreContext = createContext<ChatStoreApi<any> | undefined>(
+  undefined
+);
+
+type CompatibleChatStoreApi<TMessage extends UIMessage = UIMessage> = Omit<
+  ChatStoreApi<TMessage>,
+  "setState"
+> & {
+  setState(
+    partial:
+      | StoreState<TMessage>
+      | Partial<StoreState<TMessage>>
+      | ((
+          state: StoreState<TMessage>
+        ) => StoreState<TMessage> | Partial<StoreState<TMessage>>),
+    replace?: boolean,
+    action?:
+      | (
+          | string
+          | {
+              [x: string]: unknown;
+              [x: number]: unknown;
+              [x: symbol]: unknown;
+              type: string;
+            }
+        )
+      | undefined
+  ): void;
+};
+
+export function Provider<TMessage extends UIMessage = UIMessage>({
+  children,
+  initialMessages,
+  store,
+}: {
+  children: React.ReactNode;
+  initialMessages?: TMessage[];
+  store?: CompatibleChatStoreApi<TMessage>;
+}) {
+  const storeRef = useRef<CompatibleChatStoreApi<TMessage> | null>(null);
+
+  if (storeRef.current === null) {
+    storeRef.current =
+      store || createChatStore<TMessage>(initialMessages || []);
+  }
+
+  return React.createElement(
+    ChatStoreContext.Provider,
+    { value: storeRef.current },
+    children
+  );
+}
+
+// Standard Zustand v5 store hook
+export function useChatStore<T, TMessage extends UIMessage = UIMessage>(
+  selector: (store: StoreState<TMessage>) => T
+): T;
+export function useChatStore<
+  TMessage extends UIMessage = UIMessage,
+>(): StoreState<TMessage>;
+export function useChatStore<
+  T = StoreState<UIMessage>,
+  TMessage extends UIMessage = UIMessage,
+>(selector?: (store: StoreState<TMessage>) => T) {
+  const store = useContext(ChatStoreContext);
+  if (!store) {
+    throw new Error("useChatStore must be used within Provider");
+  }
+
+  const selectorOrIdentity =
+    selector || ((s: StoreState<TMessage>) => s as unknown as T);
+
+  // Use Zustand's built-in useStore
+  return useStore(store, selectorOrIdentity as (state: any) => T);
+}
+
+export function useChatStoreApi<TMessage extends UIMessage = UIMessage>() {
+  const store = useContext(ChatStoreContext);
+  if (!store) {
+    throw new Error("useChatStoreApi must be used within Provider");
+  }
+  return store as ChatStoreApi<TMessage>;
+}
+
+// Optimized selector hooks with memoization
+export const useChatMessages = <TMessage extends UIMessage = UIMessage>() => {
+  return useChatStore(
+    useShallow((state: StoreState<TMessage>) => state.getThrottledMessages())
+  );
+};
+
+// Stable selector functions to avoid recreation
+const statusSelector = (state: StoreState<any>) => state.status;
+const errorSelector = (state: StoreState<any>) => state.error;
+const idSelector = (state: StoreState<any>) => state.id;
+const messageCountSelector = (state: StoreState<any>) =>
+  state.getMessageCount();
+
+export const useChatStatus = () => useChatStore(statusSelector);
+export const useChatError = () => useChatStore(errorSelector);
+export const useChatId = () => useChatStore(idSelector);
+export const useMessageIds = <TMessage extends UIMessage = UIMessage>() =>
+  useChatStore(
+    useShallow((state: StoreState<TMessage>) => state.getMessageIds())
+  );
+
+// Optimized message selector with O(1) lookup
+export const useMessageById = <TMessage extends UIMessage = UIMessage>(
+  messageId: string
+) => {
+  return useChatStore(
+    useCallback(
+      (state: StoreState<TMessage>) => {
+        const message = state.getMessageById(messageId);
+        if (!message) {
+          throw new Error(`Message not found for id: ${messageId}`);
+        }
+        return message;
+      },
+      [messageId]
+    )
+  );
+};
+
+// Virtualization helper for large message lists
+export const useVirtualMessages = <TMessage extends UIMessage = UIMessage>(
+  start: number,
+  end?: number
+) => {
+  return useChatStore(
+    useCallback(
+      (state: StoreState<TMessage>) => state.getMessagesSlice(start, end),
+      [start, end]
+    )
+  );
+};
+
+export const useMessageCount = () => useChatStore(messageCountSelector);
+
+// Reset hook for convenience
+export const useChatReset = () => useChatStore((state) => state.reset);
+// Stable fallback functions to prevent infinite loops
+const fallbackSendMessage = async () => {
+  debug.warn(
+    "sendMessage not configured - make sure useChat is called with transport"
+  );
+};
+const fallbackRegenerate = async () => {
+  debug.warn(
+    "regenerate not configured - make sure useChat is called with transport"
+  );
+};
+const fallbackStop = async () => {
+  debug.warn(
+    "stop not configured - make sure useChat is called with transport"
+  );
+};
+const fallbackResumeStream = async () => {
+  debug.warn(
+    "resumeStream not configured - make sure useChat is called with transport"
+  );
+};
+const fallbackAddToolResult = async () => {
+  debug.warn(
+    "addToolResult not configured - make sure useChat is called with transport"
+  );
+};
+const fallbackClearError = () => {
+  debug.warn(
+    "clearError not configured - make sure useChat is called with transport"
+  );
+};
+
+export type ChatActions<TMessage extends UIMessage = UIMessage> = {
+  setMessages: (messages: TMessage[]) => void;
+  pushMessage: (message: TMessage) => void;
+  popMessage: () => void;
+  replaceMessage: (index: number, message: TMessage) => void;
+  replaceMessageById: (id: string, message: TMessage) => void;
+  setStatus: (status: ChatStatus) => void;
+  setError: (error: Error | undefined) => void;
+  setId: (id: string | undefined) => void;
+  setNewChat: (id: string, messages: TMessage[]) => void;
+  reset: () => void;
+  sendMessage: UseChatHelpers<TMessage>["sendMessage"];
+  regenerate: UseChatHelpers<TMessage>["regenerate"];
+  stop: UseChatHelpers<TMessage>["stop"];
+  resumeStream: UseChatHelpers<TMessage>["resumeStream"];
+  addToolResult: UseChatHelpers<TMessage>["addToolResult"];
+  clearError: UseChatHelpers<TMessage>["clearError"];
+};
+
+export const useChatActions = <
+  TMessage extends UIMessage = UIMessage,
+>(): ChatActions<TMessage> =>
+  useChatStore(
+    useShallow((state: StoreState<TMessage>) => ({
+      setMessages: state.setMessages,
+      pushMessage: state.pushMessage,
+      popMessage: state.popMessage,
+      replaceMessage: state.replaceMessage,
+      replaceMessageById: state.replaceMessageById,
+      setStatus: state.setStatus,
+      setError: state.setError,
+      setId: state.setId,
+      setNewChat: state.setNewChat,
+      reset: state.reset,
+      sendMessage: state.sendMessage || fallbackSendMessage,
+      regenerate: state.regenerate || fallbackRegenerate,
+      stop: state.stop || fallbackStop,
+      resumeStream: state.resumeStream || fallbackResumeStream,
+      addToolResult: state.addToolResult || fallbackAddToolResult,
+      clearError: state.clearError || fallbackClearError,
+    }))
+  );
+
+// Memoized complex selector hook
+export const useSelector = <TMessage extends UIMessage = UIMessage, T = any>(
+  key: string,
+  selector: (messages: TMessage[]) => T,
+  deps: any[] = []
+) => {
+  return useChatStore(
+    useCallback(
+      (state: StoreState<TMessage>) =>
+        state.getMemoizedSelector(
+          key,
+          () => selector(state.getThrottledMessages()),
+          [state.getMessageCount(), ...deps]
+        ),
+      [key, selector, deps]
+    )
+  );
+};

--- a/apps/chat/lib/stores/base/index.ts
+++ b/apps/chat/lib/stores/base/index.ts
@@ -1,0 +1,41 @@
+// biome-ignore-all lint: vendored chat store base.
+
+// Types
+export type { UIMessage } from "@ai-sdk/react";
+export { configureDebug, DebugLogger, debug } from "./debug";
+// Store and hooks
+export {
+  type ChatActions,
+  ChatStoreContext,
+  createChatStore,
+  createChatStoreCreator,
+  Provider,
+  type StoreState,
+  useChatActions,
+  useChatError,
+  useChatId,
+  useChatMessages,
+  useChatReset,
+  useChatStatus,
+  useChatStore,
+  useChatStoreApi,
+  useMessageById,
+  useMessageCount,
+  useMessageIds,
+  useSelector,
+  useVirtualMessages,
+} from "./hooks";
+// Enhanced useChat hook
+export {
+  type UseChatHelpers,
+  type UseChatOptions,
+  useChat,
+} from "./use-chat";
+// Data parts hooks
+export {
+  type DataPart,
+  type UseDataPartOptions,
+  type UseDataPartsReturn,
+  useDataPart,
+  useDataParts,
+} from "./use-data-parts";

--- a/apps/chat/lib/stores/base/use-chat.ts
+++ b/apps/chat/lib/stores/base/use-chat.ts
@@ -1,0 +1,179 @@
+// biome-ignore-all lint: vendored chat store base.
+
+import {
+  type UIMessage,
+  type UseChatHelpers,
+  type UseChatOptions,
+  useChat as useOriginalChat,
+} from "@ai-sdk/react";
+import { useCallback, useEffect, useRef } from "react";
+import { useStore } from "zustand";
+import { type StoreState, useChatStoreApi } from "./hooks";
+
+export type { UseChatHelpers, UseChatOptions };
+
+// Type for a compatible chat store
+export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
+  _syncState?: (partial: Partial<StoreState<TMessage>>) => void;
+  setState?: (partial: Partial<StoreState<TMessage>>) => void;
+  <T>(selector: (state: StoreState<TMessage>) => T): T;
+}
+
+export type UseChatOptionsWithPerformance<
+  TMessage extends UIMessage = UIMessage,
+> = UseChatOptions<TMessage> & {
+  store?: CompatibleChatStore<TMessage>;
+  // Additional performance options
+  enableBatching?: boolean;
+};
+
+export function useChat<TMessage extends UIMessage = UIMessage>(
+  options: UseChatOptionsWithPerformance<TMessage> = {} as UseChatOptionsWithPerformance<TMessage>
+): UseChatHelpers<TMessage> {
+  const {
+    store: customStore,
+    enableBatching = true,
+    ...originalOptions
+  } = options;
+
+  const originalOnData = (options as any).onData;
+
+  // Use custom store if provided, otherwise use the context store
+  const contextStore = useChatStoreApi<TMessage>();
+  const store = customStore || contextStore;
+
+  // Wrap onData to capture transient data parts
+  const wrappedOnData = useCallback(
+    (dataPart: any) => {
+      // Check if it's a data part (starts with 'data-')
+      if (dataPart.type?.startsWith("data-")) {
+        // Store transient data parts in the store
+        if (typeof (store as any).getState === "function") {
+          const storeState = (store as any).getState();
+          // If data is null or undefined, remove the transient data part
+          if (dataPart.data === null || dataPart.data === undefined) {
+            if (storeState.removeTransientDataPart) {
+              storeState.removeTransientDataPart(dataPart.type);
+            }
+          } else if (storeState.setTransientDataPart) {
+            storeState.setTransientDataPart(dataPart.type, dataPart.data);
+          }
+        }
+      }
+
+      // Call original onData handler if provided
+      if (originalOnData) {
+        originalOnData(dataPart);
+      }
+    },
+    [store, originalOnData]
+  );
+
+  const chatHelpers = useOriginalChat<TMessage>({
+    ...originalOptions,
+    onData: wrappedOnData,
+  });
+
+  const storeRef = useRef<CompatibleChatStore<TMessage> | typeof contextStore>(
+    store
+  );
+
+  // Memoize the sync function to avoid recreating it on every render
+  const syncState = useCallback((chatState: Partial<StoreState<TMessage>>) => {
+    if (!storeRef.current) {
+      return;
+    }
+
+    // Check if store has _syncState method (our internal stores)
+    if (typeof (storeRef.current as any).getState === "function") {
+      // For vanilla Zustand stores
+      const vanillaStore = storeRef.current as any;
+      vanillaStore.getState()._syncState(chatState);
+    } else if (typeof (storeRef.current as any)._syncState === "function") {
+      (storeRef.current as any)._syncState(chatState);
+    } else if (typeof (storeRef.current as any).setState === "function") {
+      // For standard Zustand stores
+      (storeRef.current as any).setState(chatState);
+    }
+  }, []);
+
+  // Simple sync - but don't overwrite store messages if chat has no messages
+  // This preserves server-side messages during hydration
+  useEffect(() => {
+    const currentStoreState = (store as any).getState?.() || { messages: [] };
+
+    // Skip syncing messages if store has messages but chat doesn't
+    // This prevents clearing server-side messages on hydration
+    const shouldSyncMessages = !(
+      currentStoreState.messages?.length > 0 &&
+      chatHelpers.messages.length === 0
+    );
+
+    // Only sync state data
+    const stateData: any = {
+      id: chatHelpers.id,
+      error: chatHelpers.error,
+      status: chatHelpers.status,
+    };
+
+    // Only add messages to sync object if we should sync them
+    if (shouldSyncMessages) {
+      stateData.messages = chatHelpers.messages;
+    }
+
+    // Sync functions separately and only once
+    const functionsData = {
+      sendMessage: chatHelpers.sendMessage,
+      regenerate: chatHelpers.regenerate,
+      stop: chatHelpers.stop,
+      resumeStream: chatHelpers.resumeStream,
+      addToolResult: chatHelpers.addToolResult,
+      setMessages: chatHelpers.setMessages,
+      clearError: chatHelpers.clearError,
+    };
+
+    const chatState = { ...stateData, ...functionsData };
+
+    if (enableBatching) {
+      // Use requestAnimationFrame for batching if available
+      if (
+        typeof window !== "undefined" &&
+        typeof window.requestAnimationFrame === "function"
+      ) {
+        window.requestAnimationFrame(() => syncState(chatState));
+      } else {
+        syncState(chatState);
+      }
+    } else {
+      syncState(chatState);
+    }
+  }, [
+    // Only depend on data that actually changes, not function references
+    chatHelpers.id,
+    chatHelpers.messages,
+    chatHelpers.error,
+    chatHelpers.status,
+    syncState,
+    enableBatching,
+    chatHelpers.resumeStream,
+    chatHelpers.clearError,
+    chatHelpers.sendMessage,
+    store,
+    chatHelpers.setMessages,
+    chatHelpers.stop,
+    chatHelpers.regenerate,
+    chatHelpers.addToolResult,
+  ]);
+
+  // Return the store's messages as the source of truth, not chatHelpers.messages
+  // Subscribe to store messages so this is reactive
+  const storeMessages = useStore(
+    store as any,
+    (state: any) => state.messages as TMessage[]
+  );
+
+  return {
+    ...chatHelpers,
+    messages: storeMessages || chatHelpers.messages,
+  };
+}

--- a/apps/chat/lib/stores/base/use-data-parts.ts
+++ b/apps/chat/lib/stores/base/use-data-parts.ts
@@ -19,9 +19,9 @@ export interface DataPart<T = unknown> {
  * Result of useDataParts hook
  */
 export interface UseDataPartsReturn {
-  /** Array of all data parts */
+  /** Latest data part for each type */
   all: DataPart<unknown>[];
-  /** All data parts grouped by type (without 'data-' prefix) */
+  /** Latest data part grouped by type (without 'data-' prefix) */
   byType: Record<string, DataPart<unknown>>;
 }
 
@@ -34,7 +34,7 @@ export interface UseDataPartOptions<T = unknown> {
 }
 
 /**
- * Hook to extract and access all data parts from messages.
+ * Hook to extract and access data parts from messages.
  * Returns the latest value for each data part type.
  *
  * @example
@@ -71,7 +71,7 @@ export function useDataParts(): UseDataPartsReturn {
         !existing ||
         (dataPart.timestamp &&
           existing.timestamp &&
-          dataPart.timestamp > existing.timestamp)
+          dataPart.timestamp >= existing.timestamp)
       ) {
         byType[key] = dataPart;
       }
@@ -91,7 +91,7 @@ export function useDataParts(): UseDataPartsReturn {
  * @template T - The type of the data part's data property
  * @param type - The data part type without 'data-' prefix (e.g., 'agent-status', 'rate-limit')
  * @param options - Optional configuration including onData callback
- * @returns Tuple of [data, clearFunction] - data is the latest value, clearFunction removes the data part
+ * @returns Tuple of [data, clearFunction] - data is the latest value, clearFunction removes transient live data only
  *
  * @example
  * ```tsx
@@ -151,7 +151,7 @@ export function useDataPart<T = unknown>(
         (!latest ||
           (dataPart.timestamp &&
             latest.timestamp &&
-            dataPart.timestamp > latest.timestamp))
+            dataPart.timestamp >= latest.timestamp))
       ) {
         latest = dataPart as DataPart<T>;
       }

--- a/apps/chat/lib/stores/base/use-data-parts.ts
+++ b/apps/chat/lib/stores/base/use-data-parts.ts
@@ -1,0 +1,250 @@
+// biome-ignore-all lint: vendored chat store base.
+
+"use client";
+
+import type { UIMessage } from "@ai-sdk/react";
+import { useCallback, useEffect, useMemo } from "react";
+import { useChatMessages, useChatStore } from "./hooks";
+
+/**
+ * Interface for a data part extracted from messages
+ */
+export interface DataPart<T = unknown> {
+  data: T;
+  timestamp?: number;
+  type: string;
+}
+
+/**
+ * Result of useDataParts hook
+ */
+export interface UseDataPartsReturn {
+  /** Array of all data parts */
+  all: DataPart<unknown>[];
+  /** All data parts grouped by type (without 'data-' prefix) */
+  byType: Record<string, DataPart<unknown>>;
+}
+
+/**
+ * Options for useDataPart hook
+ */
+export interface UseDataPartOptions<T = unknown> {
+  /** Include callback fired when the data part updates */
+  onData?: (data: DataPart<T>) => void;
+}
+
+/**
+ * Hook to extract and access all data parts from messages.
+ * Returns the latest value for each data part type.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { byType, all } = useDataParts();
+ *
+ *   const agentStatus = byType['agent-status'];
+ *   const rateLimit = byType['rate-limit'];
+ *
+ *   return (
+ *     <div>
+ *       {agentStatus && <p>Status: {agentStatus.data.status}</p>}
+ *       {rateLimit && <p>Remaining: {rateLimit.data.remaining}</p>}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useDataParts(): UseDataPartsReturn {
+  const messages = useChatMessages();
+
+  return useMemo(() => {
+    const dataParts = extractDataPartsFromMessages(messages);
+
+    // Group by type, keeping only the latest for each type
+    // Strip 'data-' prefix from keys for cleaner API
+    const byType: Record<string, DataPart<unknown>> = {};
+
+    for (const dataPart of dataParts) {
+      const key = dataPart.type.replace(/^data-/, "");
+      const existing = byType[key];
+      if (
+        !existing ||
+        (dataPart.timestamp &&
+          existing.timestamp &&
+          dataPart.timestamp > existing.timestamp)
+      ) {
+        byType[key] = dataPart;
+      }
+    }
+
+    return {
+      byType,
+      all: Object.values(byType),
+    };
+  }, [messages]);
+}
+
+/**
+ * Hook to extract and access a specific data part by type.
+ * Returns a tuple with the data and a clear function, similar to useState.
+ *
+ * @template T - The type of the data part's data property
+ * @param type - The data part type without 'data-' prefix (e.g., 'agent-status', 'rate-limit')
+ * @param options - Optional configuration including onData callback
+ * @returns Tuple of [data, clearFunction] - data is the latest value, clearFunction removes the data part
+ *
+ * @example
+ * ```tsx
+ * function AgentStatusIndicator() {
+ *   const [agentStatus, clearStatus] = useDataPart<{ status: string; agent: string }>('agent-status');
+ *
+ *   if (!agentStatus) return null;
+ *
+ *   return (
+ *     <div>
+ *       <p>Agent {agentStatus.agent} is {agentStatus.status}</p>
+ *       <button onClick={clearStatus}>Clear</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @example With callback
+ * ```tsx
+ * function RateLimitMonitor() {
+ *   const [rateLimit] = useDataPart('rate-limit', {
+ *     onData: (data) => {
+ *       if (data.data.remaining < 10) {
+ *         toast.warning('Rate limit running low!');
+ *       }
+ *     }
+ *   });
+ *
+ *   return rateLimit ? <p>{rateLimit.remaining} requests remaining</p> : null;
+ * }
+ * ```
+ */
+export function useDataPart<T = unknown>(
+  type: string,
+  options?: UseDataPartOptions<T>
+): [T | null, () => void] {
+  const messages = useChatMessages();
+  const { onData } = options || {};
+
+  // Subscribe to the transient data map directly so we re-render when it changes
+  const transientDataParts = useChatStore((state) => state._transientDataParts);
+  const removeTransientDataPart = useChatStore(
+    (state) => state.removeTransientDataPart
+  );
+
+  const result = useMemo(() => {
+    const dataParts = extractDataPartsFromMessages(messages);
+
+    // Find the latest data part of the specified type
+    // Automatically prepend 'data-' prefix for matching
+    const fullType = type.startsWith("data-") ? type : `data-${type}`;
+    let latest: DataPart<T> | null = null;
+
+    for (const dataPart of dataParts) {
+      if (
+        dataPart.type === fullType &&
+        (!latest ||
+          (dataPart.timestamp &&
+            latest.timestamp &&
+            dataPart.timestamp > latest.timestamp))
+      ) {
+        latest = dataPart as DataPart<T>;
+      }
+    }
+
+    // Check transient data parts if not found in messages
+    if (!latest) {
+      const transientData = transientDataParts.get(fullType);
+      if (transientData !== undefined) {
+        latest = {
+          type: fullType,
+          data: transientData,
+        };
+      }
+    }
+
+    return latest;
+  }, [messages, type, transientDataParts]);
+
+  // Call onData callback when data changes
+  useEffect(() => {
+    if (result && onData) {
+      onData(result);
+    }
+  }, [result, onData]);
+
+  // Memoize clear function to maintain referential equality
+  const clear = useCallback(() => {
+    const fullType = type.startsWith("data-") ? type : `data-${type}`;
+    removeTransientDataPart(fullType);
+  }, [type, removeTransientDataPart]);
+
+  return [result ? result.data : null, clear];
+}
+
+/**
+ * Extract all data parts from messages.
+ * Data parts are identified by types starting with "data-".
+ */
+function extractDataPartsFromMessages(
+  messages: UIMessage[]
+): DataPart<unknown>[] {
+  const dataParts: DataPart<unknown>[] = [];
+
+  for (const message of messages) {
+    // Check message parts for data parts
+    if (message.parts && Array.isArray(message.parts)) {
+      for (const part of message.parts) {
+        // Check if this part is a data part (starts with "data-")
+        if (part.type.startsWith("data-") && "data" in part) {
+          const dataPart = part as {
+            type: string;
+            data: unknown;
+            timestamp?: number;
+          };
+          if (dataPart.data !== undefined) {
+            dataParts.push({
+              type: dataPart.type,
+              data: dataPart.data,
+              timestamp: dataPart.timestamp || Date.now(),
+            });
+          }
+        }
+
+        // Also check tool call results that might contain data parts
+        if (part.type.startsWith("tool-") && "result" in part && part.result) {
+          const result = part.result;
+          if (typeof result === "object" && result && "parts" in result) {
+            const parts = (result as { parts?: unknown[] }).parts;
+            if (Array.isArray(parts)) {
+              for (const nestedPart of parts) {
+                const typedPart = nestedPart as {
+                  type?: string;
+                  data?: unknown;
+                  timestamp?: number;
+                };
+                if (
+                  typedPart.type?.startsWith("data-") &&
+                  typedPart.data !== undefined
+                ) {
+                  dataParts.push({
+                    type: typedPart.type,
+                    data: typedPart.data,
+                    timestamp: typedPart.timestamp || Date.now(),
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return dataParts;
+}

--- a/apps/chat/lib/stores/base/use-data-parts.ts
+++ b/apps/chat/lib/stores/base/use-data-parts.ts
@@ -3,7 +3,7 @@
 "use client";
 
 import type { UIMessage } from "@ai-sdk/react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useChatMessages, useChatStore } from "./hooks";
 
 /**
@@ -136,6 +136,7 @@ export function useDataPart<T = unknown>(
   const removeTransientDataPart = useChatStore(
     (state) => state.removeTransientDataPart
   );
+  const prevDataRef = useRef<T | null>(null);
 
   const result = useMemo(() => {
     const dataParts = extractDataPartsFromMessages(messages);
@@ -171,14 +172,16 @@ export function useDataPart<T = unknown>(
     return latest;
   }, [messages, type, transientDataParts]);
 
-  // Call onData callback when data changes
+  // Call onData callback when the underlying data changes
   useEffect(() => {
-    if (result && onData) {
+    const nextData = result ? result.data : null;
+    if (result && onData && !Object.is(prevDataRef.current, nextData)) {
       onData(result);
     }
+    prevDataRef.current = nextData;
   }, [result, onData]);
 
-  // Memoize clear function to maintain referential equality
+  // Memoize clear function to maintain referential equality. Persisted message parts are immutable here.
   const clear = useCallback(() => {
     const fullType = type.startsWith("data-") ? type : `data-${type}`;
     removeTransientDataPart(fullType);

--- a/apps/chat/lib/stores/custom-store-provider.tsx
+++ b/apps/chat/lib/stores/custom-store-provider.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import type { UIMessage } from "@ai-sdk/react";
+import { type PropsWithChildren, useContext, useRef } from "react";
+import { devtools, subscribeWithSelector } from "zustand/middleware";
+import { createStore } from "zustand/vanilla";
 import {
   Provider as ChatProvider,
   ChatStoreContext,
   createChatStoreCreator,
-} from "@ai-sdk-tools/store";
-import { type PropsWithChildren, useContext, useRef } from "react";
-import { devtools, subscribeWithSelector } from "zustand/middleware";
-import { createStore } from "zustand/vanilla";
+} from "@/lib/stores/base";
 
 import {
   type PartsAugmentedState,

--- a/apps/chat/lib/stores/hooks-base.ts
+++ b/apps/chat/lib/stores/hooks-base.ts
@@ -1,9 +1,9 @@
-// This file has hooks that are enabled by the @ai-sdk-tools/store
+// This file has hooks that are enabled by the @/lib/stores/base
 
-import { type StoreState, useChatStoreApi } from "@ai-sdk-tools/store";
 import equal from "fast-deep-equal";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
+import { type StoreState, useChatStoreApi } from "@/lib/stores/base";
 import type { ChatMessage } from "../ai/types";
 
 function useBaseChatStore<T = StoreState<ChatMessage>>(

--- a/apps/chat/lib/stores/with-message-parts.ts
+++ b/apps/chat/lib/stores/with-message-parts.ts
@@ -1,10 +1,10 @@
 "use client";
 
-// This file is a middleware that can extend @ai-sdk-tools/store with message parts functionality
+// This file is a middleware that can extend @/lib/stores/base with message parts functionality
 
-import type { StoreState as BaseChatStoreState } from "@ai-sdk-tools/store";
 import type { UIMessage } from "ai";
 import type { StateCreator } from "zustand";
+import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 
 // Helper types to safely derive the message part and part.type types from UI_MESSAGE
 type UIMessageParts<UI_MSG> = UI_MSG extends { parts: infer P } ? P : never;

--- a/apps/chat/lib/stores/with-threads.test.ts
+++ b/apps/chat/lib/stores/with-threads.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import type { StoreState as BaseChatStoreState } from "@ai-sdk-tools/store";
 import { describe, it } from "vitest";
 import { createStore } from "zustand/vanilla";
+import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 import type { ChatMessage } from "../ai/types";
 import { type ThreadAugmentedState, withThreads } from "./with-threads";
 

--- a/apps/chat/lib/stores/with-threads.ts
+++ b/apps/chat/lib/stores/with-threads.ts
@@ -1,12 +1,12 @@
 "use client";
 
-// Middleware that extends @ai-sdk-tools/store with thread epoch tracking
+// Middleware that extends @/lib/stores/base with thread epoch tracking
 // and complete message tree management for branching/sibling navigation.
 // The store owns allMessages (the full tree); React Query feeds data into it.
 
-import type { StoreState as BaseChatStoreState } from "@ai-sdk-tools/store";
 import type { UIMessage } from "ai";
 import type { StateCreator } from "zustand";
+import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 import type { MessageNode } from "@/lib/thread-utils";
 import {
   buildChildrenMap,

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -39,7 +39,6 @@
     "fetch:models": "bun scripts/fetch-models.ts && bun format"
   },
   "dependencies": {
-    "@ai-sdk-tools/store": "1.2.0",
     "@ai-sdk/anthropic": "^3.0.67",
     "@ai-sdk/devtools": "^0.0.15",
     "@ai-sdk/gateway": "^3.0.92",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
       "name": "@chatjs/chat",
       "version": "0.2.0",
       "dependencies": {
-        "@ai-sdk-tools/store": "1.2.0",
         "@ai-sdk/anthropic": "^3.0.67",
         "@ai-sdk/devtools": "^0.0.15",
         "@ai-sdk/gateway": "^3.0.92",
@@ -160,7 +159,7 @@
     },
     "apps/electron": {
       "name": "@chat-js/electron",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "@better-auth/electron": "^1.5.6",
         "@electron-forge/cli": "^7.11.1",
@@ -209,7 +208,7 @@
     },
     "packages/cli": {
       "name": "@chat-js/cli",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "bin": {
         "chat-js": "./dist/index.js",
       },
@@ -226,7 +225,7 @@
     },
     "packages/registry": {
       "name": "@chat-js/registry",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "ts-morph": "^27.0.2",
       },
@@ -237,8 +236,6 @@
     "@better-auth/core": "1.5.6",
   },
   "packages": {
-    "@ai-sdk-tools/store": ["@ai-sdk-tools/store@1.2.0", "", { "dependencies": { "@types/node": "^24.10.1", "ai": "^5.0.97" }, "peerDependencies": { "@ai-sdk/react": ">=2.0.0", "react": ">=18.0.0", "zustand": ">=5.0.0" } }, "sha512-/R01/2KA3fOyjDGDDaRSgYn6TPsGS1gO7dTYlmdC36QrCTVkN4Aqx4T3PcwUnnp4i4/nhEZb0Ar2/mpYEsQvfw=="],
-
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.69", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g=="],
 
     "@ai-sdk/devtools": ["@ai-sdk/devtools@0.0.15", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@hono/node-server": "^1.13.7", "hono": "^4.6.14" }, "bin": { "devtools": "bin/cli.js" } }, "sha512-zRF+ClRh0fcmvoKclOcmy2hmTDN48ZfHD3y1fC3Lx0vIYaX55uywssiyaA18WlV2mD+N9H4fgPxq+9JeGfMGlQ=="],
@@ -3031,10 +3028,6 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@ai-sdk-tools/store/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
-
-    "@ai-sdk-tools/store/ai": ["ai@5.0.172", "", { "dependencies": { "@ai-sdk/gateway": "2.0.76", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MjHohHMW9HkdsmVUA/gfV3FYeezu+cAXADg2b8HdRwuHjEg3GsL0WqjIfgb0Z9ntEqyzcgy9oJKe4yloEIpQAw=="],
-
     "@antfu/install-pkg/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "@changesets/changelog-github/dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
@@ -3460,16 +3453,6 @@
     "yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
-
-    "@ai-sdk-tools/store/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@ai-sdk-tools/store/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.76", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NoL38IElvxdxxjnLDPZKapb2oFyZCMhZ3qXHyERpXC5DrRO9CwkY/48/0iXihVeG3srZ04xmxMjjgdmtE8yeQQ=="],
-
-    "@ai-sdk-tools/store/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
-
-    "@ai-sdk-tools/store/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ=="],
-
-    "@ai-sdk-tools/store/ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@electron-forge/cli/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Vendor the base chat store implementation into the app and switch chat components and hooks to use the local `@/lib/stores/base` boundary instead of the external `@ai-sdk-tools/store`.

Enhancements:
- Introduce a local base chat store module under `apps/chat/lib/stores/base` that encapsulates Zustand-powered chat state, performance optimizations, and debug utilities.
- Update chat components and hooks to consume store hooks and actions from the new `@/lib/stores/base` entrypoint for improved modularity and ownership of state management.

Build:
- Remove the `@ai-sdk-tools/store` dependency from the chat app package manifest and refresh `bun.lock` to drop the external store package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `@ai-sdk-tools/store` with a local Zustand store at `@/lib/stores/base` and updated chat components/hooks to use it. Streaming is smoother, debug logging is configurable, and data parts are handled more reliably with deduped callbacks.

- **Refactors**
  - Added `apps/chat/lib/stores/base` with `Provider`, `useChat`, `useChatActions`, `useMessageById`, `useDataPart(s)`, and debug utilities.
  - Switched imports across chat components/hooks to `@/lib/stores/base`; updated `custom-store-provider` and store middlewares.
  - Performance: batched updates, ~60fps throttled messages, `requestIdleCallback`/`scheduler.postTask`, O(1) message index kept in sync, memoized selectors, virtualization helper, freeze detector, and safer throttled-effect error handling.
  - Wrapped `useChat.onData` to capture transient `data-*` parts; refined `useDataParts`/`useDataPart` to return the latest values, dedupe `onData` callbacks, and support clearing transient entries.
  - Debug: added `debug.setPrefix` and `configureDebug({ prefix })`; updated README noting vendored source.

- **Dependencies**
  - Removed `@ai-sdk-tools/store` from `apps/chat/package.json` and refreshed `bun.lock`.
  - Bumped internal versions: `@chat-js/electron` → `0.3.2`, `@chat-js/cli` → `0.6.3`, `@chat-js/registry` → `0.1.2`.

<sup>Written for commit 20f1a014477bacfed91084419209d44903e8b6ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local chat store utilities, new data-part support, and client-side syncing hooks for richer transient data handling.

* **Refactor**
  * Migrated chat store logic in-app to improve message streaming, syncing reliability, and UI responsiveness.

* **Chores**
  * Removed the external chat store dependency and consolidated store code and documentation locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->