### PR TITLE
spike(thread): compare useChat external chat class

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -212,7 +212,7 @@
     },
     "packages/cli": {
       "name": "@chat-js/cli",
-      "version": "0.6.5",
+      "version": "0.7.0",
       "bin": {
         "chat-js": "./dist/index.js",
       },
@@ -241,8 +241,10 @@
         "@ai-sdk/react": "^3.0.152",
         "@types/bun": "^1.3.12",
         "@types/react": "19.2.7",
+        "@types/react-test-renderer": "19.1.0",
         "ai": "^6.0.150",
         "react": "19.2.3",
+        "react-test-renderer": "19.2.3",
         "typescript": "6.0.2",
       },
       "peerDependencies": {
@@ -1157,6 +1159,8 @@
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
@@ -2546,7 +2550,7 @@
 
     "react-hook-form": ["react-hook-form@7.72.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+    "react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -2557,6 +2561,8 @@
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.3", "", { "dependencies": { "react-is": "^19.2.3", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw=="],
 
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
@@ -3427,6 +3433,8 @@
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/packages/thread/USE_CHAT_IMPLEMENTATION_COMPARISON.md
+++ b/packages/thread/USE_CHAT_IMPLEMENTATION_COMPARISON.md
@@ -1,0 +1,435 @@
+# `useThread` React Implementation Comparison
+
+## Question
+
+Can `useThread` reuse `@ai-sdk/react`'s `useChat` hook by passing an externally
+owned chat object that projects thread state as a linear active path?
+
+Tested against the workspace's installed versions:
+
+- `@ai-sdk/react@3.0.221`
+- `ai@6.0.219`
+
+Run the spike with:
+
+```bash
+bun run spike:external-chat
+```
+
+## Verdict
+
+Technically yes, with a concrete `Chat` facade over `ThreadRuntime`. Do not use
+that facade as the production implementation of `useThread`.
+
+This branch deliberately implements the facade alternative so its code,
+behavior, and dependency profile can be reviewed rather than inferred. The
+recommended branch keeps the direct React projection.
+
+## Executive comparison
+
+| Axis | Direct runtime subscription | `useChat({ chat: facade })` |
+| --- | --- | --- |
+| Consumer `UseChatHelpers` compatibility | Yes | Yes |
+| Canonical tree ownership | `ThreadRuntime` | `ThreadRuntime` |
+| Concurrent branch requests | Per-run `AbstractChat` | Per-run `AbstractChat` |
+| AI SDK stream/request reuse | Complete | Complete |
+| React subscription reuse | Reimplemented with public React primitives | Delegated to `useChat` |
+| Tree subscription | Direct runtime subscription | Separate direct runtime subscription |
+| Callback freshness | Runtime-owned | Runtime-owned |
+| Transport freshness | Runtime-owned | Runtime-owned |
+| External `useChat` hook options | N/A | Ignored except `resume` and throttle |
+| Dependency on concrete React `Chat` | No | Yes |
+| Dependency on tilde subscription methods | No | Yes |
+| Dead inherited linear state/request engine | No | Yes |
+| Same-ID runtime replacement | Explicitly subscribed by runtime identity | Relies on interactions between `useChat` subscriptions |
+| Canonical Zustand store extensibility | Natural runtime store seam | Facade provides no store seam |
+| Likely AI SDK patch/minor churn | Low | Low to medium |
+| Likely AI SDK major migration work | Public helper/type diff | Helper/type plus concrete `Chat` protocol diff |
+| Module depth | Runtime hides the hard behavior | Facade is a shallow adapter over the same runtime |
+
+The facade wins only on the amount of handwritten React hook glue. The direct
+implementation wins on ownership clarity, dependency surface, and future
+store extensibility. Both implementations reuse the same high-complexity AI
+SDK behavior.
+
+The facade must extend `@ai-sdk/react`'s public `Chat` class, delegate the
+standard chat operations to `ThreadRuntime`, expose the selected path through
+its `messages` getter, and replace the three React subscription methods with
+runtime subscriptions.
+
+```text
+useThread
+  ├── useChat({ chat: ThreadChatFacade })
+  │     └── standard useChat-compatible active-path helpers
+  └── ThreadRuntime subscription
+        └── tree state and branch controls
+```
+
+The facade does not replace the runtime's per-run engines. One isolated
+`AbstractChat` is still required for every concurrent assistant response. In
+practice, the facade only replaces a small amount of React subscription glue
+while adding inheritance and coupling to React Chat internals.
+
+## What `useChat({ chat })` actually requires
+
+The public `UseChatOptions` type accepts the concrete React `Chat`, not a base
+`AbstractChat` or a general chat interface:
+
+```ts
+type UseChatOptions<M extends UIMessage> =
+  | { chat: Chat<M> }
+  | ChatInit<M>;
+```
+
+At runtime, `useChat` reads the object's standard properties and calls three
+React-specific subscription methods:
+
+```ts
+chat["~registerMessagesCallback"](listener, throttleWaitMs);
+chat["~registerStatusCallback"](listener);
+chat["~registerErrorCallback"](listener);
+```
+
+An `AbstractChat` subclass does not have those methods and is rejected by the
+public TypeScript API. An arbitrary structural object could work after a cast,
+but that would rely on implementation details without type support.
+
+## Facade behavior proven by the spike
+
+The test passes a `ThreadChatFacade extends Chat` directly to `useChat` and
+proves that:
+
+- `messages`, `status`, and `error` are read from `ThreadRuntime` snapshots.
+- `sendMessage` streams into the canonical tree.
+- `setMessages` reconciles the selected path and moves the runtime cursor.
+- Cursor changes trigger `useChat` rerenders.
+- A hidden branch continues streaming after another branch becomes selected.
+- The visible `useChat.messages` remains the root-to-cursor projection.
+
+The additional tree API still needs a `ThreadRuntime` subscription because
+`useChat` only returns its fixed `UseChatHelpers` surface.
+
+## Real application validation
+
+The package's production `useThread` was temporarily changed to use the facade
+and exercised through the ChatJS application with its normal HTTP transport,
+persistence callbacks, query invalidation, Zustand selectors, message editing,
+and sibling controls.
+
+The following scenarios passed:
+
+- A new provisional chat streamed, persisted, promoted to its permanent URL,
+  and restored correctly.
+- Additional messages streamed into an existing persisted chat.
+- Editing a user message created a `2/2` branch without replacing the original.
+- Switching to the previous branch while the edited response was streaming did
+  not abort or redirect the hidden run.
+- Switching back after completion revealed the complete hidden response.
+- Stopping during submission returned the selected path to `ready`.
+
+No browser errors, duplicate messages, reversed messages, or branch-count
+inflation were observed.
+
+React-level tests also proved that callback updates reach the existing runtime,
+multiple runtime notifications are batched into one render, and externally
+owned runtimes can be replaced even when they share a chat ID.
+
+The app still required its existing runtime-to-Zustand synchronization for
+legacy selectors and persistence integration. The facade neither removed nor
+simplified that synchronization.
+
+## Next major: React 4 and AI 7
+
+The next stable major was inspected and tested:
+
+- `@ai-sdk/react@4.0.15`
+- `ai@7.0.14`
+
+The unchanged thread package passes its type check and all 22 runtime,
+integration, facade, and React behavior tests against those versions.
+
+The direction of the new major is conservative for chat:
+
+- `UseChatHelpers`, `UseChatOptions`, the concrete `Chat` requirement, and the
+  three tilde-prefixed subscriptions are unchanged.
+- `ReactChatState` is unchanged.
+- `AbstractChat`, `ChatState`, statuses, request methods, tools, approvals, and
+  the single `activeResponse` model are behaviorally unchanged.
+- The React package added unrelated realtime and MCP app surfaces rather than
+  generalizing `Chat` into a public external-store interface.
+
+The meaningful `useChat` change is transport freshness. For a hook-owned chat,
+React 4 keeps the latest `transport` in a ref and gives `Chat` a stable proxy
+transport. This fixes stale transports without recreating the chat.
+
+That improvement does not apply to `useChat({ chat })`: when an external chat
+is supplied, hook callbacks and transport are ignored and the external object
+continues to own them. A thread facade would therefore need to implement
+transport replacement itself, just like the direct runtime.
+
+This major supports the current ownership split. The frequently changing
+stream and request behavior remains in `AbstractChat`, which the thread runtime
+already uses once per active run. Routing the React projection through
+`useChat` would not increase reuse of that behavior.
+
+## Responsibility comparison
+
+There are two separate layers to compare.
+
+### AI request engine
+
+Both alternatives reuse the same AI SDK responsibilities through one
+`AbstractChat` per run:
+
+- transport invocation and reconnection
+- stream chunk processing and message accumulation
+- status transitions and request errors
+- abort controllers
+- data and tool callbacks
+- tool outputs and approvals
+- automatic tool follow-ups
+- finish callbacks and finish reasons
+- message metadata and data schemas
+
+Both alternatives also require the same thread-specific responsibilities:
+
+- canonical nodes and edges
+- cursor and selected-path projection
+- run registry and concurrency policy
+- stable assistant identity
+- tool and approval ownership routing
+- branch-aware regeneration, stopping, and resume
+- mapping a new user message onto a selected parent
+
+The facade does not reduce any of this because its `sendMessage`, `regenerate`,
+`stop`, tools, and approvals must delegate to `ThreadRuntime`. Letting one
+inherited `Chat` own these methods would restore the single `activeResponse`
+limitation and break concurrent branches.
+
+### React useChat glue
+
+The direct hook owns more of the small React layer:
+
+| Responsibility | Direct useThread | useChat facade |
+| --- | --- | --- |
+| Create or replace runtime by identity | Thread hook | Thread hook |
+| Keep callbacks fresh | Thread runtime | Thread runtime |
+| Keep transport fresh | Thread runtime | Thread runtime |
+| Subscribe to selected messages | Thread hook | useChat + adapter |
+| Subscribe to status and error | Thread hook | useChat + adapter |
+| Throttle message notifications | Thread hook | Adapter honoring useChat's wait value |
+| Apply setMessages updater | Thread hook | useChat |
+| Run resume-on-mount effect | Thread hook | useChat |
+| Assemble standard helper object | Thread hook | useChat |
+| Subscribe to complete tree | Thread hook | Thread hook |
+
+The facade reuses `useSyncExternalStore` wiring, the `setMessages` updater, the
+resume effect, and helper-object assembly. It must still provide the
+subscription implementation and throttling because `useChat` delegates those
+to the external `Chat` object.
+
+Therefore the direct alternative reimplements more of `useChat` numerically,
+but the difference is thin, stable React glue. Both alternatives reuse the
+same high-complexity and higher-change AI SDK request engine.
+
+## Why one tree-backed AbstractChat is insufficient
+
+AI SDK's `AbstractChat` owns one mutable `activeResponse`, one status/error
+pair, one abort target, and one linear message state. The negative spike starts
+two requests on one normal `Chat` and observes:
+
+- The second request receives `[user-a, user-b]`, not a sibling path.
+- `stop()` aborts only the latest active response.
+- The first assistant is appended after both user messages.
+
+Replacing its `ChatState` with a tree-aware state could redirect mutations, but
+it would not make the request lifecycle concurrent. Per-run `AbstractChat`
+engines remain the correct ownership boundary.
+
+## Callback ownership
+
+When `useChat` creates its own `Chat`, it wraps callbacks in refs so rerenders
+use the latest callback functions. When the `chat` option is supplied, those
+callback refs are empty and hook-level callbacks are not accepted.
+
+Therefore:
+
+- `ThreadRuntime` should continue owning `onData`, `onToolCall`, `onFinish`,
+  `onError`, and `sendAutomaticallyWhen`.
+- `useThread` should continue updating those callback references on rerender.
+- `ThreadChatFacade` should delegate operations and subscriptions only.
+- No callback wrapping inside `useChat` is available or needed for the facade.
+
+## Transport and option ownership
+
+The `chat` option selects externally owned chat mode. In this mode, `useChat`
+does not apply hook-level `transport`, `onData`, `onToolCall`, `onFinish`,
+`onError`, or `sendAutomaticallyWhen` options to the supplied object.
+
+The facade branch therefore keeps `ThreadRuntime.updateOptions` and delegates
+callbacks and transport to the runtime exactly like the direct branch. A
+transport update affects future per-run engines; an already active run keeps
+the transport and abort controller with which it started.
+
+`useChat` still owns two useful hook concerns for the facade:
+
+- `experimental_throttle` is passed to the facade's message subscription.
+- `resume` invokes the facade's delegated `resumeStream` on mount.
+
+This is less reuse than the call site initially suggests. Supplying `chat` is
+instance injection, not option injection.
+
+## External store and Zustand extensibility
+
+Passing a Zustand store as the `chat` option is not supported. The public type
+requires a concrete React `Chat`, and `useChat` calls its three React-specific
+subscription methods. A Zustand integration would therefore require this
+stack:
+
+```text
+useChat
+  -> concrete Chat facade
+     -> Zustand-backed ChatState or ThreadRuntime
+```
+
+That does not remove the facade and does not solve thread concurrency. A
+single inherited `Chat` still owns one `activeResponse`; the package still
+needs one isolated `AbstractChat` per active branch.
+
+The stronger store seam sits below `ThreadRuntime`:
+
+```text
+useThread
+  -> ThreadRuntime
+     -> ThreadStore (memory adapter or Zustand adapter)
+     -> per-run AbstractChat engines
+```
+
+Observable canonical state belongs in that store: messages, edges, roots,
+cursor, serializable run descriptors, statuses, and errors. Ephemeral request
+objects remain runtime-owned: `AbstractChat` instances, abort controllers,
+promises, transports, and tool ownership indexes.
+
+The direct React implementation can subscribe to any runtime store satisfying
+that interface. The facade adds another subscription layer but no additional
+extensibility. It also cannot remove the ChatJS app's current runtime-to-
+Zustand synchronization because existing selectors still read the app store.
+
+## React lifecycle and identity
+
+`useChat` replaces its internal `chatRef` when the supplied object changes, but
+its message subscription callback is keyed by throttle and `chat.id`. Replacing
+an external facade with another facade that has the same ID does not directly
+force that message subscription to be recreated. Status and error
+subscriptions do receive the new facade methods, and React checks snapshots
+around commits, so the tested replacement scenario works today.
+
+That behavior is nevertheless indirect. The direct implementation keys its
+subscription on the actual `ThreadRuntime` object and has an explicit test for
+same-ID replacement. A production facade would need to keep this scenario as a
+regression test for every supported `@ai-sdk/react` version.
+
+The facade must also be created during render so `useChat` receives the current
+instance. Moving runtime subscription rewiring into render would be a bad
+React pattern; this branch avoids that by making each facade immutable and
+delegating subscriptions directly to its runtime.
+
+## Performance and allocation profile
+
+Both implementations clone canonical message snapshots and notify React from
+the same runtime. Neither changes stream reduction cost.
+
+The facade adds:
+
+- one concrete `Chat` and its unused `ReactChatState`
+- inherited callback sets and linear message allocation
+- facade methods and three runtime subscription adapters
+- a second runtime subscription for tree-only state
+
+The direct implementation adds only the hook's `useSyncExternalStore`
+subscriptions. The difference is unlikely to dominate token streaming, but it
+favors the direct implementation and makes the facade harder to explain.
+
+## Testability
+
+Both alternatives can be tested through the same public `UseThreadHelpers`
+interface and runtime integration suite. The facade needs extra tests for:
+
+- concrete `Chat` type compatibility
+- the three tilde-prefixed subscription methods
+- message throttling delegated by `useChat`
+- same-ID external runtime replacement
+- callback and transport ownership in external-chat mode
+- `useChat` behavior across every supported React package major
+
+The direct implementation needs focused tests for its small subscription,
+updater, throttle, and resume glue. Its request and tree behavior remains
+covered at the runtime seam in both alternatives.
+
+## Options
+
+### 1. Keep the current direct useThread subscriptions
+
+`useThread` subscribes to `ThreadRuntime` itself and returns a compatible
+object. This has the smallest dependency on `@ai-sdk/react` internals and
+already works.
+
+### 2. Implement useThread with a Chat facade
+
+`useThread` creates a stable `ThreadChatFacade`, calls `useChat({ chat: facade
+})` for the standard active-path API, subscribes separately for tree state, and
+returns `{ ...chat, tree }`.
+
+This mechanically delegates the standard React contract to AI SDK. It does not
+simplify tree or run ownership, callback ownership, or application state
+integration.
+
+### 3. Export the facade for callers to pass to useChat
+
+This works, but `useChat` does not return tree helpers. Callers would need to
+retain the external object and use a second API for tree state. That is less
+ergonomic than `useThread` and exposes more lifecycle responsibility.
+
+### 4. Cast an AbstractChat or arbitrary object to Chat
+
+Do not use this option. It bypasses the public type and depends directly on the
+three tilde-prefixed subscription methods.
+
+## Architectural assessment
+
+The facade is an adapter, not another state store: its getters read
+`ThreadRuntime` directly and it does not duplicate messages. It therefore does
+not create a state synchronization bridge by itself.
+
+It is still a shallow module:
+
+- It subclasses `Chat` but bypasses the inherited `ReactChatState` and request
+  engine.
+- It overrides every operation returned by `useChat`.
+- It depends on the tilde-prefixed React subscription protocol.
+- It allocates the base `Chat` state even though that state is never used.
+- It still needs a separate runtime subscription for `tree`.
+- It leaves callback refresh in `ThreadRuntime` because external `useChat`
+  callbacks are unavailable.
+- It does not remove the app's runtime-to-Zustand integration.
+
+Under the deletion test, removing the facade restores a small amount of direct
+`useSyncExternalStore` code. Its complexity does not reappear across callers;
+it remains local to `useThread`. The adapter therefore provides little module
+depth or leverage.
+
+## Recommendation
+
+Keep the current direct `useThread` implementation and the per-run
+`AbstractChat` engines.
+
+Compatibility should be guaranteed at the public interface and by
+differential tests against `UseChatHelpers`, not by routing the implementation
+through the `useChat` hook. The direct implementation uses stable public React
+primitives, avoids pretending to use `Chat` state that it actually bypasses,
+and keeps the canonical runtime as the only state owner.
+
+The facade spike should remain as evidence that `useChat({ chat })` is
+technically interoperable and as a regression oracle if AI SDK later publishes
+a proper external chat interface. It should not be exported or used in the
+production hook today.

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -42,7 +42,8 @@
 	},
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
-		"format": "bunx @biomejs/biome@2.4.10 check --write src test *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"format": "bunx @biomejs/biome@2.4.10 check --write src test spike *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"spike:external-chat": "bun test spike/use-chat-external-chat.test.tsx",
 		"test": "bun test ./test",
 		"test:types": "tsc --noEmit"
 	},
