### PR TITLE
fix

### DIFF
--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -338,11 +338,11 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   });
 
   const chatQueryReady = isFreshRouteQueryReady({
-      isFetchedAfterMount: chatQuery.isFetchedAfterMount,
-    });
+    isFetchedAfterMount: chatQuery.isFetchedAfterMount,
+  });
   const messagesQueryReady = isFreshRouteQueryReady({
-      isFetchedAfterMount: messagesQuery.isFetchedAfterMount,
-    });
+    isFetchedAfterMount: messagesQuery.isFetchedAfterMount,
+  });
   const persistedChat = getFreshRouteQueryData({
     data: chatQuery.data,
     isFetchedAfterMount: chatQuery.isFetchedAfterMount,

--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -337,14 +337,10 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
       shouldLoadPersistedMessages && (messagesQueryOptions.enabled ?? true),
   });
 
-  const chatQueryReady =
-    !shouldLoadPersistedMessages ||
-    isFreshRouteQueryReady({
+  const chatQueryReady = isFreshRouteQueryReady({
       isFetchedAfterMount: chatQuery.isFetchedAfterMount,
     });
-  const messagesQueryReady =
-    !shouldLoadPersistedMessages ||
-    isFreshRouteQueryReady({
+  const messagesQueryReady = isFreshRouteQueryReady({
       isFetchedAfterMount: messagesQuery.isFetchedAfterMount,
     });
   const persistedChat = getFreshRouteQueryData({


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent chat and messages readiness flags from being marked ready prematurely when persisted messages are involved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always require a fresh fetch before marking chat and message queries as ready, removing the persisted-messages shortcut. This prevents 404s on the chat page by keeping the UI in loading until real data is fetched.

<sup>Written for commit 63e237e01bb3dec5bc68d035e628ef0fe5dabd86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading-state logic for chat and message data so readiness is determined correctly. This prevents unnecessary persisted-loading screens and ensures the app proceeds to the correct chat view or not-found flow when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->