### PR TITLE
Threads 4: Navigate and retry threaded branches

### DIFF
--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -391,6 +391,15 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   const liveStore = existingStore;
   const hasLiveRuntime = !!(liveRuntime && liveStore);
   const liveRuntimeMessages = liveStore?.getState().messages;
+
+  useEffect(() => {
+    if (!(liveStore && persistedMessages)) {
+      return;
+    }
+
+    liveStore.getState().setAllMessages(persistedMessages);
+  }, [liveStore, persistedMessages]);
+
   const initialMessages =
     liveRuntimeMessages ?? persistedInitialState.initialMessages;
   const initialTool =

--- a/apps/chat/components/responsive-tools.tsx
+++ b/apps/chat/components/responsive-tools.tsx
@@ -18,7 +18,6 @@ import { useSession } from "@/providers/session-provider";
 import { enabledTools, toolDefinitions } from "./chat-features-definitions";
 import { Button } from "./ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { LoginPrompt } from "./upgrade-cta/login-prompt";
 
 export function ResponsiveTools({
@@ -57,20 +56,16 @@ export function ResponsiveTools({
     <div className="flex items-center @[500px]:gap-2 gap-1">
       {isAnonymous ? (
         <Popover onOpenChange={setShowLoginPopover} open={showLoginPopover}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5"
-                  variant="ghost"
-                >
-                  <Settings2 size={14} />
-                  <span className="@[500px]:inline hidden">Tools</span>
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Select Tools</TooltipContent>
-          </Tooltip>
+          <PopoverTrigger asChild>
+            <Button
+              className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5"
+              title="Select Tools"
+              variant="ghost"
+            >
+              <Settings2 size={14} />
+              <span className="@[500px]:inline hidden">Tools</span>
+            </Button>
+          </PopoverTrigger>
           <PopoverContent align="start" className="w-80 p-0">
             <LoginPrompt
               description="Access web search, deep research, and more to get better answers."
@@ -80,21 +75,17 @@ export function ResponsiveTools({
         </Popover>
       ) : (
         <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5 px-2.5"
-                  size="sm"
-                  variant="ghost"
-                >
-                  <Settings2 size={14} />
-                  <span className="@[500px]:inline hidden">Tools</span>
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Select Tools</TooltipContent>
-          </Tooltip>
+          <DropdownMenuTrigger asChild>
+            <Button
+              className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5 px-2.5"
+              size="sm"
+              title="Select Tools"
+              variant="ghost"
+            >
+              <Settings2 size={14} />
+              <span className="@[500px]:inline hidden">Tools</span>
+            </Button>
+          </DropdownMenuTrigger>
           <DropdownMenuContent
             align="start"
             className="w-48"

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -17,12 +17,12 @@ export function RetryButton({
   messageId: string;
   className?: string;
 }) {
-  const { setMessages, sendMessage } = useChatActions<ChatMessage>();
+  const { setMessages, regenerate } = useChatActions<ChatMessage>();
   const chatStore = useChatStoreApi<ChatMessage>();
   const status = useChatStatus();
 
   const handleRetry = useCallback(() => {
-    if (!sendMessage) {
+    if (!regenerate) {
       toast.error("Cannot retry this message");
       return;
     }
@@ -47,11 +47,15 @@ export function RetryButton({
 
     setMessages(retryInput.messagesBeforeRetry);
 
-    // Resend the parent user message
-    sendMessage(retryInput.message, {});
+    regenerate({
+      body: {
+        selectedModelId: retryInput.selectedModelId,
+      },
+      messageId,
+    });
 
     toast.success("Retrying message...");
-  }, [sendMessage, messageId, setMessages, chatStore]);
+  }, [regenerate, messageId, setMessages, chatStore]);
 
   if (status === "streaming" || status === "submitted") {
     return null;

--- a/apps/chat/hooks/use-navigate-to-message.ts
+++ b/apps/chat/hooks/use-navigate-to-message.ts
@@ -6,17 +6,19 @@ import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useSwitchToMessage } from "@/lib/stores/hooks-threads";
 
 export function useNavigateToMessage() {
-  const { stop } = useChatActions<ChatMessage>();
+  const { setMessages } = useChatActions<ChatMessage>();
   const { setDataStream } = useDataStream();
   const { artifact, closeArtifact } = useArtifact();
   const switchToMessage = useSwitchToMessage();
 
   return useCallback(
     (messageId: string) => {
-      stop?.();
       setDataStream([]);
 
       const newThread = switchToMessage(messageId);
+      if (newThread) {
+        setMessages(newThread);
+      }
 
       if (
         newThread &&
@@ -34,7 +36,7 @@ export function useNavigateToMessage() {
       artifact.messageId,
       closeArtifact,
       setDataStream,
-      stop,
+      setMessages,
       switchToMessage,
     ]
   );

--- a/apps/chat/hooks/use-navigate-to-sibling.ts
+++ b/apps/chat/hooks/use-navigate-to-sibling.ts
@@ -6,22 +6,25 @@ import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useSwitchToSibling } from "@/lib/stores/hooks-threads";
 
 /**
- * Navigate to a sibling thread with side effects (stop stream, close artifact).
+ * Navigate to a sibling thread while preserving branch-owned active runs.
  * Uses the store's switchToSibling for the pure state transition.
  */
 export function useNavigateToSibling() {
-  const { stop } = useChatActions<ChatMessage>();
+  const { setMessages } = useChatActions<ChatMessage>();
   const { setDataStream } = useDataStream();
   const { artifact, closeArtifact } = useArtifact();
   const switchToSibling = useSwitchToSibling();
 
   return useCallback(
     (messageId: string, direction: "prev" | "next") => {
-      // Hard-disconnect the current stream + clear buffered deltas
-      stop?.();
+      // Data parts belong to the previously selected path. Active runs remain
+      // owned by ThreadChat and continue updating their tree nodes.
       setDataStream([]);
 
       const newThread = switchToSibling(messageId, direction);
+      if (newThread) {
+        setMessages(newThread);
+      }
 
       // Close artifact if its message is not in the new thread
       if (
@@ -40,7 +43,7 @@ export function useNavigateToSibling() {
       artifact.messageId,
       closeArtifact,
       setDataStream,
-      stop,
+      setMessages,
       switchToSibling,
     ]
   );

--- a/apps/chat/lib/chat-tree-actions.test.ts
+++ b/apps/chat/lib/chat-tree-actions.test.ts
@@ -30,7 +30,7 @@ function message({
 }
 
 describe("getRetryMessageInput", () => {
-  it("builds a retry message from an assistant response and trims before the parent user message", () => {
+  it("builds a retry message from an assistant response and keeps the parent user visible", () => {
     const root = message({ id: "root", role: "user" });
     const assistant = message({
       id: "assistant",
@@ -46,7 +46,7 @@ describe("getRetryMessageInput", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      messagesBeforeRetry: [],
+      messagesBeforeRetry: [root],
       message: {
         id: root.id,
         role: "user",
@@ -59,6 +59,7 @@ describe("getRetryMessageInput", () => {
           selectedModel: "openai/gpt-5-nano",
         },
       },
+      selectedModelId: "openai/gpt-5-nano",
     });
   });
 

--- a/apps/chat/lib/chat-tree-actions.ts
+++ b/apps/chat/lib/chat-tree-actions.ts
@@ -1,3 +1,4 @@
+import type { AppModelId } from "@/lib/ai/app-models";
 import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
 
 export type RetryMessageResult =
@@ -5,6 +6,7 @@ export type RetryMessageResult =
       message: ChatMessage;
       messagesBeforeRetry: ChatMessage[];
       ok: true;
+      selectedModelId: AppModelId;
     }
   | {
       ok: false;
@@ -54,7 +56,7 @@ export function getRetryMessageInput({
 
   return {
     ok: true,
-    messagesBeforeRetry: messages.slice(0, parentMessageIndex),
+    messagesBeforeRetry: messages.slice(0, parentMessageIndex + 1),
     message: {
       ...parentMessage,
       metadata: {
@@ -68,6 +70,7 @@ export function getRetryMessageInput({
         selectedModel: retryModelId,
       },
     },
+    selectedModelId: retryModelId as AppModelId,
   };
 }
 


### PR DESCRIPTION
## Summary
- switch message paths without stopping branch-owned requests
- regenerate from the selected branch for retries
- keep persisted route messages synchronized with the live tree store

## Verification
- `bun --filter @chatjs/chat lint`
- `bun --filter @chatjs/chat test:types`
- `bun --filter @chatjs/chat test:unit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable seamless navigation across threaded branches without interrupting active runs. Retries now use `regenerate` with the branch’s model and keep the parent user message visible, and persisted messages sync into the live store for a consistent UI.

- **New Features**
  - Switch between message paths without stopping branch-owned requests. Clear only the transient data stream, set messages to the new thread, and close the artifact if it’s off-path.
  - Retry via `regenerate` using `selectedModelId` from the chosen branch and target the retried assistant by `messageId`. Keep the parent user message visible.
  - Sync persisted messages into the live tree store with `setAllMessages` whenever they change.

- **Refactors**
  - Simplified Tools triggers by removing `Tooltip` wrappers; use button `title` to avoid nested trigger issues.

<sup>Written for commit 115498b4080bbeaf55c9c8ca588f788710d2f070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. #221
3. #222
4. **#223** 👈 current
5. #224
6. #225
7. #226
8. #227
9. #228
10. #229
<!-- stack:links:end -->