### PR TITLE
ci: enable npm provenance publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,4 @@ jobs:
           commit: "chore: version releases"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- set `NPM_CONFIG_PROVENANCE=true` for the Changesets publish step
- keeps npm trusted publishing tokenless while forcing npm to use OIDC provenance mode

## Validation
- parsed `.github/workflows/release.yml` with Ruby YAML loader

## Summary by Sourcery

CI:
- Set NPM_CONFIG_PROVENANCE environment variable for the Changesets publish step to enforce OIDC-based trusted publishing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled `npm` provenance publishing in the release workflow by setting `NPM_CONFIG_PROVENANCE=true` for the Changesets publish step. This enforces OIDC-backed attestations while keeping trusted publishing tokenless.

<sup>Written for commit d2266526af3db034bb96e081cc0be28f30a22d26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

