### PR TITLE
Delay chat 404s until session and route queries settle

### DIFF
--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -177,13 +177,21 @@ function getFreshRouteQueryData<TData>({
 }
 
 function isFreshRouteQueryReady({
+  isFetchedAfterMount,
+}: {
+  isFetchedAfterMount: boolean;
+}) {
+  return isFetchedAfterMount;
+}
+
+function getFreshRouteQueryError({
   error,
   isFetchedAfterMount,
 }: {
   error: unknown;
   isFetchedAfterMount: boolean;
 }) {
-  return isFetchedAfterMount || !!error;
+  return isFetchedAfterMount ? error : null;
 }
 
 function getOverrideModelId({
@@ -307,11 +315,12 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   const isExistingRuntimePersisted = useRuntimeIsChatPersisted(existingStore);
   const persistedChatId = persistedRoute?.id ?? "";
   const shouldLoadPersistedMessages =
-    !!persistedRoute && isExistingRuntimePersisted;
+    !!persistedRoute && isExistingRuntimePersisted && !isSessionPending;
 
   const projectQuery = useQuery({
     ...trpc.project.getById.queryOptions({ id: projectHomeId ?? "" }),
-    enabled: route.type === "projectHome" && !!session?.user,
+    enabled:
+      route.type === "projectHome" && !!session?.user && !isSessionPending,
   });
 
   const chatQueryOptions = useGetChatByIdQueryOptions(persistedChatId);
@@ -331,13 +340,11 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   const chatQueryReady =
     !shouldLoadPersistedMessages ||
     isFreshRouteQueryReady({
-      error: chatQuery.error,
       isFetchedAfterMount: chatQuery.isFetchedAfterMount,
     });
   const messagesQueryReady =
     !shouldLoadPersistedMessages ||
     isFreshRouteQueryReady({
-      error: messagesQuery.error,
       isFetchedAfterMount: messagesQuery.isFetchedAfterMount,
     });
   const persistedChat = getFreshRouteQueryData({
@@ -346,6 +353,14 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   });
   const persistedMessages = getFreshRouteQueryData({
     data: messagesQuery.data,
+    isFetchedAfterMount: messagesQuery.isFetchedAfterMount,
+  });
+  const persistedChatError = getFreshRouteQueryError({
+    error: chatQuery.error,
+    isFetchedAfterMount: chatQuery.isFetchedAfterMount,
+  });
+  const persistedMessagesError = getFreshRouteQueryError({
+    error: messagesQuery.error,
     isFetchedAfterMount: messagesQuery.isFetchedAfterMount,
   });
 
@@ -419,9 +434,9 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   if (
     shouldReturnNotFound({
       chat: persistedChat,
-      chatError: chatQuery.error,
+      chatError: persistedChatError,
       hasLiveRuntime,
-      messagesError: messagesQuery.error,
+      messagesError: persistedMessagesError,
       persistedRoute,
       project: projectQuery.data,
       route,


### PR DESCRIPTION
## Summary by Sourcery

Delay 404 handling in hosted chat routes until session and related queries have settled to avoid premature not-found responses.

Bug Fixes:
- Prevent chat routes from returning 404s while the user session or persisted chat/messages queries are still pending by deferring evaluation until data has been fetched after mount.

Enhancements:
- Gate loading of persisted messages and project data on a non-pending session and separate readiness from error detection for chat and message queries to improve route stability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay 404 responses on hosted chat routes until the session and chat/message queries have settled to prevent not-found before data loads. This fixes premature 404s and improves route stability.

- **Bug Fixes**
  - Load persisted messages and enable project queries only when the session isn’t pending.
  - Mark queries as ready only after `isFetchedAfterMount`; surface errors only then.
  - Use deferred `persistedChatError` and `persistedMessagesError` in not-found checks to avoid early 404s.

<sup>Written for commit b45d2ea823307a76289d5906556d672fbcf296a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined error handling for persisted chat messages to ensure errors surface only when appropriate during session initialization and loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->