### PR TITLE
Add floating development login tool

### DIFF
--- a/apps/chat/app/(auth)/login/page.tsx
+++ b/apps/chat/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft } from "lucide-react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
+import { DevLoginTool } from "@/components/dev-login-tool";
 import { ElectronTransferUser } from "@/components/electron-auth-ui";
 import { InternalLink } from "@/components/internal-link";
 import { LoginForm } from "@/components/login-form";
@@ -43,6 +44,7 @@ export default async function LoginPage({
         <ChevronLeft className="mr-2 h-4 w-4" />
         Back
       </InternalLink>
+      <DevLoginTool />
       <div className="mx-auto flex w-full flex-col items-center justify-center sm:w-[420px]">
         {session?.user && isElectronTransfer ? (
           <ElectronTransferUser query={query} session={session} />

--- a/apps/chat/components/dev-login-tool.tsx
+++ b/apps/chat/components/dev-login-tool.tsx
@@ -1,0 +1,29 @@
+import { LogIn } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function DevLoginTool() {
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
+
+  return (
+    <a
+      className={cn(
+        buttonVariants({ size: "sm", variant: "outline" }),
+        "group fixed bottom-4 left-16 z-50 h-9 rounded-full border-border/80 bg-background/90 px-3 shadow-black/10 shadow-lg backdrop-blur-md hover:border-foreground/20 hover:bg-accent"
+      )}
+      href="/api/dev-login"
+    >
+      <span aria-hidden="true" className="relative flex size-2">
+        <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400 opacity-50 motion-reduce:animate-none" />
+        <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+      </span>
+      <LogIn className="text-muted-foreground transition-colors group-hover:text-foreground" />
+      <span>Dev login</span>
+      <span className="font-mono text-[10px] text-muted-foreground/70">
+        DEV
+      </span>
+    </a>
+  );
+}

--- a/apps/chat/components/dev-login-tool.tsx
+++ b/apps/chat/components/dev-login-tool.tsx
@@ -10,20 +10,17 @@ export function DevLoginTool() {
   return (
     <a
       className={cn(
-        buttonVariants({ size: "sm", variant: "outline" }),
-        "group fixed bottom-4 left-16 z-50 h-9 rounded-full border-border/80 bg-background/90 px-3 shadow-black/10 shadow-lg backdrop-blur-md hover:border-foreground/20 hover:bg-accent"
+        buttonVariants({ size: "sm" }),
+        "group fixed bottom-5 left-16 z-50 h-9 rounded-full border border-white/10 bg-black/80 px-2.5 text-xs text-zinc-300 shadow-black/30 shadow-lg backdrop-blur-md hover:border-white/15 hover:bg-zinc-900 hover:text-white"
       )}
       href="/api/dev-login"
     >
-      <span aria-hidden="true" className="relative flex size-2">
+      <span aria-hidden="true" className="relative flex size-1.5">
         <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400 opacity-50 motion-reduce:animate-none" />
-        <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+        <span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
       </span>
-      <LogIn className="text-muted-foreground transition-colors group-hover:text-foreground" />
+      <LogIn className="size-3.5 text-zinc-500 transition-colors group-hover:text-zinc-300" />
       <span>Dev login</span>
-      <span className="font-mono text-[10px] text-muted-foreground/70">
-        DEV
-      </span>
     </a>
   );
 }

--- a/apps/chat/tests/chat.e2e.ts
+++ b/apps/chat/tests/chat.e2e.ts
@@ -5,3 +5,13 @@ test("chat page loads", async ({ page }) => {
   await expect(page).toHaveURL("/");
   await expect(page.getByRole("textbox")).toBeVisible();
 });
+
+test("development login tool is available on the login page", async ({
+  page,
+}) => {
+  await page.goto("/login");
+
+  const devLogin = page.getByRole("link", { name: "Dev login" });
+  await expect(devLogin).toBeVisible();
+  await expect(devLogin).toHaveAttribute("href", "/api/dev-login");
+});


### PR DESCRIPTION
## What

- Add a development-only floating login control to the login page
- Link directly to the existing `/api/dev-login` flow
- Match the size and placement of the Next.js development launcher
- Use a compact dark treatment that stays visually separate from product UI
- Add Playwright coverage for visibility and destination

## Why

OAuth callback allowlists make authentication inconvenient across many local worktree ports. The existing development-login endpoint solves authentication for local users and browser agents, but it was not discoverable from the login screen.

The control is omitted outside `NODE_ENV=development`.

## Checks

- 4 Playwright E2E tests on an isolated local port
- Workspace lint
- Workspace typecheck

## Summary by Sourcery

Add a development-only floating login control on the login page that links to the existing dev login flow.

New Features:
- Introduce a DevLoginTool component that surfaces a floating dev login control on the login screen in development environments.

Tests:
- Extend Playwright E2E coverage to assert the dev login tool is visible on the login page and links to the /api/dev-login endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development-only “Dev login” shortcut to the login page.
  * The shortcut links directly to the development login endpoint and is hidden outside development environments.

* **Tests**
  * Added end-to-end coverage verifying the shortcut’s visibility and destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->