### PR TITLE
ci: install npm in user prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+        run: |
+          npm install --global npm@latest --prefix ~/.npm-global
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- install latest npm into a user-owned prefix for trusted publishing
- add that prefix to `GITHUB_PATH` before Changesets publishes

## Validation
- parsed `.github/workflows/release.yml` with Ruby YAML loader

## Summary by Sourcery

CI:
- Update the release workflow to install the latest npm into a user-scoped prefix and add its bin directory to GITHUB_PATH before running the Changesets publish step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the release workflow to install the latest `npm` into a user-scoped prefix (`~/.npm-global`) and add `~/.npm-global/bin` to `GITHUB_PATH` before the Changesets publish step. This supports Trusted Publishing and avoids permission issues with global installs.

<sup>Written for commit 8452ad140d7ee1e1665e53cebead9a9a84dff396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to make package publishing more reliable and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->