### PR TITLE
Pin Playwright browser install to workspace version

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,9 +53,7 @@ jobs:
       - uses: actions/cache@v4
         if: steps.affected.outputs.run == 'true'
         with:
-          path: |
-            ~/.bun
-            **/node_modules
+          path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - if: steps.affected.outputs.run == 'true'
@@ -68,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lock') }}
       - name: Install Playwright browsers
         if: steps.affected.outputs.run == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install --with-deps chromium
+        run: apps/chat/node_modules/.bin/playwright install --with-deps chromium
       - if: steps.affected.outputs.run == 'true'
         env:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
## What

- cache only Bun's package download cache instead of `node_modules`
- install Playwright browsers with the workspace-local binary

## Why

PR #207 exposed a dependency-version mismatch in CI. The browser installation step resolved a newer transient Playwright release and downloaded Chromium revision 1228, while the tests ran the lockfile-pinned Playwright 1.59.1 and required revision 1217. The cached `node_modules` archive also failed to restore because Bun's hardlinks were incomplete.

Using the installed workspace binary guarantees browser installation and test execution use the same Playwright version. Avoiding `node_modules` caching prevents partial Bun hardlink restorations.

## Impact

Future PR E2E runs should no longer fail because the installed browser revision differs from the Playwright test runner.

## Checks

- `bun install --frozen-lockfile`
- workflow YAML parse
- `git diff --check`
- workspace Playwright version: 1.59.1
- workspace Playwright browser dry-run: Chromium/headless-shell revision 1217

## Summary by Sourcery

Align Playwright browser installation in CI with the workspace-pinned Playwright version and adjust caching to avoid Bun hardlink issues.

Bug Fixes:
- Ensure Playwright browsers are installed using the workspace-local Playwright binary so tests and installed browsers share the same version.

CI:
- Switch CI caching from node_modules to Bun's install cache to prevent partial hardlink restores and improve reliability of Playwright runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Playwright browser installation to the workspace-pinned version and switch caching to Bun’s install cache. This prevents E2E failures from browser revision mismatches in CI.

- **Bug Fixes**
  - Install browsers via `apps/chat/node_modules/.bin/playwright` to match the lockfile version used by tests.
  - Cache only `~/.bun/install/cache` instead of `node_modules` to avoid Bun hardlink restore issues.

<sup>Written for commit 3f40424c4b4f65d09cf645c859e9d110c8f230ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated testing setup by refining dependency caching.
  * Updated Playwright browser installation to use the project’s configured tooling while preserving Chromium support and system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->