### PR TITLE
fix: align package repository metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,12 +5,12 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/franciscomoretti/chat-js.git",
+		"url": "git+https://github.com/FranciscoMoretti/chat-js.git",
 		"directory": "packages/cli"
 	},
-	"homepage": "https://github.com/franciscomoretti/chat-js/tree/main/packages/cli",
+	"homepage": "https://github.com/FranciscoMoretti/chat-js/tree/main/packages/cli",
 	"bugs": {
-		"url": "https://github.com/franciscomoretti/chat-js/issues"
+		"url": "https://github.com/FranciscoMoretti/chat-js/issues"
 	},
 	"keywords": [
 		"chatjs",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -5,12 +5,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/franciscomoretti/chat-js.git",
+    "url": "git+https://github.com/FranciscoMoretti/chat-js.git",
     "directory": "packages/registry"
   },
-  "homepage": "https://github.com/franciscomoretti/chat-js/tree/main/packages/registry",
+  "homepage": "https://github.com/FranciscoMoretti/chat-js/tree/main/packages/registry",
   "bugs": {
-    "url": "https://github.com/franciscomoretti/chat-js/issues"
+    "url": "https://github.com/FranciscoMoretti/chat-js/issues"
   },
   "keywords": [
     "chatjs",


### PR DESCRIPTION
## Summary
- align publishable package repository metadata with `FranciscoMoretti/chat-js`
- use npm-normalized `git+https` repository URLs for trusted publishing

## Validation
- parsed updated package JSON files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned repository metadata in `packages/cli` and `packages/registry` with `FranciscoMoretti/chat-js` to fix npm links and support trusted publishing.
Switched to npm-normalized `git+https` repository URLs and corrected homepage/issues URLs.

<sup>Written for commit 008ea0f9a7a565eb07236b232624627cc7b0644c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