@@ -55,8 +56,10 @@
 		"@ai-sdk/react": "^3.0.152",
 		"@types/bun": "^1.3.12",
 		"@types/react": "19.2.7",
+		"@types/react-test-renderer": "19.1.0",
 		"ai": "^6.0.150",
 		"react": "19.2.3",
+		"react-test-renderer": "19.2.3",
 		"typescript": "6.0.2"
 	}
 }

--- a/packages/thread/spike/use-chat-external-chat-types.ts
+++ b/packages/thread/spike/use-chat-external-chat-types.ts
@@ -1,0 +1,26 @@
+import { type Chat, useChat } from "@ai-sdk/react";
+import { AbstractChat, type ChatState, type UIMessage } from "ai";
+
+declare const state: ChatState<UIMessage>;
+
+class AbstractExternalChat extends AbstractChat<UIMessage> {
+	constructor() {
+		super({ state });
+	}
+}
+
+declare const concreteChat: Chat<UIMessage>;
+declare const abstractChat: AbstractExternalChat;
+
+function Supported() {
+	return useChat({ chat: concreteChat });
+}
+
+function RejectedByPublicType() {
+	// AbstractChat lacks @ai-sdk/react's three `~register*Callback` methods.
+	// @ts-expect-error useChat({ chat }) requires the concrete React Chat class.
+	return useChat({ chat: abstractChat });
+}
+
+void Supported;
+void RejectedByPublicType;

