### PR TITLE
Threads 2: Expose a useChat-compatible useThread hook

### DIFF
--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -26,6 +26,12 @@
 			"bun": "./src/index.ts",
 			"development": "./src/index.ts",
 			"default": "./dist/index.js"
+		},
+		"./react": {
+			"types": "./src/react.ts",
+			"bun": "./src/react.ts",
+			"development": "./src/react.ts",
+			"default": "./dist/react.js"
 		}
 	},
 	"types": "./src/index.ts",
@@ -39,7 +45,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external",
+		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external && bun build ./src/react.ts --outfile ./dist/react.js --target=browser --format=esm --packages external --banner='\"use client\";'",
 		"format": "bunx @biomejs/biome@2.4.10 check --write src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"lint": "bunx @biomejs/biome@2.4.10 check src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
@@ -48,7 +54,9 @@
 		"test:types": "tsc --noEmit"
 	},
 	"peerDependencies": {
-		"ai": "^6.0.0"
+		"@ai-sdk/react": "^3.0.0",
+		"ai": "^6.0.0",
+		"react": ">=18"
 	},
 	"devDependencies": {
 		"@ai-sdk/react": "^3.0.152",

--- a/packages/thread/src/react.ts
+++ b/packages/thread/src/react.ts
@@ -1,0 +1,8 @@
+"use client";
+
+export {
+	type TreeHelpers,
+	type UseThreadHelpers,
+	type UseThreadOptions,
+	useThread,
+} from "./use-thread";

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -1,0 +1,219 @@
+"use client";
+
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { ThreadChat } from "./thread-chat";
+import type {
+	MessageTreeSnapshot,
+	ThreadChatOptions,
+	ThreadRun,
+	ThreadRunHandle,
+	ThreadStartRunOptions,
+	TreeSendOptions,
+} from "./types";
+
+type ThreadHookOptions = {
+	experimental_throttle?: number;
+	resume?: boolean;
+};
+
+type ExternalThreadOptions<TMessage extends UIMessage> = ThreadHookOptions & {
+	chat: ThreadChat<TMessage>;
+};
+
+export type UseThreadOptions<TMessage extends UIMessage = UIMessage> =
+	| ExternalThreadOptions<TMessage>
+	| (ThreadHookOptions &
+			ThreadChatOptions<TMessage> & {
+				chat?: never;
+			});
+
+function hasSuppliedChat<TMessage extends UIMessage>(
+	options: UseThreadOptions<TMessage>,
+): options is ExternalThreadOptions<TMessage> {
+	return "chat" in options && options.chat !== undefined;
+}
+
+export type TreeHelpers<TMessage extends UIMessage = UIMessage> = {
+	childrenByParentId: Record<string, string[]>;
+	cursorId: string | null;
+	getChildren: (messageId: string | null) => TMessage[];
+	getLeaves: (messageId?: string | null) => TMessage[];
+	getMessage: (messageId: string) => TMessage | undefined;
+	getParent: (messageId: string) => TMessage | undefined;
+	getPath: (messageId?: string | null) => TMessage[];
+	getSiblings: (messageId: string) => TMessage[];
+	messagesById: Record<string, TMessage>;
+	parentById: Record<string, string | null>;
+	rootIds: string[];
+	activeRuns: ThreadRun[];
+	runs: ThreadRun[];
+	status: ReturnType<ThreadChat<TMessage>["getSnapshot"]>["treeStatus"];
+	getRun: (runId: string) => ThreadRun | undefined;
+	getRunForMessage: (messageId: string) => ThreadRun | undefined;
+	getSnapshot: () => MessageTreeSnapshot<TMessage>;
+	resumeRun: (runId: string, options?: TreeSendOptions) => Promise<void>;
+	setCursor: (messageId: string | null) => void;
+	setCursorToParentOf: (messageId: string) => void;
+	startRun: (
+		options?: ThreadStartRunOptions<TMessage>,
+	) => Promise<ThreadRunHandle>;
+	stopAll: () => Promise<void>;
+	stopRun: (runId: string) => Promise<void>;
+	stopRunForMessage: (messageId: string) => Promise<void>;
+};
+
+export type UseThreadHelpers<TMessage extends UIMessage = UIMessage> =
+	UseChatHelpers<TMessage> & {
+		lastEvent: string;
+		sendMessage: (
+			message?: Parameters<UseChatHelpers<TMessage>["sendMessage"]>[0],
+			options?: TreeSendOptions,
+		) => Promise<void>;
+		tree: TreeHelpers<TMessage>;
+	};
+
+function useThreadChatSnapshot<TMessage extends UIMessage>(
+	chat: ThreadChat<TMessage>,
+	throttleWaitMs?: number,
+) {
+	const subscribe = useCallback(
+		(listener: () => void) => {
+			if (!throttleWaitMs) {
+				return chat.subscribe(listener);
+			}
+
+			let lastCall = 0;
+			let timeout: ReturnType<typeof setTimeout> | undefined;
+			const notify = () => {
+				const elapsed = Date.now() - lastCall;
+				if (elapsed >= throttleWaitMs) {
+					lastCall = Date.now();
+					listener();
+					return;
+				}
+				if (timeout) {
+					return;
+				}
+				timeout = setTimeout(() => {
+					timeout = undefined;
+					lastCall = Date.now();
+					listener();
+				}, throttleWaitMs - elapsed);
+			};
+
+			const unsubscribe = chat.subscribe(notify);
+			return () => {
+				unsubscribe();
+				if (timeout) {
+					clearTimeout(timeout);
+				}
+			};
+		},
+		[chat, throttleWaitMs],
+	);
+
+	return useSyncExternalStore(subscribe, chat.getSnapshot, chat.getSnapshot);
+}
+
+export function useThread<TMessage extends UIMessage = UIMessage>(
+	options: UseThreadOptions<TMessage> = {},
+): UseThreadHelpers<TMessage> {
+	const chatRef = useRef<ThreadChat<TMessage> | null>(null);
+	const suppliedChat = hasSuppliedChat(options) ? options.chat : undefined;
+	const chatOptions = hasSuppliedChat(options) ? undefined : options;
+	if (suppliedChat) {
+		chatRef.current = suppliedChat;
+	} else if (
+		!chatRef.current ||
+		(chatOptions?.id !== undefined && chatRef.current.id !== chatOptions.id)
+	) {
+		chatRef.current = new ThreadChat(chatOptions);
+	}
+
+	const chat = chatRef.current;
+	if (chatOptions) {
+		chat.updateOptions({
+			...chatOptions,
+			onData: chatOptions.onData,
+			onError: chatOptions.onError,
+			onFinish: chatOptions.onFinish,
+			onThreadEvent: chatOptions.onThreadEvent,
+			onToolCall: chatOptions.onToolCall,
+			sendAutomaticallyWhen: chatOptions.sendAutomaticallyWhen,
+		});
+	}
+	const snapshot = useThreadChatSnapshot(chat, options.experimental_throttle);
+	const status = useSyncExternalStore(
+		chat.subscribe,
+		() => chat.getSnapshot().status,
+		() => chat.getSnapshot().status,
+	);
+	const treeStatus = useSyncExternalStore(
+		chat.subscribe,
+		() => chat.getSnapshot().treeStatus,
+		() => chat.getSnapshot().treeStatus,
+	);
+	const error = useSyncExternalStore(
+		chat.subscribe,
+		() => chat.getSnapshot().error,
+		() => chat.getSnapshot().error,
+	);
+
+	useEffect(() => {
+		if (!options.resume) {
+			return;
+		}
+		chat.resumeStream();
+	}, [options.resume, chat]);
+
+	const setMessages = useCallback<UseChatHelpers<TMessage>["setMessages"]>(
+		(messages) => chat.setMessages(messages),
+		[chat],
+	);
+
+	return {
+		addToolApprovalResponse: chat.addToolApprovalResponse,
+		addToolOutput: chat.addToolOutput,
+		addToolResult: chat.addToolResult,
+		clearError: chat.clearError,
+		error,
+		id: chat.id,
+		lastEvent: snapshot.lastEvent,
+		messages: snapshot.messages,
+		regenerate: chat.regenerate,
+		resumeStream: chat.resumeStream,
+		sendMessage: chat.sendMessage,
+		setMessages,
+		status,
+		stop: chat.stop,
+		tree: {
+			activeRuns: snapshot.activeRuns,
+			childrenByParentId: snapshot.childrenByParentId,
+			cursorId: snapshot.cursorId,
+			getChildren: (messageId) => chat.getChildren(messageId),
+			getLeaves: (messageId) => chat.getLeaves(messageId),
+			getMessage: (messageId) => chat.getMessage(messageId),
+			getParent: (messageId) => chat.getParent(messageId),
+			getPath: (messageId) => chat.getPath(messageId),
+			getRun: (runId) => chat.getRun(runId),
+			getRunForMessage: (messageId) => chat.getRunForMessage(messageId),
+			getSnapshot: () => chat.getTreeSnapshot(),
+			getSiblings: (messageId) => chat.getSiblings(messageId),
+			messagesById: snapshot.messagesById,
+			parentById: snapshot.parentById,
+			rootIds: snapshot.rootIds,
+			runs: snapshot.runs,
+			status: treeStatus,
+			resumeRun: (runId, requestOptions) =>
+				chat.resumeRun(runId, requestOptions),
+			setCursor: (messageId) => chat.setCursor(messageId),
+			setCursorToParentOf: (messageId) => chat.setCursorToParentOf(messageId),
+			startRun: (runOptions) => chat.startRun(runOptions),
+			stopAll: () => chat.stopAll(),
+			stopRun: (runId) => chat.stopRun(runId),
+			stopRunForMessage: (messageId) => chat.stopRunForMessage(messageId),
+		},
+	};
+}

--- a/packages/thread/test/use-thread-types.ts
+++ b/packages/thread/test/use-thread-types.ts
@@ -1,0 +1,39 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { type UseThreadHelpers, useThread } from "../src/react";
+import { ThreadChat } from "../src/thread-chat";
+
+declare const messageId: string;
+
+function useCompatibilityCheck() {
+	const thread = useThread();
+	const chatCompatible: UseChatHelpers<UIMessage> = thread;
+
+	chatCompatible.messages;
+	chatCompatible.sendMessage({ text: "hello" });
+	chatCompatible.setMessages((messages) => messages);
+
+	thread.tree.setCursor(messageId);
+	thread.tree.setCursor(null);
+	thread.tree.getPath(messageId);
+	thread.tree.getChildren(null);
+	thread.tree.getSiblings(messageId);
+	thread.tree.stopAll();
+	thread.tree.activeRuns;
+	thread.tree.runs;
+	thread.tree.status;
+	thread.tree.getRunForMessage(messageId);
+	thread.tree.getSnapshot();
+	thread.tree.startRun({ from: messageId, message: { text: "branch" } });
+
+	const explicitHelpers: UseThreadHelpers<UIMessage> = thread;
+	return explicitHelpers;
+}
+
+function useExternalChatCheck() {
+	const chat = new ThreadChat<UIMessage>();
+	return useThread({ chat });
+}
+
+void useCompatibilityCheck;
+void useExternalChatCheck;


### PR DESCRIPTION
## Summary
- expose `useThread` from `@chatjs/thread/react`
- preserve the AI SDK `useChat` interface for the active path
- add tree navigation, run control, `ThreadChat` injection, and type compatibility

## Verification
- `bun --filter @chatjs/thread lint`
- `bun --filter @chatjs/thread test:types`
- `bun --filter @chatjs/thread test:unit`
- `bun --filter @chatjs/thread build`

## Summary by Sourcery

Expose a new React `useThread` hook for the `ThreadChat` engine that is API-compatible with `useChat`, and bundle it as a dedicated `/react` entry point.

New Features:
- Add a `useThread` React hook that wraps `ThreadChat` and exposes `UseChat`-compatible helpers plus tree navigation and run control utilities.

Enhancements:
- Extend the thread package build to emit a separate `react` bundle with a client-ready entry point and include `ARCHITECTURE.md` in published files.
- Add type-level tests to verify `useThread` remains compatible with `UseChatHelpers` and supports external `ThreadChat` injection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a React `useThread` hook in `@chatjs/thread/react` that matches `useChat` from `@ai-sdk/react` and adds tree navigation and run control for threaded conversations. Ships a client-only `/react` bundle with a "use client" entry.

- **New Features**
  - New `./react` entry exporting `useThread`, `TreeHelpers`, `UseThreadHelpers`, and `UseThreadOptions`; build emits `dist/react.js` with a `"use client"` banner.
  - `useThread` mirrors `useChat`, adds `tree` helpers (cursor, path/children/siblings), run control (start/stop/resume), `lastEvent`, and `error`; supports injected or internal `ThreadChat`, `experimental_throttle`, `resume`, and `sendMessage` with `TreeSendOptions`.
  - Type tests verify `UseChatHelpers` compatibility.

- **Dependencies**
  - Add peer deps `react` (>=18) and `@ai-sdk/react` (^3) alongside `ai` (^6).

<sup>Written for commit ad6813ed54244983f54a3525cd6bc16853607cfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. **#221** 👈 current
3. #222
4. #223
5. #224
6. #225
7. #226
8. #227
9. #228
10. #229
<!-- stack:links:end -->
