### PR TITLE
Threads 3: Adapt ChatJS state to threaded paths

### DIFF
--- a/apps/chat/components/chat-runtime-controller.tsx
+++ b/apps/chat/components/chat-runtime-controller.tsx
@@ -118,7 +118,7 @@ export function AppRuntimeSlot({ runtime }: { runtime: AppRuntime }) {
   return (
     <CustomStoreProvider store={store}>
       <ChatConfirmationEffects chatId={runtime.data.chatId} />
-      <ChatSync id={runtime.data.chatId} />
+      <ChatSync chat={runtime.data.chat} id={runtime.data.chatId} />
     </CustomStoreProvider>
   );
 }

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ThreadChat } from "@chatjs/thread";
 import { DefaultChatTransport } from "ai";
 import { useRef } from "react";
 import { toast } from "sonner";
@@ -14,14 +15,20 @@ import {
   useAddMessageToTree,
   useThreadInitialMessages,
 } from "@/lib/stores/hooks-threads";
-import { fetchWithErrorHandlers, generateUUID } from "@/lib/utils";
+import { fetchWithErrorHandlers } from "@/lib/utils";
 import { useSession } from "@/providers/session-provider";
 
 function isResumableActiveStreamId(activeStreamId: string | null | undefined) {
   return !!(activeStreamId && !activeStreamId.startsWith("pending:"));
 }
 