--- a/packages/thread/spike/use-chat-external-chat.test.tsx
+++ b/packages/thread/spike/use-chat-external-chat.test.tsx
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Chat, type UseChatHelpers, useChat } from "@ai-sdk/react";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { getMessageText, ThreadRuntime } from "../src/runtime";
+import { ThreadChatFacade } from "../src/thread-chat-facade";
+import { type UseThreadHelpers, useThread } from "../src/use-thread";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type PendingRequest = {
+	abortSignal: AbortSignal | undefined;
+	controller: ReadableStreamDefaultController<UIMessageChunk>;
+	messages: UIMessage[];
+};
+
+class ControlledTransport implements ChatTransport<UIMessage> {
+	readonly aborted = new Set<string>();
+	readonly requests = new Map<string, PendingRequest>();
+
+	sendMessages: ChatTransport<UIMessage>["sendMessages"] = (options) => {
+		const body = options.body as
+			| {
+					assistantMessageId?: string;
+					tree?: { assistantMessageId?: string };
+			  }
+			| undefined;
+		const requestId =
+			body?.tree?.assistantMessageId ?? body?.assistantMessageId;
+		if (!requestId) {
+			throw new Error("Spike requires an assistantMessageId");
+		}
+
+		return Promise.resolve(
+			new ReadableStream<UIMessageChunk>({
+				start: (controller) => {
+					this.requests.set(requestId, {
+						abortSignal: options.abortSignal,
+						controller,
+						messages: structuredClone(options.messages),
+					});
+					options.abortSignal?.addEventListener(
+						"abort",
+						() => {
+							this.aborted.add(requestId);
+							controller.enqueue({ type: "abort" });
+							controller.close();
+						},
+						{ once: true },
+					);
+				},
+			}),
+		);
+	};
+
+	reconnectToStream() {
+		return Promise.resolve(null);
+	}
+
+	emitText(requestId: string, textId: string, text: string) {
+		const request = this.requests.get(requestId);
+		if (!request) {
+			throw new Error(`Unknown request ${requestId}`);
+		}
+		request.controller.enqueue({ messageId: requestId, type: "start" });
+		request.controller.enqueue({ id: textId, type: "text-start" });
+		request.controller.enqueue({ delta: text, id: textId, type: "text-delta" });
+	}
+
+	finish(requestId: string) {
+		const request = this.requests.get(requestId);
+		if (!request) {
+			throw new Error(`Unknown request ${requestId}`);
+		}
+		request.controller.enqueue({ finishReason: "stop", type: "finish" });
+		request.controller.close();
+	}
+}
+
+function userMessage(id: string, text: string): UIMessage {
+	return {
+		id,
+		parts: [{ text, type: "text" }],
+		role: "user",
+	};
+}
+
+async function waitFor(predicate: () => boolean) {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (predicate()) {
+			return;
+		}
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for spike state");
+}
+
+let renderer: ReactTestRenderer | undefined;
+
+afterEach(() => {
+	if (renderer) {
+		act(() => renderer?.unmount());
+		renderer = undefined;
+	}
+});
+
+describe("SPIKE: useChat with an externally owned thread facade", () => {
+	test("honors useChat's message subscription throttle", async () => {
+		const runtime = new ThreadRuntime<UIMessage>({
+			messages: [userMessage("root", "root")],
+		});
+		const facade = new ThreadChatFacade(runtime);
+		let notifications = 0;
+		const unsubscribe = facade["~registerMessagesCallback"](() => {
+			notifications += 1;
+		}, 10);
+
+		runtime.setCursor(null);
+		runtime.setCursor("root");
+		expect(notifications).toBe(1);
+
+		await Bun.sleep(15);
+		expect(notifications).toBe(2);
+		unsubscribe();
+	});
+
+	test("standard useChat helpers read and mutate ThreadRuntime directly", async () => {
+		const transport = new ControlledTransport();
+		const runtime = new ThreadRuntime<UIMessage>({ transport });
+		const facade = new ThreadChatFacade(runtime);
+		let helpers: UseChatHelpers<UIMessage> | undefined;
+
+		function Probe() {
+			helpers = useChat({ chat: facade });
+			return null;
+		}
+
+		await act(async () => {
+			renderer = create(createElement(Probe));
+		});
+
+		let sendPromise: Promise<void> | undefined;
+		await act(async () => {
+			sendPromise = helpers?.sendMessage(userMessage("user-a", "A"), {
+				body: { assistantMessageId: "assistant-a" },
+			});
+			await waitFor(() => transport.requests.has("assistant-a"));
+			transport.emitText("assistant-a", "text-a", "alpha");
+			transport.finish("assistant-a");
+			await sendPromise;
+		});
+
+		expect(helpers?.messages.map((message) => message.id)).toEqual([
+			"user-a",
+			"assistant-a",
+		]);
+		expect(getMessageText(runtime.getMessage("assistant-a") as UIMessage)).toBe(
+			"alpha",
+		);
+		expect(helpers?.status).toBe("ready");
+
+		await act(async () => {
+			helpers?.setMessages((messages) => messages.slice(0, 1));
+		});
+		expect(runtime.getSnapshot().cursorId).toBe("user-a");
+		expect(helpers?.messages.map((message) => message.id)).toEqual(["user-a"]);
+	});
+
+	test("the facade keeps hidden branch runs alive while useChat follows the cursor", async () => {
+		const transport = new ControlledTransport();
+		const runtime = new ThreadRuntime<UIMessage>({ transport });
+		const facade = new ThreadChatFacade(runtime);
+		let helpers: UseChatHelpers<UIMessage> | undefined;
+
+		function Probe() {
+			helpers = useChat({ chat: facade });
+			return null;
+		}
+
+		await act(async () => {
+			renderer = create(createElement(Probe));
+		});
+
+		let runA: Awaited<ReturnType<ThreadRuntime["startRun"]>> | undefined;
+		let runB: Awaited<ReturnType<ThreadRuntime["startRun"]>> | undefined;
+		await act(async () => {
+			runA = await runtime.startRun({
+				follow: true,
+				message: userMessage("user-a", "A"),
+				request: { body: { assistantMessageId: "assistant-a" } },
+			});
+			runB = await runtime.startRun({
+				follow: false,
+				from: null,
+				message: userMessage("user-b", "B"),
+				request: { body: { assistantMessageId: "assistant-b" } },
+			});
+			await waitFor(() => transport.requests.size === 2);
+			transport.emitText("assistant-a", "text-a", "alpha");
+			transport.emitText("assistant-b", "text-b", "beta");
+			await waitFor(
+				() =>
+					getMessageText(runtime.getMessage("assistant-a") as UIMessage) ===
+						"alpha" &&
+					getMessageText(runtime.getMessage("assistant-b") as UIMessage) ===
+						"beta",
+			);
+			runtime.setCursor("assistant-b");
+		});
+
+		expect(helpers?.messages.map((message) => message.id)).toEqual([
+			"user-b",
+			"assistant-b",
+		]);
+
+		await act(async () => {
+			transport.requests.get("assistant-a")?.controller.enqueue({
+				delta: "-hidden",
+				id: "text-a",
+				type: "text-delta",
+			});
+			transport.finish("assistant-a");
+			transport.finish("assistant-b");
+			await Promise.all([runA?.finished, runB?.finished]);
+		});
+
+		expect(getMessageText(runtime.getMessage("assistant-a") as UIMessage)).toBe(
+			"alpha-hidden",
+		);
+		expect(getMessageText(helpers?.messages.at(-1) as UIMessage)).toBe("beta");
+	});
+});
+
+describe("SPIKE: current useThread React behavior", () => {
+	test("refreshes callbacks without replacing the runtime", async () => {
+		const transport = new ControlledTransport();
+		const finishedBy: string[] = [];
+		let helpers: UseThreadHelpers<UIMessage> | undefined;
+
+		function Probe({ callbackVersion }: { callbackVersion: string }) {
+			helpers = useThread({
+				id: "callback-chat",
+				onFinish: () => finishedBy.push(callbackVersion),
+				transport,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			renderer = create(createElement(Probe, { callbackVersion: "old" }));
+		});
+		await act(async () => {
+			renderer?.update(createElement(Probe, { callbackVersion: "new" }));
+		});
+
+		let run: Awaited<ReturnType<ThreadRuntime["startRun"]>> | undefined;
+		await act(async () => {
+			run = await helpers?.tree.startRun({
+				message: userMessage("callback-user", "callback"),
+				request: { body: { assistantMessageId: "callback-assistant" } },
+			});
+			await waitFor(() => transport.requests.has("callback-assistant"));
+			transport.emitText("callback-assistant", "callback-text", "done");
+			transport.finish("callback-assistant");
+			await run?.finished;
+		});
+
+		expect(finishedBy).toEqual(["new"]);
+	});
+
+	test("batches multiple external-store notifications into one React render", async () => {
+		const runtime = new ThreadRuntime<UIMessage>({
+			id: "render-chat",
+			messages: [userMessage("root", "root")],
+		});
+		let helpers: UseThreadHelpers<UIMessage> | undefined;
+		let renderCount = 0;
+
+		function Probe() {
+			renderCount += 1;
+			helpers = useThread({ runtime });
+			return null;
+		}
+
+		await act(async () => {
+			renderer = create(createElement(Probe));
+		});
+		const rendersBefore = renderCount;
+
+		await act(async () => {
+			helpers?.tree.setCursor(null);
+		});
+
+		expect(renderCount - rendersBefore).toBe(1);
+		expect(helpers?.messages).toEqual([]);
+	});
+
+	test("switches externally owned runtimes with the same chat id", async () => {
+		const runtimeA = new ThreadRuntime<UIMessage>({
+			id: "shared-id",
+			messages: [userMessage("user-a", "A")],
+		});
+		const runtimeB = new ThreadRuntime<UIMessage>({
+			id: "shared-id",
+			messages: [userMessage("user-b", "B")],
+		});
+		let helpers: UseThreadHelpers<UIMessage> | undefined;
+
+		function Probe({ runtime }: { runtime: ThreadRuntime<UIMessage> }) {
+			helpers = useThread({ runtime });
+			return null;
+		}
+
+		await act(async () => {
+			renderer = create(createElement(Probe, { runtime: runtimeA }));
+		});
+		expect(helpers?.messages.map((message) => message.id)).toEqual(["user-a"]);
+
+		await act(async () => {
+			renderer?.update(createElement(Probe, { runtime: runtimeB }));
+		});
+		expect(helpers?.messages.map((message) => message.id)).toEqual(["user-b"]);
+
+		await act(async () => {
+			runtimeB.setCursor(null);
+		});
+		expect(helpers?.messages).toEqual([]);
+	});
+});
+
+describe("SPIKE: one normal Chat instance is not a concurrent tree engine", () => {
+	test("a second send shares linear history and stop only owns the latest response", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Chat<UIMessage>({ transport });
+
+		const requestA = chat.sendMessage(userMessage("user-a", "A"), {
+			body: { assistantMessageId: "assistant-a" },
+		});
+		await waitFor(() => transport.requests.has("assistant-a"));
+		const requestB = chat.sendMessage(userMessage("user-b", "B"), {
+			body: { assistantMessageId: "assistant-b" },
+		});
+		await waitFor(() => transport.requests.has("assistant-b"));
+
+		expect(
+			transport.requests
+				.get("assistant-a")
+				?.messages.map((message) => message.id),
+		).toEqual(["user-a"]);
+		expect(
+			transport.requests
+				.get("assistant-b")
+				?.messages.map((message) => message.id),
+		).toEqual(["user-a", "user-b"]);
+
+		await chat.stop();
+		await requestB;
+		expect(transport.aborted).toEqual(new Set(["assistant-b"]));
+
+		transport.emitText("assistant-a", "text-a", "alpha");
+		transport.finish("assistant-a");
+		await requestA;
+		expect(chat.messages.map((message) => message.id)).toEqual([
+			"user-a",
+			"user-b",
+			"assistant-a",
+		]);
+	});
+});

