### PR TITLE
Threads 5: Isolate threaded stream lifecycles

### DIFF
--- a/apps/chat/components/assistant-message.tsx
+++ b/apps/chat/components/assistant-message.tsx
@@ -2,7 +2,10 @@
 import { memo } from "react";
 import { config } from "@/lib/config";
 import { useChatId, useChatStatus } from "@/lib/stores/base";
-import { useMessageMetadataById } from "@/lib/stores/hooks-base";
+import {
+  useLastMessageId,
+  useMessageMetadataById,
+} from "@/lib/stores/hooks-base";
 import { Message, MessageContent } from "./ai-elements/message";
 import { FollowUpSuggestionsParts } from "./followup-suggestions";
 import { MessageActions } from "./message-actions";
@@ -19,6 +22,11 @@ const PureAssistantMessage = ({
   const chatId = useChatId();
   const metadata = useMessageMetadataById(messageId);
   const status = useChatStatus();
+  const lastMessageId = useLastMessageId();
+  const isPendingLastMessage =
+    messageId === lastMessageId &&
+    (status === "submitted" || status === "streaming");
+  const shouldHideCompletionActions = isLoading || isPendingLastMessage;
   const isReconnectingToMessageStream =
     metadata.activeStreamId !== null && status === "submitted";
 
@@ -43,12 +51,14 @@ const PureAssistantMessage = ({
 
         <MessageActions
           chatId={chatId}
-          isLoading={isLoading}
+          isLoading={shouldHideCompletionActions}
           isReadOnly={isReadonly}
           key={`action-${messageId}`}
           messageId={messageId}
         />
-        {isReadonly || !config.ai.tools.followupSuggestions.enabled ? null : (
+        {isReadonly ||
+        shouldHideCompletionActions ||
+        !config.ai.tools.followupSuggestions.enabled ? null : (
           <FollowUpSuggestionsParts messageId={messageId} />
         )}
       </MessageContent>

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -45,6 +45,7 @@ export function ChatSync({
   const isLastMessagePartial = isResumableActiveStreamId(
     lastMessage?.metadata?.activeStreamId
   );
+  const resumeOnMountRef = useRef(isLastMessagePartial);
 
   useChat<ChatMessage>({
     chat,
@@ -58,7 +59,7 @@ export function ChatSync({
       addMessageToTree(message);
       saveChatMessage({ message, chatId: id });
     },
-    resume: isLastMessagePartial,
+    resume: resumeOnMountRef.current,
     transport: new DefaultChatTransport({
       api: "/api/chat",
       fetch: fetchWithErrorHandlers as typeof fetch,
@@ -72,15 +73,21 @@ export function ChatSync({
           },
         };
       },
-      prepareReconnectToStreamRequest({ id: chatId }) {
+      prepareReconnectToStreamRequest({ body, id: chatId }) {
         const current = lastMessageRef.current;
         const activeStreamId = current?.metadata?.activeStreamId ?? null;
-        const partialMessageId = isResumableActiveStreamId(activeStreamId)
-          ? (current?.id ?? null)
-          : null;
+        const runMessageId =
+          typeof body?.assistantMessageId === "string"
+            ? body.assistantMessageId
+            : null;
+        const partialMessageId =
+          runMessageId ??
+          (isResumableActiveStreamId(activeStreamId)
+            ? (current?.id ?? null)
+            : null);
 
         return {
-          api: `/api/chat/${chatId}/stream${partialMessageId ? `?messageId=${partialMessageId}` : ""}`,
+          api: `/api/chat/${chatId}/stream${partialMessageId ? `?messageId=${encodeURIComponent(partialMessageId)}` : ""}`,
         };
       },
     }),

--- a/apps/chat/components/message-actions.tsx
+++ b/apps/chat/components/message-actions.tsx
@@ -42,7 +42,7 @@ function PureMessageActions({
   // Version selector and model tag handled by MessageVersionAndModel component
 
   if (isLoading) {
-    return <div className="h-7" />;
+    return null;
   }
 
   const showActionsWithoutHover = isMobile || isEditing || role === "assistant";

--- a/apps/chat/hooks/chat-sync-hooks.ts
+++ b/apps/chat/hooks/chat-sync-hooks.ts
@@ -337,9 +337,8 @@ export function useSaveMessageMutation() {
         // response siblings get their updated activeStreamId from the server.
         // Placed in onSettled (not onSuccess) so this runs after the real
         // backend write when the mutationFn is eventually made server-side.
-        qc.invalidateQueries({
-          queryKey: trpc.chat.getChatMessages.queryKey({ chatId }),
-        });
+        const key = trpc.chat.getChatMessages.queryKey({ chatId });
+        qc.invalidateQueries({ queryKey: key });
       }
     },
   });

--- a/apps/chat/hooks/use-complete-data-part.test.ts
+++ b/apps/chat/hooks/use-complete-data-part.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "@/lib/ai/types";
+import { mergeCompletedMessageIntoVisiblePath } from "./use-complete-data-part";
+
+function message({
+  id,
+  parentMessageId,
+}: {
+  id: string;
+  parentMessageId: string | null;
+}): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text: id }],
+    metadata: {
+      activeStreamId: null,
+      createdAt: new Date(),
+      isPrimaryParallel: null,
+      parallelGroupId: null,
+      parallelIndex: null,
+      parentMessageId,
+      selectedModel: "openai/gpt-4o-mini",
+    },
+  };
+}
+
+describe("mergeCompletedMessageIntoVisiblePath", () => {
+  it("does not attach a completion from a hidden sibling branch", () => {
+    const visibleUser = message({ id: "visible-user", parentMessageId: null });
+    const visibleAssistant = message({
+      id: "visible-assistant",
+      parentMessageId: visibleUser.id,
+    });
+    const hiddenCompletion = message({
+      id: "hidden-assistant",
+      parentMessageId: "hidden-user",
+    });
+
+    expect(
+      mergeCompletedMessageIntoVisiblePath(
+        [visibleUser, visibleAssistant],
+        hiddenCompletion
+      )
+    ).toBeNull();
+  });
+
+  it("replaces an existing partial message without changing its position", () => {
+    const user = message({ id: "user", parentMessageId: null });
+    const partial = message({ id: "assistant", parentMessageId: user.id });
+    const completed = {
+      ...partial,
+      parts: [{ type: "text" as const, text: "complete" }],
+    };
+
+    expect(
+      mergeCompletedMessageIntoVisiblePath([user, partial], completed)
+    ).toEqual([user, completed]);
+  });
+});

--- a/apps/chat/hooks/use-complete-data-part.ts
+++ b/apps/chat/hooks/use-complete-data-part.ts
@@ -1,41 +1,70 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { ChatMessage } from "@/lib/ai/types";
-import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
+import { useChatActions } from "@/lib/stores/base";
+import { useCustomChatStoreApi } from "@/lib/stores/custom-store-provider";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
+
+export function mergeCompletedMessageIntoVisiblePath(
+  currentMessages: ChatMessage[],
+  message: ChatMessage
+): ChatMessage[] | null {
+  const existingIdx = currentMessages.findIndex(
+    (candidate) => candidate.id === message.id
+  );
+
+  if (existingIdx !== -1) {
+    return [
+      ...currentMessages.slice(0, existingIdx),
+      message,
+      ...currentMessages.slice(existingIdx + 1),
+    ];
+  }
+
+  const currentLeafId = currentMessages.at(-1)?.id ?? null;
+  if (message.metadata.parentMessageId !== currentLeafId) {
+    return null;
+  }
+
+  return [...currentMessages, message];
+}
 
 // Completes the first received data part into a concrete message (e.g. data-appendMessage).
 export function useCompleteDataPart() {
   const { dataStream } = useDataStream();
   const { setMessages } = useChatActions<ChatMessage>();
-  const storeApi = useChatStoreApi<ChatMessage>();
+  const storeApi = useCustomChatStoreApi<ChatMessage>();
+  const processedPartsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!dataStream || dataStream.length === 0) {
       return;
     }
 
-    const dataPart = dataStream[0];
-    if (dataPart.type !== "data-appendMessage") {
-      return;
+    for (const dataPart of dataStream) {
+      if (dataPart.type !== "data-appendMessage") {
+        continue;
+      }
+
+      const partKey = `${dataPart.type}:${dataPart.data}`;
+      if (processedPartsRef.current.has(partKey)) {
+        continue;
+      }
+      processedPartsRef.current.add(partKey);
+
+      const message = JSON.parse(dataPart.data) as ChatMessage;
+      storeApi.getState().addMessageToTree(message);
+
+      const currentMessages = storeApi.getState().messages as ChatMessage[];
+      const nextMessages = mergeCompletedMessageIntoVisiblePath(
+        currentMessages,
+        message
+      );
+
+      if (nextMessages) {
+        setMessages(nextMessages);
+      }
     }
-
-    const message = JSON.parse(dataPart.data) as ChatMessage;
-
-    const currentMessages = storeApi.getState().messages as ChatMessage[];
-    const existingIdx = currentMessages.findIndex((m) => m.id === message.id);
-
-    // If it exists (often last due to partial placeholder), replace in place.
-    if (existingIdx !== -1) {
-      setMessages([
-        ...currentMessages.slice(0, existingIdx),
-        message,
-        ...currentMessages.slice(existingIdx + 1),
-      ]);
-      return;
-    }
-
-    setMessages([...currentMessages, message]);
   }, [dataStream, setMessages, storeApi]);
 }


### PR DESCRIPTION
## Summary
- route completed data parts to their owning branch
- preserve hidden branch streams while navigating
- hide completion actions until the selected assistant response is complete

## Verification
- `bun --filter @chatjs/chat lint`
- `bun --filter @chatjs/chat test:types`
- `bun --filter @chatjs/chat test:unit`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. #221
3. #222
4. #223
5. **#224** 👈 current
6. #225
7. #226
8. #227
9. #228
10. #229
<!-- stack:links:end -->