-export function ChatSync({ id }: { id: string }) {
+export function ChatSync({
+  chat,
+  id,
+}: {
+  chat: ThreadChat<ChatMessage>;
+  id: string;
+}) {
   const { data: session } = useSession();
   const { mutate: saveChatMessage } = useSaveMessageMutation();
   const { setChatPersisted } = useChatPersistenceActions();
@@ -40,13 +47,13 @@ export function ChatSync({ id }: { id: string }) {
   );
 
   useChat<ChatMessage>({
+    chat,
     experimental_throttle: 100,
     id,
     // TODO: this is a special "snapshot" value in the store that is only updated
     // on store init + sibling switch. Once the store can guarantee up-to-date
     // messages at ChatSync remount time, we can likely remove this override.
     messages: threadInitialMessages,
-    generateId: generateUUID,
     onFinish: ({ message }) => {
       addMessageToTree(message);
       saveChatMessage({ message, chatId: id });

--- a/apps/chat/lib/app-chat-runtime.ts
+++ b/apps/chat/lib/app-chat-runtime.ts
@@ -1,3 +1,4 @@
+import { ThreadChat } from "@chatjs/thread";
 import {
   createContext,
   createElement,
@@ -20,6 +21,7 @@ import {
 
 export interface AppRuntimeData {
   bootstrap: boolean;
+  chat: ThreadChat<ChatMessage>;
   chatId: string;
   initialMessages?: ChatMessage[];
   initialTool?: UiToolName | null;
@@ -100,13 +102,20 @@ export function createAppRuntimeInput({
     throw new Error(`Invalid chat runtime id: ${runtimeId}`);
   }
 
+  const store = createAppRuntimeStore({ bootstrap, initialMessages });
+
   return {
     data: {
       bootstrap,
+      chat: new ThreadChat<ChatMessage>({
+        generateId: generateUUID,
+        id: parsed.chatId,
+        initialTree: store.getState().treeSnapshot,
+      }),
       chatId: parsed.chatId,
       initialMessages,
       initialTool,
-      store: createAppRuntimeStore({ bootstrap, initialMessages }),
+      store,
       threadId: parsed.threadId,
     },
     runtimeId,

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -3,6 +3,7 @@
 "use client";
 
 import type { UIMessage, UseChatHelpers } from "@ai-sdk/react";
+import type { UseThreadHelpers } from "@chatjs/thread/react";
 import type { ChatStatus } from "ai";
 import * as React from "react";
 import { createContext, useCallback, useContext, useRef } from "react";
@@ -255,6 +256,7 @@ export interface StoreState<TMessage extends UIMessage = UIMessage> {
 
   // Transient data methods
   setTransientDataPart: (type: string, data: any) => void;
+  startRun?: UseThreadHelpers<TMessage>["tree"]["startRun"];
   status: ChatStatus;
   stop?: UseChatHelpers<TMessage>["stop"];
 }
@@ -304,6 +306,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
 
       // Chat helpers
       sendMessage: undefined,
+      startRun: undefined,
       regenerate: undefined,
       stop: undefined,
       resumeStream: undefined,
@@ -796,6 +799,11 @@ const fallbackSendMessage = async () => {
     "sendMessage not configured - make sure useChat is called with transport"
   );
 };
+const fallbackStartRun = async () => {
+  throw new Error(
+    "startRun not configured - make sure useChat is called with transport"
+  );
+};
 const fallbackRegenerate = async () => {
   debug.warn(
     "regenerate not configured - make sure useChat is called with transport"
@@ -834,6 +842,7 @@ export type ChatActions<TMessage extends UIMessage = UIMessage> = {
   setNewChat: (id: string, messages: TMessage[]) => void;
   reset: () => void;
   sendMessage: UseChatHelpers<TMessage>["sendMessage"];
+  startRun: UseThreadHelpers<TMessage>["tree"]["startRun"];
   regenerate: UseChatHelpers<TMessage>["regenerate"];
   stop: UseChatHelpers<TMessage>["stop"];
   resumeStream: UseChatHelpers<TMessage>["resumeStream"];
@@ -857,6 +866,7 @@ export const useChatActions = <
       setNewChat: state.setNewChat,
       reset: state.reset,
       sendMessage: state.sendMessage || fallbackSendMessage,
+      startRun: state.startRun || fallbackStartRun,
       regenerate: state.regenerate || fallbackRegenerate,
       stop: state.stop || fallbackStop,
       resumeStream: state.resumeStream || fallbackResumeStream,

--- a/apps/chat/lib/stores/base/use-chat.ts
+++ b/apps/chat/lib/stores/base/use-chat.ts
@@ -4,13 +4,28 @@ import {
   type UIMessage,
   type UseChatHelpers,
   type UseChatOptions,
-  useChat as useOriginalChat,
 } from "@ai-sdk/react";
+import {
+  type MessageTreeSnapshot,
+  ROOT_PARENT_ID,
+  type ThreadChat,
+  type ThreadChatOptions,
+} from "@chatjs/thread";
+import {
+  type UseThreadHelpers,
+  type UseThreadOptions,
+  useThread as useOriginalChat,
+} from "@chatjs/thread/react";
+import type { ChatInit } from "ai";
 import { useCallback, useEffect, useRef } from "react";
-import { useStore } from "zustand";
 import { type StoreState, useChatStoreApi } from "./hooks";
 
-export type { UseChatHelpers, UseChatOptions };
+export type {
+  UseChatHelpers,
+  UseChatOptions,
+  UseThreadHelpers,
+  UseThreadOptions,
+};
 
 // Type for a compatible chat store
 export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
@@ -21,26 +36,97 @@ export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
 
 export type UseChatOptionsWithPerformance<
   TMessage extends UIMessage = UIMessage,
-> = UseChatOptions<TMessage> & {
-  store?: CompatibleChatStore<TMessage>;
-  // Additional performance options
-  enableBatching?: boolean;
-};
+> = ChatInit<TMessage> & {
+  experimental_throttle?: number;
+  resume?: boolean;
+} & Pick<ThreadChatOptions<TMessage>, "concurrency" | "initialTree"> & {
+    chat?: ThreadChat<TMessage>;
+    store?: CompatibleChatStore<TMessage>;
+    // Additional performance options
+    enableBatching?: boolean;
+  };
+
+function getInitialTree<TMessage extends UIMessage>(
+  store: CompatibleChatStore<TMessage> | { getState?: () => any },
+  fallbackMessages: TMessage[] | undefined,
+  explicitInitialTree: MessageTreeSnapshot<TMessage> | undefined
+) {
+  if (explicitInitialTree) {
+    return explicitInitialTree;
+  }
+
+  const state = (store as any).getState?.();
+  const messages = fallbackMessages ?? [];
+  const childrenByParentId = Object.fromEntries(
+    messages.map((message, index, allMessages) => [
+      index === 0 ? ROOT_PARENT_ID : allMessages[index - 1]?.id,
+      [message.id],
+    ])
+  );
+
+  return (
+    (state?.treeSnapshot as MessageTreeSnapshot<TMessage> | undefined) ??
+    ({
+      childrenByParentId,
+      cursorId: messages.at(-1)?.id ?? null,
+      messagesById: Object.fromEntries(
+        messages.map((message) => [message.id, message])
+      ),
+      parentById: Object.fromEntries(
+        messages.map((message, index, allMessages) => [
+          message.id,
+          index === 0 ? null : allMessages[index - 1]?.id,
+        ])
+      ),
+      rootIds: messages[0] ? [messages[0].id] : [],
+      version: 1,
+    } satisfies MessageTreeSnapshot<TMessage>)
+  );
+}
+
+function messagesSignature<TMessage extends UIMessage>(messages: TMessage[]) {
+  return JSON.stringify(messages);
+}
+
+function treeSignature<TMessage extends UIMessage>(
+  snapshot: MessageTreeSnapshot<TMessage>
+) {
+  return JSON.stringify({
+    childrenByParentId: snapshot.childrenByParentId,
+    cursorId: snapshot.cursorId,
+    messagesById: snapshot.messagesById,
+    parentById: snapshot.parentById,
+    rootIds: snapshot.rootIds,
+  });
+}
 
 export function useChat<TMessage extends UIMessage = UIMessage>(
   options: UseChatOptionsWithPerformance<TMessage> = {} as UseChatOptionsWithPerformance<TMessage>
-): UseChatHelpers<TMessage> {
+): UseThreadHelpers<TMessage> {
   const {
+    chat,
     store: customStore,
     enableBatching = true,
+    initialTree,
     ...originalOptions
   } = options;
 
   const originalOnData = (options as any).onData;
+  const externalMessages = (originalOptions as any).messages as
+    | TMessage[]
+    | undefined;
 
   // Use custom store if provided, otherwise use the context store
   const contextStore = useChatStoreApi<TMessage>();
   const store = customStore || contextStore;
+  const initialTreeRef = useRef<MessageTreeSnapshot<TMessage> | null>(null);
+  if (!initialTreeRef.current) {
+    initialTreeRef.current = getInitialTree(
+      store,
+      (originalOptions as any).messages as TMessage[] | undefined,
+      initialTree
+    );
+  }
 
   // Wrap onData to capture transient data parts
   const wrappedOnData = useCallback(
@@ -69,13 +155,39 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     [store, originalOnData]
   );
 
-  const chatHelpers = useOriginalChat<TMessage>({
-    ...originalOptions,
-    onData: wrappedOnData,
-  });
+  if (chat) {
+    chat.updateOptions({
+      onData: wrappedOnData,
+      onError: originalOptions.onError,
+      onFinish: originalOptions.onFinish,
+      onToolCall: originalOptions.onToolCall,
+      sendAutomaticallyWhen: originalOptions.sendAutomaticallyWhen,
+      transport: originalOptions.transport,
+    });
+  }
+
+  const chatHelpers = useOriginalChat<TMessage>(
+    chat
+      ? {
+          chat,
+          experimental_throttle: originalOptions.experimental_throttle,
+          resume: originalOptions.resume,
+        }
+      : {
+          ...originalOptions,
+          initialTree: initialTreeRef.current,
+          onData: wrappedOnData,
+        }
+  ) as UseThreadHelpers<TMessage>;
 
   const storeRef = useRef<CompatibleChatStore<TMessage> | typeof contextStore>(
     store
+  );
+
+  const lastSyncedStateRef = useRef<string | null>(null);
+  const lastSyncedTreeRef = useRef<string | null>(null);
+  const lastExternalMessagesRef = useRef<string | null>(
+    externalMessages ? messagesSignature(externalMessages) : null
   );
 
   // Memoize the sync function to avoid recreating it on every render
@@ -97,18 +209,40 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     }
   }, []);
 
+  const setMessages = useCallback<UseThreadHelpers<TMessage>["setMessages"]>(
+    (messagesOrUpdater) => {
+      const currentMessages =
+        ((store as any).getState?.().messages as TMessage[] | undefined) ??
+        chatHelpers.messages;
+      const nextMessages =
+        typeof messagesOrUpdater === "function"
+          ? messagesOrUpdater(currentMessages)
+          : messagesOrUpdater;
+
+      chatHelpers.setMessages(nextMessages);
+    },
+    [chatHelpers.messages, chatHelpers.setMessages, store]
+  );
+
+  useEffect(() => {
+    if (!externalMessages) {
+      return;
+    }
+
+    const externalSignature = messagesSignature(externalMessages);
+    if (lastExternalMessagesRef.current === externalSignature) {
+      return;
+    }
+
+    lastExternalMessagesRef.current = externalSignature;
+    if (messagesSignature(chatHelpers.messages) !== externalSignature) {
+      setMessages(externalMessages);
+    }
+  }, [externalMessages, chatHelpers.messages, setMessages]);
+
   // Simple sync - but don't overwrite store messages if chat has no messages
   // This preserves server-side messages during hydration
   useEffect(() => {
-    const currentStoreState = (store as any).getState?.() || { messages: [] };
-
-    // Skip syncing messages if store has messages but chat doesn't
-    // This prevents clearing server-side messages on hydration
-    const shouldSyncMessages = !(
-      currentStoreState.messages?.length > 0 &&
-      chatHelpers.messages.length === 0
-    );
-
     // Only sync state data
     const stateData: any = {
       id: chatHelpers.id,
@@ -116,36 +250,54 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
       status: chatHelpers.status,
     };
 
-    // Only add messages to sync object if we should sync them
-    if (shouldSyncMessages) {
-      stateData.messages = chatHelpers.messages;
-    }
-
     // Sync functions separately and only once
     const functionsData = {
       sendMessage: chatHelpers.sendMessage,
+      startRun: chatHelpers.tree.startRun,
       regenerate: chatHelpers.regenerate,
       stop: chatHelpers.stop,
       resumeStream: chatHelpers.resumeStream,
       addToolResult: chatHelpers.addToolResult,
-      setMessages: chatHelpers.setMessages,
+      setMessages,
       clearError: chatHelpers.clearError,
     };
 
     const chatState = { ...stateData, ...functionsData };
+    const syncSignature = JSON.stringify({
+      error: chatHelpers.error?.message,
+      id: chatHelpers.id,
+      status: chatHelpers.status,
+    });
 
-    if (enableBatching) {
-      // Use requestAnimationFrame for batching if available
-      if (
-        typeof window !== "undefined" &&
-        typeof window.requestAnimationFrame === "function"
-      ) {
-        window.requestAnimationFrame(() => syncState(chatState));
+    if (lastSyncedStateRef.current !== syncSignature) {
+      lastSyncedStateRef.current = syncSignature;
+
+      if (enableBatching) {
+        // Use requestAnimationFrame for batching if available
+        if (
+          typeof window !== "undefined" &&
+          typeof window.requestAnimationFrame === "function"
+        ) {
+          window.requestAnimationFrame(() => {
+            syncState(chatState);
+          });
+        } else {
+          syncState(chatState);
+        }
       } else {
         syncState(chatState);
       }
-    } else {
-      syncState(chatState);
+    }
+
+    const setTreeSnapshot = (store as any).getState?.().setTreeSnapshot;
+    if (typeof setTreeSnapshot === "function") {
+      const snapshot = chatHelpers.tree.getSnapshot();
+      const signature = treeSignature(snapshot);
+
+      if (lastSyncedTreeRef.current !== signature) {
+        lastSyncedTreeRef.current = signature;
+        setTreeSnapshot(snapshot);
+      }
     }
   }, [
     // Only depend on data that actually changes, not function references
@@ -158,22 +310,17 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     chatHelpers.resumeStream,
     chatHelpers.clearError,
     chatHelpers.sendMessage,
+    chatHelpers.tree.startRun,
     store,
-    chatHelpers.setMessages,
+    setMessages,
     chatHelpers.stop,
     chatHelpers.regenerate,
     chatHelpers.addToolResult,
   ]);
 
-  // Return the store's messages as the source of truth, not chatHelpers.messages
-  // Subscribe to store messages so this is reactive
-  const storeMessages = useStore(
-    store as any,
-    (state: any) => state.messages as TMessage[]
-  );
-
   return {
     ...chatHelpers,
-    messages: storeMessages || chatHelpers.messages,
+    setMessages,
+    messages: chatHelpers.messages,
   };
 }

--- a/apps/chat/lib/stores/with-threads.test.ts
+++ b/apps/chat/lib/stores/with-threads.test.ts
@@ -13,6 +13,7 @@ function createMessage({
   parallelGroupId = null,
   parallelIndex = null,
   activeStreamId = null,
+  text = "",
 }: {
   id: string;
   role: ChatMessage["role"];
@@ -21,11 +22,12 @@ function createMessage({
   parallelGroupId?: string | null;
   parallelIndex?: number | null;
   activeStreamId?: string | null;
+  text?: string;
 }): ChatMessage {
   return {
     id,
     role,
-    parts: [],
+    parts: text ? [{ type: "text", text }] : [],
     metadata: {
       createdAt: new Date(createdAt),
       parentMessageId,
@@ -44,14 +46,82 @@ function createThreadStore(initialMessages: ChatMessage[]) {
     withThreads<ChatMessage, BaseChatStoreState<ChatMessage>>(
       (set) =>
         ({
+          _messageIndex: { update: () => undefined },
+          _memoizedSelectors: new Map(),
+          _throttledMessages: initialMessages,
           messages: initialMessages,
           setMessages: (messages: ChatMessage[]) => set({ messages }),
-        }) as BaseChatStoreState<ChatMessage>
+        }) as unknown as BaseChatStoreState<ChatMessage>
     )
   );
 }
 
 describe("withThreads", () => {
+  it("preserves hidden branches when ThreadChat publishes an active-path snapshot", () => {
+    const userA = createMessage({
+      id: "user-a",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistantA = createMessage({
+      id: "assistant-a",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: userA.id,
+    });
+    const userB = createMessage({
+      id: "user-b",
+      role: "user",
+      createdAt: "2024-01-01T00:00:02.000Z",
+    });
+    const assistantB = createMessage({
+      id: "assistant-b",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:03.000Z",
+      parentMessageId: userB.id,
+    });
+    const store = createThreadStore([userB, assistantB]);
+
+    store.getState().setAllMessages([userA, assistantA, userB, assistantB]);
+    store.getState().setTreeSnapshot({
+      childrenByParentId: {
+        __root__: [userB.id],
+        [userB.id]: [assistantB.id],
+      },
+      cursorId: assistantB.id,
+      messagesById: {
+        [userB.id]: userB,
+        [assistantB.id]: assistantB,
+      },
+      parentById: {
+        [userB.id]: null,
+        [assistantB.id]: userB.id,
+      },
+      rootIds: [userB.id],
+      version: 1,
+    });
+
+    const siblingInfo = store.getState().getMessageSiblingInfo(userB.id);
+    assert.deepEqual(
+      siblingInfo?.siblings.map((message) => message.id),
+      [userA.id, userB.id]
+    );
+    const previousThread = store.getState().switchToSibling(userB.id, "prev");
+    const previousThreadIds = [userA.id, assistantA.id];
+    assert.deepEqual(
+      previousThread?.map((message) => message.id),
+      previousThreadIds
+    );
+    assert.deepEqual(
+      store.getState().messages.map((message) => message.id),
+      previousThreadIds
+    );
+    assert.deepEqual(
+      store.getState()._throttledMessages?.map((message) => message.id),
+      previousThreadIds
+    );
+  });
+
   it("preserves local-only optimistic branch nodes across server syncs", () => {
     const rootUser = createMessage({
       id: "user-root",
@@ -118,9 +188,9 @@ describe("withThreads", () => {
     assert.deepEqual(allMessageIds, [
       "user-root",
       "assistant-a",
-      "assistant-b",
       "user-nested",
       "assistant-nested-a",
+      "assistant-b",
       "assistant-nested-b",
     ]);
 
@@ -133,5 +203,183 @@ describe("withThreads", () => {
       restoredThread?.at(-1)?.metadata.activeStreamId,
       "pending:assistant-nested-b"
     );
+  });
+
+  it("preserves a pending stream marker when a run inserts its assistant shell", () => {
+    const rootUser = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistant = createMessage({
+      id: "assistant-a",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: rootUser.id,
+      activeStreamId: "pending:assistant-a",
+    });
+    const assistantWithoutMetadata = {
+      id: assistant.id,
+      parts: [],
+      role: "assistant",
+    } as unknown as ChatMessage;
+
+    const store = createThreadStore([rootUser, assistant]);
+    store.getState().addMessageToTree(assistantWithoutMetadata);
+
+    const updatedAssistant = store.getState().allMessages.at(-1);
+    assert.equal(
+      updatedAssistant?.metadata.activeStreamId,
+      "pending:assistant-a"
+    );
+    assert.equal(
+      updatedAssistant?.metadata.selectedModel,
+      assistant.metadata.selectedModel
+    );
+  });
+
+  it("replaces a selected placeholder with completed server content when ready", () => {
+    const rootUser = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const placeholder = createMessage({
+      id: "assistant-b",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: rootUser.id,
+      parallelGroupId: "group-root",
+      parallelIndex: 1,
+      activeStreamId: "pending:assistant-b",
+    });
+    const completed = createMessage({
+      id: placeholder.id,
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: rootUser.id,
+      parallelGroupId: "group-root",
+      parallelIndex: 1,
+      text: "Completed secondary response",
+    });
+    const store = createThreadStore([rootUser, placeholder]);
+
+    store.getState().setAllMessages([rootUser, completed]);
+
+    const completedPart = store.getState().messages.at(-1)?.parts.at(0);
+    assert.equal(completedPart?.type, "text");
+    assert.equal(
+      completedPart?.type === "text" ? completedPart.text : null,
+      "Completed secondary response"
+    );
+    assert.equal(
+      store.getState().messages.at(-1)?.metadata.activeStreamId,
+      null
+    );
+    const throttledPart = store
+      .getState()
+      ._throttledMessages?.at(-1)
+      ?.parts.at(0);
+    assert.equal(
+      throttledPart?.type === "text" ? throttledPart.text : null,
+      "Completed secondary response"
+    );
+  });
+
+  it("fills metadata for ThreadChat assistant shells in tree snapshots", () => {
+    const rootUser = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistantWithoutMetadata = {
+      id: "assistant-a",
+      parts: [],
+      role: "assistant",
+    } as unknown as ChatMessage;
+
+    const store = createThreadStore([rootUser]);
+
+    store.getState().setTreeSnapshot({
+      childrenByParentId: {
+        __root__: [rootUser.id],
+        [rootUser.id]: [assistantWithoutMetadata.id],
+      },
+      cursorId: assistantWithoutMetadata.id,
+      messagesById: {
+        [rootUser.id]: rootUser,
+        [assistantWithoutMetadata.id]: assistantWithoutMetadata,
+      },
+      parentById: {
+        [rootUser.id]: null,
+        [assistantWithoutMetadata.id]: rootUser.id,
+      },
+      rootIds: [rootUser.id],
+      version: 1,
+    });
+
+    const assistant = store.getState().messages.at(-1);
+    assert.equal(assistant?.metadata.parentMessageId, rootUser.id);
+    assert.equal(
+      assistant?.metadata.selectedModel,
+      rootUser.metadata.selectedModel
+    );
+  });
+
+  it("adds exactly one user sibling when editing after branch navigation", () => {
+    const userA = createMessage({
+      id: "user-a",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistantA = createMessage({
+      id: "assistant-a",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: userA.id,
+    });
+    const userB = createMessage({
+      id: "user-b",
+      role: "user",
+      createdAt: "2024-01-01T00:00:02.000Z",
+    });
+    const assistantB = createMessage({
+      id: "assistant-b",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:03.000Z",
+      parentMessageId: userB.id,
+    });
+    const userC = createMessage({
+      id: "user-c",
+      role: "user",
+      createdAt: "2024-01-01T00:00:04.000Z",
+    });
+    const assistantC = createMessage({
+      id: "assistant-c",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:05.000Z",
+      parentMessageId: userC.id,
+    });
+
+    const store = createThreadStore([userA, assistantA]);
+    store.getState().addMessageToTree(userB);
+    store.getState().addMessageToTree(assistantB);
+
+    assert.equal(
+      store.getState().getMessageSiblingInfo(userB.id)?.siblings.length,
+      2
+    );
+
+    store.getState().switchToSibling(userB.id, "prev");
+    store.getState().setMessages([]);
+    store.getState().addMessageToTree(userC);
+    store.getState().addMessageToTree(assistantC);
+
+    const rootSiblingIds = store
+      .getState()
+      .getMessageSiblingInfo(userC.id)
+      ?.siblings.map((message: ChatMessage) => message.id);
+
+    assert.deepEqual(rootSiblingIds, [userA.id, userB.id, userC.id]);
   });
 });

--- a/apps/chat/lib/stores/with-threads.ts
+++ b/apps/chat/lib/stores/with-threads.ts
@@ -4,15 +4,11 @@
 // and complete message tree management for branching/sibling navigation.
 // The store owns allMessages (the full tree); React Query feeds data into it.
 
+import { type MessageTreeSnapshot, ROOT_PARENT_ID } from "@chatjs/thread";
 import type { UIMessage } from "ai";
 import type { StateCreator } from "zustand";
 import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 import type { MessageNode } from "@/lib/thread-utils";
-import {
-  buildChildrenMap,
-  buildThreadFromLeaf,
-  findLeafDfsToRightFromMessageId,
-} from "@/lib/thread-utils";
 
 export interface MessageSiblingInfo<UM> {
   siblingIndex: number;
@@ -36,11 +32,16 @@ export type ThreadAugmentedState<UM extends UIMessage> =
     threadInitialMessages: UM[];
     /** Complete message tree (all branches). Source of truth for sibling navigation. */
     allMessages: UM[];
+    /** Headless package snapshot for the same message tree. */
+    treeSnapshot: MessageTreeSnapshot<UM>;
+    treeSnapshotSignature: string;
     /** Parent→children mapping, rebuilt when allMessages changes. */
     childrenMap: Map<string | null, UM[]>;
     bumpThreadEpoch: () => void;
     resetThreadEpoch: () => void;
     setMessagesWithEpoch: (messages: UM[]) => void;
+    /** Replace the package tree snapshot and derive store fields from it. */
+    setTreeSnapshot: (snapshot: MessageTreeSnapshot<UM>) => void;
     /** Replace the full message tree (used when syncing from server). */
     setAllMessages: (messages: UM[]) => void;
     /** Add or replace a single message in the tree (used during streaming/sending). */
@@ -59,6 +60,221 @@ export type ThreadAugmentedState<UM extends UIMessage> =
     switchToMessage: (messageId: string) => UM[] | null;
   };
 
+function parentKey(parentId: string | null) {
+  return parentId ?? ROOT_PARENT_ID;
+}
+
+function getMetadataParentId<UM extends UIMessage>(message: UM) {
+  return ((message as UM & MessageNode).metadata?.parentMessageId ?? null) as
+    | string
+    | null;
+}
+
+function getMessageTimestamp<UM extends UIMessage>(message: UM) {
+  const createdAt = (message as UM & MessageNode).metadata?.createdAt;
+  if (!createdAt) {
+    return 0;
+  }
+  return createdAt instanceof Date
+    ? createdAt.getTime()
+    : new Date(createdAt).getTime();
+}
+
+function compareSiblingMessages<UM extends UIMessage>(a: UM, b: UM) {
+  const aMetadata = (a as UM & MessageNode).metadata;
+  const bMetadata = (b as UM & MessageNode).metadata;
+  const sameParallelGroup =
+    aMetadata?.parallelGroupId &&
+    aMetadata.parallelGroupId === bMetadata?.parallelGroupId;
+
+  if (
+    sameParallelGroup &&
+    typeof aMetadata.parallelIndex === "number" &&
+    typeof bMetadata?.parallelIndex === "number" &&
+    aMetadata.parallelIndex !== bMetadata.parallelIndex
+  ) {
+    return aMetadata.parallelIndex - bMetadata.parallelIndex;
+  }
+
+  return getMessageTimestamp(a) - getMessageTimestamp(b);
+}
+
+function buildTreeSnapshotFromMessages<UM extends UIMessage>(
+  messages: UM[],
+  cursorId: string | null = messages.at(-1)?.id ?? null
+): MessageTreeSnapshot<UM> {
+  const messagesById: Record<string, UM> = {};
+  const parentById: Record<string, string | null> = {};
+  const childrenByParentId: Record<string, string[]> = {};
+
+  for (const message of messages) {
+    const parentId = getMetadataParentId(message);
+    messagesById[message.id] = message;
+    parentById[message.id] = parentId;
+
+    const key = parentKey(parentId);
+    childrenByParentId[key] = [...(childrenByParentId[key] ?? []), message.id];
+  }
+
+  for (const childIds of Object.values(childrenByParentId)) {
+    childIds.sort((a, b) =>
+      compareSiblingMessages(messagesById[a] as UM, messagesById[b] as UM)
+    );
+  }
+
+  return {
+    childrenByParentId,
+    cursorId,
+    messagesById,
+    parentById,
+    rootIds: childrenByParentId[ROOT_PARENT_ID] ?? [],
+    version: 1,
+  };
+}
+
+function buildChildrenMapFromSnapshot<UM extends UIMessage>(
+  messages: UM[],
+  snapshot: MessageTreeSnapshot<UM>
+): Map<string | null, UM[]> {
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message])
+  );
+  const map = new Map<string | null, UM[]>();
+
+  for (const [key, childIds] of Object.entries(snapshot.childrenByParentId)) {
+    const parentId = key === ROOT_PARENT_ID ? null : key;
+    map.set(
+      parentId,
+      childIds
+        .map((id) => messagesById.get(id))
+        .filter((message): message is UM => Boolean(message))
+    );
+  }
+
+  return map;
+}
+
+function buildThreadFromSnapshot<UM extends UIMessage>(
+  messages: UM[],
+  snapshot: MessageTreeSnapshot<UM>,
+  leafMessageId: string
+): UM[] {
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message])
+  );
+  const thread: UM[] = [];
+  let currentMessageId: string | null = leafMessageId;
+  let iteration = 0;
+
+  while (currentMessageId) {
+    iteration += 1;
+    if (iteration > 100) {
+      break;
+    }
+
+    const currentMessage = messagesById.get(currentMessageId);
+    if (!currentMessage) {
+      break;
+    }
+
+    thread.unshift(currentMessage);
+    currentMessageId = snapshot.parentById[currentMessageId] ?? null;
+  }
+
+  return thread;
+}
+
+function findLeafDfsToRightFromSnapshot<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>,
+  messageId: string
+): string | null {
+  const children = snapshot.childrenByParentId[messageId] ?? [];
+  const rightmostChild = children.at(-1);
+
+  if (!rightmostChild) {
+    return null;
+  }
+
+  return (
+    findLeafDfsToRightFromSnapshot(snapshot, rightmostChild) ?? rightmostChild
+  );
+}
+
+function getSnapshotSignature<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>
+) {
+  return JSON.stringify({
+    childrenByParentId: snapshot.childrenByParentId,
+    cursorId: snapshot.cursorId,
+    messagesById: snapshot.messagesById,
+    parentById: snapshot.parentById,
+    rootIds: snapshot.rootIds,
+  });
+}
+
+type MetadataWithSelectedModel = MessageNode["metadata"] & {
+  selectedModel?: unknown;
+  selectedTool?: unknown;
+};
+
+function mergeMessageIntoMap<UM extends UIMessage>(
+  merged: Map<string, UM>,
+  message: UM
+) {
+  const existing = merged.get(message.id);
+  const existingMetadata = (existing as (UM & MessageNode) | undefined)
+    ?.metadata;
+  if (
+    existing &&
+    (message as UM & MessageNode).metadata === undefined &&
+    existingMetadata !== undefined
+  ) {
+    merged.set(message.id, {
+      ...message,
+      metadata: {
+        ...existingMetadata,
+      },
+    } as UM);
+    return;
+  }
+
+  merged.set(message.id, message);
+}
+
+function addFallbackMetadataToMessages<UM extends UIMessage>(
+  merged: Map<string, UM>,
+  parentById: Record<string, string | null>
+) {
+  for (const [messageId, message] of merged) {
+    if ((message as UM & MessageNode).metadata !== undefined) {
+      continue;
+    }
+
+    const parentId = parentById[messageId] ?? null;
+    const parent = parentId ? merged.get(parentId) : undefined;
+    const parentMetadata = (parent as (UM & MessageNode) | undefined)
+      ?.metadata as MetadataWithSelectedModel | undefined;
+
+    if (!(parentMetadata && "selectedModel" in parentMetadata)) {
+      continue;
+    }
+
+    merged.set(messageId, {
+      ...message,
+      metadata: {
+        activeStreamId: null,
+        createdAt: new Date(),
+        isPrimaryParallel: null,
+        parallelGroupId: null,
+        parallelIndex: null,
+        parentMessageId: parentId,
+        selectedModel: parentMetadata.selectedModel,
+        selectedTool: parentMetadata.selectedTool,
+      },
+    } as UM);
+  }
+}
+
 export const withThreads =
   <UI_MESSAGE extends UIMessage, T extends BaseChatStoreState<UI_MESSAGE>>(
     creator: StateCreator<T, [], []>
@@ -69,33 +285,33 @@ export const withThreads =
     // Wrap the original setMessages to auto-bump epoch
     const originalSetMessages = base.setMessages;
 
-    const rebuildMap = (msgs: UI_MESSAGE[]) =>
-      buildChildrenMap(msgs as (UI_MESSAGE & MessageNode)[]);
+    const rebuildMap = (
+      msgs: UI_MESSAGE[],
+      snapshot = buildTreeSnapshotFromMessages(msgs)
+    ) => buildChildrenMapFromSnapshot(msgs, snapshot);
 
     const mergeTreeMessages = (
       serverMessages: UI_MESSAGE[],
       existingTreeMessages: UI_MESSAGE[],
-      currentVisibleMessages: UI_MESSAGE[]
+      currentVisibleMessages: UI_MESSAGE[],
+      parentById: Record<string, string | null> = {}
     ): UI_MESSAGE[] => {
       const merged = new Map<string, UI_MESSAGE>();
 
-      for (const message of serverMessages) {
-        merged.set(message.id, message);
-      }
-
-      // Preserve every local-only tree node until the server returns a message with
-      // the same id. Restricting this to pending assistant shells orphaned optimistic
-      // user messages when switching away from an in-flight branch mid-stream.
       for (const message of existingTreeMessages) {
-        if (!merged.has(message.id)) {
-          merged.set(message.id, message);
-        }
+        mergeMessageIntoMap(merged, message);
       }
 
+      for (const message of serverMessages) {
+        mergeMessageIntoMap(merged, message);
+      }
+
+      // Preserve in-flight visible messages when server data is still stale.
       for (const message of currentVisibleMessages) {
-        merged.set(message.id, message);
+        mergeMessageIntoMap(merged, message);
       }
 
+      addFallbackMetadataToMessages(merged, parentById);
       return Array.from(merged.values());
     };
 
@@ -104,6 +320,10 @@ export const withThreads =
       threadEpoch: 0,
       threadInitialMessages: base.messages,
       allMessages: base.messages,
+      treeSnapshot: buildTreeSnapshotFromMessages(base.messages),
+      treeSnapshotSignature: getSnapshotSignature(
+        buildTreeSnapshotFromMessages(base.messages)
+      ),
       childrenMap: rebuildMap(base.messages),
 
       bumpThreadEpoch: () => {
@@ -122,12 +342,66 @@ export const withThreads =
       },
 
       setMessagesWithEpoch: (messages: UI_MESSAGE[]) => {
-        originalSetMessages(messages);
-        set((state) => ({
-          ...state,
-          threadEpoch: state.threadEpoch + 1,
-          threadInitialMessages: messages,
-        }));
+        const cursorId = messages.at(-1)?.id ?? null;
+        set((state) => {
+          const snapshot = buildTreeSnapshotFromMessages(
+            state.allMessages,
+            cursorId
+          );
+          state._messageIndex.update(messages);
+          return {
+            ...state,
+            messages,
+            _memoizedSelectors: new Map(),
+            _throttledMessages: messages,
+            threadEpoch: state.threadEpoch + 1,
+            threadInitialMessages: messages,
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(state.allMessages, snapshot),
+          };
+        });
+      },
+
+      setTreeSnapshot: (snapshot: MessageTreeSnapshot<UI_MESSAGE>) => {
+        const state = get();
+        const snapshotMessages = Object.values(snapshot.messagesById);
+        const mergedMessages = mergeTreeMessages(
+          snapshotMessages,
+          state.allMessages,
+          [],
+          snapshot.parentById
+        );
+        const mergedSnapshot = buildTreeSnapshotFromMessages(
+          mergedMessages,
+          snapshot.cursorId
+        );
+        const signature = getSnapshotSignature(mergedSnapshot);
+        if (state.treeSnapshotSignature === signature) {
+          return;
+        }
+
+        const nextVisibleThread = mergedSnapshot.cursorId
+          ? buildThreadFromSnapshot(
+              mergedMessages,
+              mergedSnapshot,
+              mergedSnapshot.cursorId
+            )
+          : [];
+
+        set((prev) => {
+          prev._messageIndex.update(nextVisibleThread);
+          return {
+            ...prev,
+            messages: nextVisibleThread,
+            _memoizedSelectors: new Map(),
+            _throttledMessages: nextVisibleThread,
+            allMessages: mergedMessages,
+            treeSnapshot: mergedSnapshot,
+            treeSnapshotSignature: signature,
+            childrenMap: rebuildMap(mergedMessages, mergedSnapshot),
+          };
+        });
       },
 
       setAllMessages: (messages: UI_MESSAGE[]) => {
@@ -137,7 +411,13 @@ export const withThreads =
         const mergedMessages = mergeTreeMessages(
           messages,
           existingTreeMessages,
-          currentVisibleMessages
+          state.status === "streaming" || state.status === "submitted"
+            ? currentVisibleMessages
+            : []
+        );
+        const snapshot = buildTreeSnapshotFromMessages(
+          mergedMessages,
+          currentVisibleMessages.at(-1)?.id ?? null
         );
 
         // While the SDK is actively streaming, updating the visible thread with
@@ -150,26 +430,29 @@ export const withThreads =
           set((prev) => ({
             ...prev,
             allMessages: mergedMessages,
-            childrenMap: rebuildMap(mergedMessages),
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(mergedMessages, snapshot),
           }));
           return;
         }
 
         const currentLeafId = currentVisibleMessages.at(-1)?.id;
         const nextVisibleThread = currentLeafId
-          ? (buildThreadFromLeaf(
-              mergedMessages as (UI_MESSAGE & MessageNode)[],
-              currentLeafId
-            ) as UI_MESSAGE[])
+          ? buildThreadFromSnapshot(mergedMessages, snapshot, currentLeafId)
           : currentVisibleMessages;
 
         originalSetMessages(nextVisibleThread);
         set((prev) => ({
           ...prev,
           messages: nextVisibleThread,
+          _memoizedSelectors: new Map(),
+          _throttledMessages: nextVisibleThread,
           threadInitialMessages: nextVisibleThread,
           allMessages: mergedMessages,
-          childrenMap: rebuildMap(mergedMessages),
+          treeSnapshot: snapshot,
+          treeSnapshotSignature: getSnapshotSignature(snapshot),
+          childrenMap: rebuildMap(mergedMessages, snapshot),
         }));
       },
 
@@ -181,24 +464,49 @@ export const withThreads =
             next = [...state.allMessages, message];
           } else {
             next = [...state.allMessages];
-            next[idx] = message;
+            const existing = next[idx];
+            const existingMetadata = (
+              existing as (UI_MESSAGE & MessageNode) | undefined
+            )?.metadata;
+            next[idx] =
+              existing &&
+              (message as UI_MESSAGE & MessageNode).metadata === undefined &&
+              existingMetadata !== undefined
+                ? ({
+                    ...message,
+                    metadata: {
+                      ...existingMetadata,
+                    },
+                  } as UI_MESSAGE)
+                : message;
           }
-          return { ...state, allMessages: next, childrenMap: rebuildMap(next) };
+          const snapshot = buildTreeSnapshotFromMessages(
+            next,
+            state.messages.at(-1)?.id ?? null
+          );
+          return {
+            ...state,
+            allMessages: next,
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(next, snapshot),
+          };
         });
       },
 
       getMessageSiblingInfo: (
         messageId: string
       ): MessageSiblingInfo<UI_MESSAGE> | null => {
-        const { allMessages, childrenMap } = get();
+        const state = get();
+        const { allMessages, childrenMap } = state;
         const message = allMessages.find((m) => m.id === messageId);
         if (!message) {
           return null;
         }
 
         const parentId =
-          (message as UI_MESSAGE & MessageNode).metadata?.parentMessageId ||
-          null;
+          state.treeSnapshot.parentById[message.id] ??
+          getMetadataParentId(message);
         const siblings = (childrenMap.get(parentId) ?? []) as UI_MESSAGE[];
         const siblingIndex = siblings.findIndex((s) => s.id === messageId);
 
@@ -219,7 +527,9 @@ export const withThreads =
         const parentId =
           message.role === "user"
             ? message.id
-            : metadata?.parentMessageId || null;
+            : (state.treeSnapshot.parentById[message.id] ??
+              metadata?.parentMessageId ??
+              null);
 
         if (!(parentId && parallelGroupId)) {
           return null;
@@ -269,7 +579,7 @@ export const withThreads =
         direction: "prev" | "next"
       ): UI_MESSAGE[] | null => {
         const state = get();
-        const { allMessages, childrenMap } = state;
+        const { allMessages } = state;
         if (!allMessages.length) {
           return null;
         }
@@ -286,13 +596,14 @@ export const withThreads =
             : (siblingIndex - 1 + siblings.length) % siblings.length;
 
         const targetSibling = siblings[nextIndex];
-        const leaf = findLeafDfsToRightFromMessageId(
-          childrenMap as Map<string | null, (UI_MESSAGE & MessageNode)[]>,
+        const leafId = findLeafDfsToRightFromSnapshot(
+          state.treeSnapshot,
           targetSibling.id
         );
-        const newThread = buildThreadFromLeaf(
-          allMessages as (UI_MESSAGE & MessageNode)[],
-          leaf ? leaf.id : targetSibling.id
+        const newThread = buildThreadFromSnapshot(
+          allMessages,
+          state.treeSnapshot,
+          leafId ?? targetSibling.id
         ) as UI_MESSAGE[];
 
         state.setMessagesWithEpoch(newThread);
@@ -301,7 +612,7 @@ export const withThreads =
 
       switchToMessage: (messageId: string): UI_MESSAGE[] | null => {
         const state = get();
-        const { allMessages, childrenMap } = state;
+        const { allMessages } = state;
         const message = allMessages.find(
           (candidate) => candidate.id === messageId
         );
@@ -309,13 +620,14 @@ export const withThreads =
           return null;
         }
 
-        const leaf = findLeafDfsToRightFromMessageId(
-          childrenMap as Map<string | null, (UI_MESSAGE & MessageNode)[]>,
+        const leafId = findLeafDfsToRightFromSnapshot(
+          state.treeSnapshot,
           messageId
         );
-        const newThread = buildThreadFromLeaf(
-          allMessages as (UI_MESSAGE & MessageNode)[],
-          leaf ? leaf.id : messageId
+        const newThread = buildThreadFromSnapshot(
+          allMessages,
+          state.treeSnapshot,
+          leafId ?? messageId
         ) as UI_MESSAGE[];
 
         state.setMessagesWithEpoch(newThread);
@@ -332,9 +644,16 @@ export const withThreads =
 
         // Only bump epoch if the thread structure actually changed
         if (currentIds !== newIds) {
+          const snapshot = buildTreeSnapshotFromMessages(
+            get().allMessages,
+            messages.at(-1)?.id ?? null
+          );
           set((state) => ({
             ...state,
             threadEpoch: state.threadEpoch + 1,
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(state.allMessages, snapshot),
           }));
         }
       },

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -47,6 +47,7 @@
     "@ai-sdk/openai-compatible": "2.0.56",
     "@ai-sdk/provider": "3.0.13",
     "@ai-sdk/react": "3.0.221",
+    "@chatjs/thread": "workspace:*",
     "@better-auth/core": "1.5.6",
     "@better-auth/electron": "^1.5.6",
     "@codemirror/lang-javascript": "^6.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@ai-sdk/react": "3.0.221",
         "@better-auth/core": "1.5.6",
         "@better-auth/electron": "^1.5.6",
+        "@chatjs/thread": "workspace:*",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/state": "^6.5.0",


### PR DESCRIPTION
## Summary
- connect the ChatJS store facade to `useThread`
- maintain canonical tree snapshots alongside the active message path
- preserve cursor, metadata, branches, and per-run state during reconciliation

## Verification
- `bun --filter @chatjs/chat lint`
- `bun --filter @chatjs/chat test:types`
- `bun --filter @chatjs/chat test:unit`

## Summary by Sourcery

Integrate the chat store with the new `ThreadChat` engine and synchronize message tree snapshots with UI state.

New Features:
- Expose `ThreadChat` helpers and options via the chat hook, including initial tree support and run control.
- Add support for tree snapshots and cursor-aware threading to the chat store, enabling navigation across branches and sibling messages.

Bug Fixes:
- Ensure metadata such as stream markers, selected model, and parent relationships are preserved when merging server and local messages or updating the tree.
- Prevent loss of hidden branches and optimistic nodes when reconciling `ThreadChat` snapshots and server syncs.

Enhancements:
- Refactor thread state to derive children maps and visible paths from canonical message tree snapshots instead of ad-hoc utilities.
- Optimize store–`ThreadChat` synchronization by deduplicating syncs using signatures for messages and tree snapshots.
- Improve tests to cover threaded navigation, snapshot reconciliation, pending-stream preservation, and branch editing behavior.

Build:
- Add @chatjs/thread as a dependency of the chat app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adapted ChatJS state to threaded paths with a shared `@chatjs/thread` `ThreadChat`, using canonical tree snapshots for stable branching, cursor, pending streams, and run state across streaming and server syncs.

- **New Features**
  - `AppRuntime` constructs a `ThreadChat` with `generateId` and `initialTree` from the store; `ChatSync` passes it to `useChat`.
  - `useChat` accepts a `chat` instance or builds one with `initialTree`, delegates to `useThread`, returns `UseThreadHelpers`, exposes `tree.startRun`, syncs a `MessageTreeSnapshot` to the store with signature-deduped updates, and dedupes external `messages`.
  - Store tracks `treeSnapshot` + signature and adds `setTreeSnapshot`; derives `childrenMap` and all navigation from snapshots; updates threads via snapshot-aware `setAllMessages`/`addMessageToTree`/`setMessagesWithEpoch`.
  - Reconciliation keeps hidden branches, optimistic nodes, and pending stream markers; fills metadata for assistant shells and replaces selected placeholders when server content arrives.

- **Migration**
  - `useChat` now returns `UseThreadHelpers` and exposes `startRun`; update types/usages that relied on `UseChatHelpers`.
  - You can pass `chat`, `initialTree`, and `concurrency` to `useChat`; if omitted, a tree is derived from the store or provided `messages`.
  - Added dependency on `@chatjs/thread`.

<sup>Written for commit 5fb16480ea09d7a7124100866950490097049eeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. #221
3. **#222** 👈 current
4. #223
5. #224
6. #225
7. #226
8. #227
9. #228
10. #229
<!-- stack:links:end -->