--- a/packages/thread/src/thread-chat-facade.ts
+++ b/packages/thread/src/thread-chat-facade.ts
@@ -1,0 +1,90 @@
+import { Chat } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import type { ThreadRuntime } from "./runtime";
+
+function subscribeWithThrottle<TMessage extends UIMessage>(
+	runtime: ThreadRuntime<TMessage>,
+	listener: () => void,
+	waitMs?: number,
+) {
+	if (!waitMs) {
+		return runtime.subscribe(listener);
+	}
+
+	let lastCall = 0;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const notify = () => {
+		const elapsed = Date.now() - lastCall;
+		if (elapsed >= waitMs) {
+			lastCall = Date.now();
+			listener();
+			return;
+		}
+		if (timeout) {
+			return;
+		}
+		timeout = setTimeout(() => {
+			timeout = undefined;
+			lastCall = Date.now();
+			listener();
+		}, waitMs - elapsed);
+	};
+
+	const unsubscribe = runtime.subscribe(notify);
+	return () => {
+		unsubscribe();
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+	};
+}
+
+/**
+ * Adapts the canonical thread runtime to the concrete Chat contract required
+ * by useChat({ chat }). The inherited linear state and request engine are not
+ * used; all state and operations delegate to ThreadRuntime.
+ */
+export class ThreadChatFacade<
+	TMessage extends UIMessage = UIMessage,
+> extends Chat<TMessage> {
+	readonly runtime: ThreadRuntime<TMessage>;
+
+	constructor(runtime: ThreadRuntime<TMessage>) {
+		super({
+			id: runtime.chatId,
+			messages: runtime.getSnapshot().messages,
+			transport: runtime.transport,
+		});
+		this.runtime = runtime;
+
+		this.sendMessage = runtime.sendMessage;
+		this.regenerate = runtime.regenerate;
+		this.stop = runtime.stop;
+		this.resumeStream = runtime.resumeStream;
+		this.clearError = runtime.clearError;
+		this.addToolOutput = runtime.addToolOutput;
+		this.addToolResult = runtime.addToolResult;
+		this.addToolApprovalResponse = runtime.addToolApprovalResponse;
+
+		this["~registerMessagesCallback"] = (listener, waitMs) =>
+			subscribeWithThrottle(runtime, listener, waitMs);
+		this["~registerStatusCallback"] = (listener) => runtime.subscribe(listener);
+		this["~registerErrorCallback"] = (listener) => runtime.subscribe(listener);
+	}
+
+	override get messages() {
+		return this.runtime.getSnapshot().messages;
+	}
+
+	override set messages(messages: TMessage[]) {
+		this.runtime.setMessages(messages);
+	}
+
+	override get status() {
+		return this.runtime.getSnapshot().status;
+	}
+
+	override get error() {
+		return this.runtime.getSnapshot().error;
+	}
+}

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -1,9 +1,10 @@
 "use client";
 
