### PR TITLE
Handle unsupported AI Gateway catalog models

### DIFF
--- a/apps/chat/lib/ai/ai-gateway-models-schemas.ts
+++ b/apps/chat/lib/ai/ai-gateway-models-schemas.ts
@@ -31,8 +31,14 @@ const aiGatewayModelTypeInputSchema = z.union([
   z.string(),
 ]);
 
+const pricingTierSchema = z.object({
+  cost: z.string(),
+  min: z.number().default(0),
+  max: z.number().optional(),
+});
+
 // Single model schema
-const aiGatewayModelSchema = z.object({
+export const aiGatewayModelSchema = z.object({
   id: z.string(),
   object: z.literal("model"),
   created: z.number(),
@@ -50,33 +56,9 @@ const aiGatewayModelSchema = z.object({
     input_cache_write: z.string().optional(),
     web_search: z.string().optional(),
     image: z.string().optional(),
-    input_tiers: z
-      .array(
-        z.object({
-          cost: z.string(),
-          min: z.number(),
-          max: z.number().optional(),
-        })
-      )
-      .optional(),
-    output_tiers: z
-      .array(
-        z.object({
-          cost: z.string(),
-          min: z.number(),
-          max: z.number().optional(),
-        })
-      )
-      .optional(),
-    input_cache_read_tiers: z
-      .array(
-        z.object({
-          cost: z.string(),
-          min: z.number(),
-          max: z.number().optional(),
-        })
-      )
-      .optional(),
+    input_tiers: z.array(pricingTierSchema).optional(),
+    output_tiers: z.array(pricingTierSchema).optional(),
+    input_cache_read_tiers: z.array(pricingTierSchema).optional(),
   }),
 });
 
@@ -90,8 +72,12 @@ export function isAiGatewayModelType(type: string): type is AiGatewayModelType {
   return supportedAiGatewayModelTypes.includes(type as AiGatewayModelType);
 }
 
-// Models response schema
-export const aiGatewayModelsResponseSchema = z.object({
+export const aiGatewayModelDiscriminatorSchema = z.object({
+  type: z.string(),
+});
+
+// Parse the response envelope before validating individual supported models.
+export const aiGatewayModelsEnvelopeSchema = z.object({
   object: z.literal("list"),
-  data: z.array(aiGatewayModelSchema),
+  data: z.array(z.unknown()),
 });

--- a/apps/chat/lib/ai/gateways/vercel-gateway.test.ts
+++ b/apps/chat/lib/ai/gateways/vercel-gateway.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { VercelGateway } from "./vercel-gateway";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("VercelGateway", () => {
+  it("skips unsupported models before validating supported model metadata", async () => {
+    vi.stubEnv("AI_GATEWAY_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          Response.json({
+            object: "list",
+            data: [
+              {
+                id: "openai/tts-1",
+                object: "model",
+                created: 1,
+                owned_by: "openai",
+                name: "TTS 1",
+                description: "Text to speech",
+                type: "speech",
+                pricing: {},
+              },
+              {
+                id: "openai/gpt-test",
+                object: "model",
+                created: 2,
+                owned_by: "openai",
+                name: "GPT Test",
+                description: "Language model",
+                context_window: 128_000,
+                max_tokens: 16_384,
+                type: "language",
+                pricing: {
+                  input_cache_read_tiers: [
+                    { cost: "0.000001", max: 64_000 },
+                    { cost: "0.000002", min: 64_000 },
+                  ],
+                },
+              },
+            ],
+          })
+        )
+      )
+    );
+
+    const models = await new VercelGateway().fetchModels();
+
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      id: "openai/gpt-test",
+      pricing: {
+        input_cache_read_tiers: [
+          { cost: "0.000001", min: 0, max: 64_000 },
+          { cost: "0.000002", min: 64_000 },
+        ],
+      },
+      type: "language",
+    });
+  });
+});

--- a/apps/chat/lib/ai/gateways/vercel-gateway.ts
+++ b/apps/chat/lib/ai/gateways/vercel-gateway.ts
@@ -4,7 +4,9 @@ import type { ImageModel, LanguageModel } from "ai";
 import { createModuleLogger } from "@/lib/logger";
 import {
   type AiGatewayModel,
-  aiGatewayModelsResponseSchema,
+  aiGatewayModelDiscriminatorSchema,
+  aiGatewayModelSchema,
+  aiGatewayModelsEnvelopeSchema,
   isAiGatewayModelType,
 } from "../ai-gateway-models-schemas";
 import { getFallbackModels } from "./fallback-models";
@@ -79,16 +81,18 @@ export class VercelGateway
       }
 
       const bodyRaw = await response.json();
-      const body = aiGatewayModelsResponseSchema.parse(bodyRaw);
+      const body = aiGatewayModelsEnvelopeSchema.parse(bodyRaw);
       const unsupportedTypes = new Set<string>();
       const models: AiGatewayModel[] = [];
 
-      for (const model of body.data) {
-        if (!isAiGatewayModelType(model.type)) {
-          unsupportedTypes.add(model.type);
+      for (const candidate of body.data) {
+        const { type } = aiGatewayModelDiscriminatorSchema.parse(candidate);
+        if (!isAiGatewayModelType(type)) {
+          unsupportedTypes.add(type);
           continue;
         }
-        models.push({ ...model, type: model.type });
+        const model = aiGatewayModelSchema.parse(candidate);
+        models.push({ ...model, type });
       }
 
       if (unsupportedTypes.size > 0) {


### PR DESCRIPTION
## What

- Filter unsupported AI Gateway model types before validating the chat-model schema
- Accept pricing tiers where the gateway omits `min` by defaulting it to zero
- Add a regression test covering unsupported catalog entries and incomplete tier bounds

## Why

The live Vercel AI Gateway catalog now includes speech, transcription, realtime, and reranking models that do not carry the chat-only token metadata this app expects. It also includes a language-model pricing tier without a `min` field. Parsing the whole response strictly caused one unsupported entry to reject the entire catalog and silently switch the app to its generated fallback list.

This keeps strict validation for supported language and embedding models while ignoring catalog entries the app cannot use.

## Checks

- Targeted Vitest regression suite
- Ultracite checks for the changed files
- `bun test:types`
- Full suite on the source commit: 4 E2E and 84 unit tests

## Summary by Sourcery

Filter unsupported AI Gateway catalog entries before strict model validation and relax pricing tier bounds to handle missing minimum values.

Bug Fixes:
- Ignore AI Gateway models with unsupported types when parsing the catalog so they do not cause the entire response to be rejected.
- Default missing pricing tier minimums to zero to accept gateway entries with incomplete tier bounds.

Enhancements:
- Introduce a shared pricing tier schema for AI Gateway models and separate envelope/discriminator schemas for catalog parsing.

Tests:
- Add a regression test verifying unsupported models are skipped and pricing tiers without a minimum are parsed correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip unsupported Vercel Gateway catalog entries and default missing pricing tier minimums to 0 to prevent catalog parse failures and fallback switching. Keeps strict checks for supported language and embedding models.

- **Bug Fixes**
  - Parse the list envelope, read `type`, and ignore unsupported entries (speech, transcription, realtime, reranking).
  - Validate only supported models with the strict model schema and token metadata.
  - Use a shared `pricingTierSchema` with `min` defaulting to 0 for tier arrays.
  - Add a regression test for unsupported entries and tiers missing `min`.

<sup>Written for commit ae2a4502a2b121b311ce8124eeaca70c8431872e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