-import type { UseChatHelpers } from "@ai-sdk/react";
+import { type UseChatHelpers, useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
-import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 import { ThreadRuntime } from "./runtime";
+import { ThreadChatFacade } from "./thread-chat-facade";
 import type {
 	MessageTreeSnapshot,
 	ThreadRun,
@@ -143,50 +144,32 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 	if (runtimeOptions) {
 		runtime.updateOptions(runtimeOptions);
 	}
+	const facadeRef = useRef<{
+		facade: ThreadChatFacade<TMessage>;
+		runtime: ThreadRuntime<TMessage>;
+	} | null>(null);
+	if (!facadeRef.current || facadeRef.current.runtime !== runtime) {
+		facadeRef.current = {
+			facade: new ThreadChatFacade(runtime),
+			runtime,
+		};
+	}
+	const chat = useChat({
+		chat: facadeRef.current.facade,
+		experimental_throttle: options.experimental_throttle,
+		resume: options.resume,
+	});
 	const snapshot = useRuntimeSnapshot(runtime, options.experimental_throttle);
-	const status = useSyncExternalStore(
-		runtime.subscribe,
-		() => runtime.getSnapshot().status,
-		() => runtime.getSnapshot().status,
-	);
 	const treeStatus = useSyncExternalStore(
 		runtime.subscribe,
 		() => runtime.getSnapshot().treeStatus,
 		() => runtime.getSnapshot().treeStatus,
 	);
-	const error = useSyncExternalStore(
-		runtime.subscribe,
-		() => runtime.getSnapshot().error,
-		() => runtime.getSnapshot().error,
-	);
-
-	useEffect(() => {
-		if (!options.resume) {
-			return;
-		}
-		runtime.resumeStream();
-	}, [options.resume, runtime]);
-
-	const setMessages = useCallback<UseChatHelpers<TMessage>["setMessages"]>(
-		(messages) => runtime.setMessages(messages),
-		[runtime],
-	);
 
 	return {
-		addToolApprovalResponse: runtime.addToolApprovalResponse,
-		addToolOutput: runtime.addToolOutput,
-		addToolResult: runtime.addToolResult,
-		clearError: runtime.clearError,
-		error,
-		id: runtime.chatId,
+		...chat,
 		lastEvent: snapshot.lastEvent,
-		messages: snapshot.messages,
-		regenerate: runtime.regenerate,
-		resumeStream: runtime.resumeStream,
 		sendMessage: runtime.sendMessage,
-		setMessages,
-		status,
-		stop: runtime.stop,
 		tree: {
 			activeRuns: snapshot.activeRuns,
 			childrenByParentId: snapshot.childrenByParentId,

--- a/packages/thread/tsconfig.json
+++ b/packages/thread/tsconfig.json
@@ -12,5 +12,5 @@
 		"isolatedModules": true,
 		"types": ["bun"]
 	},
-	"include": ["src/**/*.ts", "test/**/*.ts"]
+	"include": ["src/**/*.ts", "spike/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
## What changed

- implements `useThread` through `@ai-sdk/react`'s real `useChat({ chat })` external-chat path
- adds a concrete `ThreadChatFacade extends Chat` that delegates state and operations to the canonical `ThreadRuntime`
- retains one isolated `AbstractChat` engine per active branch, so concurrent branch streams and stop ownership are unchanged
- includes the original type/runtime spike and production React behavior coverage
- adds an in-depth comparison of both implementations across maintenance, AI SDK upgrades, responsibility reuse, state ownership, concurrency, callbacks, transport freshness, React lifecycle, performance, testability, and Zustand extensibility

## Why

This makes the external-chat alternative concrete and reviewable. It answers whether routing the standard active-path helpers through upstream `useChat` materially improves compatibility or maintainability.

The comparison concludes that the facade is technically valid and consumer-compatible, but only reuses thin React glue. It does not replace the thread runtime, per-run request engines, callback/transport ownership, tree subscription, or the app's Zustand synchronization. The direct implementation remains the recommendation.

## Validation

- `bun --filter @chatjs/thread test` (17 passing)
- `bun --filter @chatjs/thread spike:external-chat` (7 passing)
- `bun --filter @chatjs/thread test:types`
- `bun --filter @chatjs/thread build`
- `bun --filter @chatjs/chat test:types`
- real app: normal send, edited `2/2` branch, switch away/back during streaming, stop active response
- browser console: no warnings or errors

## Review note

This is intentionally stacked on `codex/use-thread`. It is an alternative implementation PR, not the recommended production direction.

## Summary by Sourcery

Implement a spike version of useThread that delegates its chat helpers to @ai-sdk/react's useChat via a ThreadChatFacade, and add documentation and tests comparing this external-chat facade approach to the existing direct runtime implementation.

Enhancements:
- Introduce a ThreadChatFacade that adapts ThreadRuntime to the concrete Chat contract required by useChat({ chat }).
- Refactor useThread to integrate useChat with the facade while preserving existing thread runtime state, tree controls, and concurrent branch behavior.

Build:
- Update thread package build and test configuration to include spike sources and new React test-renderer dependencies, and adjust formatting and test script paths.

Documentation:
- Add a detailed USE_CHAT_IMPLEMENTATION_COMPARISON.md explaining the tradeoffs between the facade-based useChat implementation and the direct runtime-based useThread implementation.

Tests:
- Add spike tests validating useThread and ThreadChatFacade behavior with useChat, including callback freshness, concurrency, throttling, and limitations of a single Chat instance.
- Add a spike types test ensuring useChat({ chat }) only accepts the concrete Chat class and not arbitrary AbstractChat implementations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements an external `useChat({ chat })` path in `useThread` via a new `ThreadChatFacade` that adapts `ThreadRuntime` to React `Chat`. Preserves runtime ownership of tree state, per-branch concurrency, callbacks, and transport while confirming compatibility with `@ai-sdk/react`.

- **Refactors**
  - `use-thread` now builds a `ThreadChatFacade` and uses `useChat({ chat: facade, resume, experimental_throttle })` for `messages/status/error`; tree remains a direct runtime subscription.
  - Adds `ThreadChatFacade extends Chat` with `~register*Callback` adapters (with throttle) and delegations for send/regenerate/stop/tools/approvals.
  - Adds spike tests covering facade behavior, throttling, hidden-branch streaming, and a types test proving `useChat({ chat })` only accepts the concrete `Chat`.
  - Adds a detailed `USE_CHAT_IMPLEMENTATION_COMPARISON.md` comparing the facade to the direct implementation.

- **Dependencies**
  - Added `react-test-renderer@19.2.3` and `@types/react-test-renderer@19.1.0`; added `spike:external-chat` script and included `spike/**` in `tsconfig.json`.

<sup>Written for commit 85d5a3426f2363da8f13d052a0270ecab6f8596c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

