### PR TITLE
Threads 6: Coordinate parallel thread responses

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -354,12 +354,17 @@ async function createChatStream({
   // Build the data stream that will emit tokens
   const stream = createUIMessageStream<ChatMessage>({
     execute: async ({ writer: dataStream }) => {
-      // Confirm chat persistence on first message (chat + user message are persisted before streaming begins)
-      if (isNewChat) {
+      // Release provisional parallel responses only after this exact user
+      // message has been persisted by the primary request.
+      if (isNewChat && userId && isPrimaryParallel !== false) {
         dataStream.write({
           id: generateUUID(),
-          type: "data-chatConfirmed",
-          data: { chatId },
+          type: "data-userMessagePersisted",
+          data: {
+            chatId,
+            parallelGroupId,
+            userMessageId: userMessage.id,
+          },
           transient: true,
         });
       }
@@ -534,7 +539,7 @@ async function executeChatRequest({
   const streamId = generateUUID();
 
   if (!isAnonymous) {
-    // The first provisional request can replay before chatConfirmed arrives, so
+    // The first provisional request can replay before its persistence acknowledgment arrives, so
     // placeholder creation must be idempotent.
     const insertedMessage = await saveMessageIfNotExists({
       id: messageId,

--- a/apps/chat/components/chat-runtime-controller.tsx
+++ b/apps/chat/components/chat-runtime-controller.tsx
@@ -7,32 +7,34 @@ import { ChatSync } from "@/components/chat-sync";
 import { type AppRuntime, getAppRuntimeStore } from "@/lib/app-chat-runtime";
 import {
   markParallelRequestSpecsFailed,
-  runParallelRequestSpecs,
+  runParallelThreadRequestSpecs,
 } from "@/lib/parallel-chat-requests";
+import { claimConfirmedProvisionalChat } from "@/lib/provisional-chat-confirmations";
+import { useChatActions } from "@/lib/stores/base";
 import { CustomStoreProvider } from "@/lib/stores/custom-store-provider";
-import {
-  useChatPersistenceActions,
-  useIsChatPersisted,
-  usePendingChatConfirmation,
-} from "@/lib/stores/hooks-chat-persistence";
+import { useIsChatPersisted } from "@/lib/stores/hooks-chat-persistence";
 import { useAddMessageToTree } from "@/lib/stores/hooks-threads";
 import { useTRPC } from "@/trpc/react";
 
 function ChatConfirmationEffects({ chatId }: { chatId: string }) {
   const addMessageToTree = useAddMessageToTree();
+  const { startRun } = useChatActions();
   const isChatPersisted = useIsChatPersisted(chatId);
-  const pendingConfirmation = usePendingChatConfirmation();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
-  const { clearPendingChatConfirmation } = useChatPersistenceActions();
   const handledConfirmationRef = useRef(false);
 
   useEffect(() => {
-    if (!(isChatPersisted && pendingConfirmation)) {
+    if (!isChatPersisted) {
       return;
     }
 
     if (handledConfirmationRef.current) {
+      return;
+    }
+
+    const pendingConfirmation = claimConfirmedProvisionalChat(chatId);
+    if (!pendingConfirmation) {
       return;
     }
 
@@ -60,19 +62,19 @@ function ChatConfirmationEffects({ chatId }: { chatId: string }) {
     const secondaryRequestSpecs = pendingConfirmation.requestSpecs.slice(1);
 
     if (secondaryRequestSpecs.length === 0) {
-      invalidatePersistedChatQueries()
-        .catch(() => {
-          toast.error("Failed to refresh chat history");
-        })
-        .finally(clearPendingChatConfirmation);
+      invalidatePersistedChatQueries().catch(() => {
+        toast.error("Failed to refresh chat history");
+      });
       return;
     }
 
-    runParallelRequestSpecs({
+    runParallelThreadRequestSpecs({
       chatId,
       message: pendingConfirmation.message,
       projectId: pendingConfirmation.projectId,
       requestSpecs: secondaryRequestSpecs,
+      startRun,
+      userMessagePersisted: true,
     })
       .then((failedRequestSpecs) => {
         if (failedRequestSpecs.length > 0) {
@@ -93,21 +95,11 @@ function ChatConfirmationEffects({ chatId }: { chatId: string }) {
         toast.error("Failed to complete all parallel responses");
       })
       .finally(() => {
-        invalidatePersistedChatQueries()
-          .catch(() => {
-            toast.error("Failed to refresh chat history");
-          })
-          .finally(clearPendingChatConfirmation);
+        invalidatePersistedChatQueries().catch(() => {
+          toast.error("Failed to refresh chat history");
+        });
       });
-  }, [
-    addMessageToTree,
-    chatId,
-    clearPendingChatConfirmation,
-    isChatPersisted,
-    pendingConfirmation,
-    queryClient,
-    trpc,
-  ]);
+  }, [addMessageToTree, chatId, isChatPersisted, queryClient, startRun, trpc]);
 
   return null;
 }

--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -8,6 +8,7 @@ import { useSaveMessageMutation } from "@/hooks/chat-sync-hooks";
 import { useCompleteDataPart } from "@/hooks/use-complete-data-part";
 import { getStreamErrorToastContent } from "@/lib/ai/stream-errors";
 import type { ChatMessage } from "@/lib/ai/types";
+import { acknowledgeProvisionalUserMessagePersistence } from "@/lib/provisional-chat-confirmations";
 import { useChat } from "@/lib/stores/base";
 import { useChatPersistenceActions } from "@/lib/stores/hooks-chat-persistence";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
@@ -94,11 +95,16 @@ export function ChatSync({
     onData: (dataPart) => {
       if (
         !hasReportedConfirmationRef.current &&
-        dataPart.type === "data-chatConfirmed" &&
+        dataPart.type === "data-userMessagePersisted" &&
         dataPart.data.chatId === id
       ) {
-        hasReportedConfirmationRef.current = true;
-        setChatPersisted(true);
+        const matchesPendingChat = acknowledgeProvisionalUserMessagePersistence(
+          dataPart.data
+        );
+        if (matchesPendingChat) {
+          hasReportedConfirmationRef.current = true;
+          setChatPersisted(true);
+        }
       }
       setDataStream((ds) =>
         ds ? [...ds, dataPart as (typeof ds)[number]] : []

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -42,7 +42,7 @@ import {
   addPendingAssistantMessages,
   createParallelRequestBody,
   markParallelRequestSpecsFailed,
-  runParallelRequestSpecs,
+  runParallelThreadRequestSpecs,
 } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
 import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
@@ -119,6 +119,7 @@ function PureMultimodalInput({
   const {
     setMessages,
     sendMessage,
+    startRun,
     stop: stopHelper,
   } = useChatActions<ChatMessage>();
   const lastMessageId = useLastMessageId();
@@ -399,11 +400,12 @@ function PureMultimodalInput({
         requestSpecs,
       });
 
-      runParallelRequestSpecs({
+      runParallelThreadRequestSpecs({
         chatId,
         message,
         projectId: currentRoute.projectId,
         requestSpecs: requestSpecs.slice(1),
+        startRun,
       })
         .then(async (failedRequestSpecs) => {
           if (failedRequestSpecs.length > 0) {
@@ -453,6 +455,7 @@ function PureMultimodalInput({
     selectedTool,
     sendMessage,
     startProvisionalChat,
+    startRun,
     trimMessagesInEditMode,
   ]);
 
@@ -648,10 +651,10 @@ function PureMultimodalInput({
 
   const handleStop = useCallback(() => {
     if (session?.user && lastMessageId) {
-      stopStreamMutation.mutate({ messageId: lastMessageId });
+      stopStreamMutation.mutate({ chatId, messageId: lastMessageId });
     }
     stopHelper?.();
-  }, [lastMessageId, session?.user, stopHelper, stopStreamMutation]);
+  }, [chatId, lastMessageId, session?.user, stopHelper, stopStreamMutation]);
 
   return (
     <div className="relative">

--- a/apps/chat/components/parallel-response-cards.test.ts
+++ b/apps/chat/components/parallel-response-cards.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+  getParallelResponseLifecycle,
+  getStatusLabel,
+} from "./parallel-response-status";
+
+function createAssistantMessage(activeStreamId: string | null) {
+  return {
+    metadata: { activeStreamId },
+  };
+}
+
+describe("parallel response card status", () => {
+  it("keeps queued and streaming responses in a loading state", () => {
+    assert.equal(getParallelResponseLifecycle(null), "queued");
+    assert.equal(
+      getParallelResponseLifecycle(
+        createAssistantMessage("pending:assistant-1")
+      ),
+      "queued"
+    );
+    assert.equal(
+      getParallelResponseLifecycle(createAssistantMessage("stream-1")),
+      "generating"
+    );
+    assert.equal(getStatusLabel(true, "queued"), "Generating...");
+    assert.equal(getStatusLabel(false, "generating"), "Generating...");
+  });
+
+  it("shows completion only after the stream marker is cleared", () => {
+    assert.equal(
+      getParallelResponseLifecycle(createAssistantMessage(null)),
+      "complete"
+    );
+    assert.equal(getStatusLabel(true, "complete"), "Selected");
+    assert.equal(getStatusLabel(false, "complete"), "Task completed");
+  });
+});

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -15,6 +15,10 @@ import { useParallelGroupInfo } from "@/lib/stores/hooks-threads";
 import { cn } from "@/lib/utils";
 import { useChatInput } from "@/providers/chat-input-provider";
 import { useChatModels } from "@/providers/chat-models-provider";
+import {
+  getParallelResponseLifecycle,
+  getStatusLabel,
+} from "./parallel-response-status";
 
 function getEffectiveModelId(
   message: {
@@ -36,16 +40,6 @@ function getModelOrderIndex(
   }
   const index = models.findIndex((m) => m.id === modelId);
   return index === -1 ? Number.POSITIVE_INFINITY : index;
-}
-
-function getStatusLabel(isSelected: boolean, isStreaming: boolean): string {
-  if (isSelected) {
-    return "Selected";
-  }
-  if (isStreaming) {
-    return "Generating...";
-  }
-  return "Task completed";
 }
 
 function PureParallelResponseCards({ messageId }: { messageId: string }) {
@@ -131,10 +125,9 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
           ? (getModelById(modelId)?.name ?? modelId)
           : "Model";
         const isSelected = selectedParallelIndex === slot.parallelIndex;
-        const isStreaming = slot.message
-          ? slot.message.metadata.activeStreamId !== null
-          : true;
-        const statusLabel = getStatusLabel(isSelected, isStreaming);
+        const lifecycle = getParallelResponseLifecycle(slot.message);
+        const isLoading = lifecycle !== "complete";
+        const statusLabel = getStatusLabel(isSelected, lifecycle);
 
         return (
           <Button
@@ -157,7 +150,7 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
           >
             <span className="font-medium text-sm">{modelName}</span>
             <span className="flex items-center gap-1 text-muted-foreground text-xs">
-              {isStreaming ? (
+              {isLoading ? (
                 <LoaderCircle className="size-3 animate-spin" />
               ) : null}
               {statusLabel}

--- a/apps/chat/components/parallel-response-status.ts
+++ b/apps/chat/components/parallel-response-status.ts
@@ -1,0 +1,29 @@
+export type ParallelResponseLifecycle = "queued" | "generating" | "complete";
+
+interface ParallelResponseStatusMessage {
+  metadata: {
+    activeStreamId: string | null;
+  };
+}
+
+export function getParallelResponseLifecycle(
+  message: ParallelResponseStatusMessage | null
+): ParallelResponseLifecycle {
+  if (!message || message.metadata.activeStreamId?.startsWith("pending:")) {
+    return "queued";
+  }
+  if (message.metadata.activeStreamId !== null) {
+    return "generating";
+  }
+  return "complete";
+}
+
+export function getStatusLabel(
+  isSelected: boolean,
+  lifecycle: ParallelResponseLifecycle
+): string {
+  if (lifecycle !== "complete") {
+    return "Generating...";
+  }
+  return isSelected ? "Selected" : "Task completed";
+}

--- a/apps/chat/lib/ai/types.ts
+++ b/apps/chat/lib/ai/types.ts
@@ -190,8 +190,10 @@ interface FollowupSuggestions {
 
 export type CustomUIDataTypes = {
   appendMessage: string;
-  chatConfirmed: {
+  userMessagePersisted: {
     chatId: string;
+    parallelGroupId: string | null;
+    userMessageId: string;
   };
   followupSuggestions: FollowupSuggestions;
   researchUpdate: ResearchUpdate;

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -1074,10 +1074,13 @@ export async function updateMessageCanceledAt({
   canceledAt: Date | null;
 }) {
   try {
-    return await db
+    const updatedMessages = await db
       .update(message)
       .set({ canceledAt })
-      .where(eq(message.id, messageId));
+      .where(eq(message.id, messageId))
+      .returning({ id: message.id });
+
+    return updatedMessages.length > 0;
   } catch (error) {
     logger.error({ error, messageId }, "updateMessageCanceledAt failed");
     throw error;

--- a/apps/chat/lib/parallel-chat-requests.test.ts
+++ b/apps/chat/lib/parallel-chat-requests.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import type { TreeHelpers } from "@chatjs/thread/react";
+import { afterEach, describe, it, vi } from "vitest";
+import type { ChatMessage } from "@/lib/ai/types";
+import type { ParallelRequestSpec } from "./draft-chat-submission";
+import { runParallelThreadRequestSpecs } from "./parallel-chat-requests";
+
+const message = {
+  id: "user-follow-up",
+  parts: [{ type: "text", text: "Compare both approaches" }],
+  role: "user",
+} as ChatMessage;
+
+const requestSpecs = [
+  {
+    assistantMessageId: "assistant-mini",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    isPrimary: false,
+    modelId: "openai/gpt-5-mini",
+    parallelGroupId: "response-group-1",
+    parallelIndex: 1,
+  },
+  {
+    assistantMessageId: "assistant-nano",
+    createdAt: new Date("2026-01-01T00:00:00.001Z"),
+    isPrimary: false,
+    modelId: "openai/gpt-5-nano",
+    parallelGroupId: "response-group-1",
+    parallelIndex: 2,
+  },
+] satisfies ParallelRequestSpec[];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("runParallelThreadRequestSpecs", () => {
+  it("starts secondary responses as live thread runs with response-group identity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 }))
+    );
+
+    const finishResolvers: Array<() => void> = [];
+    const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() => {
+      const finished = new Promise<void>((resolve) => {
+        finishResolvers.push(resolve);
+      });
+      return Promise.resolve({
+        assistantMessageId: "unused",
+        finished,
+        getSnapshot: () => undefined,
+        id: "unused",
+        stop: () => Promise.resolve(),
+      });
+    });
+
+    let settled = false;
+    const resultPromise = runParallelThreadRequestSpecs({
+      chatId: "chat-1",
+      message,
+      projectId: "project-1",
+      requestSpecs,
+      startRun,
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.waitFor(() => {
+      assert.equal(startRun.mock.calls.length, 2);
+    });
+
+    assert.deepEqual(startRun.mock.calls[0]?.[0], {
+      follow: false,
+      from: message.id,
+      request: {
+        body: {
+          assistantMessageId: "assistant-mini",
+          isPrimaryParallel: false,
+          parallelGroupId: "response-group-1",
+          parallelIndex: 1,
+          projectId: "project-1",
+          selectedModelId: "openai/gpt-5-mini",
+        },
+      },
+    });
+    assert.equal(settled, false);
+
+    for (const resolve of finishResolvers) {
+      resolve();
+    }
+
+    assert.deepEqual(await resultPromise, []);
+  });
+
+  it("starts confirmed provisional runs without preparing persistence again", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const startRun = vi.fn<TreeHelpers<ChatMessage>["startRun"]>(() =>
+      Promise.resolve({
+        assistantMessageId: "assistant-mini",
+        finished: Promise.resolve(),
+        getSnapshot: () => undefined,
+        id: "assistant-mini",
+        stop: () => Promise.resolve(),
+      })
+    );
+
+    assert.deepEqual(
+      await runParallelThreadRequestSpecs({
+        chatId: "chat-1",
+        message,
+        projectId: null,
+        requestSpecs: requestSpecs.slice(0, 1),
+        startRun,
+        userMessagePersisted: true,
+      }),
+      []
+    );
+
+    assert.equal(fetchMock.mock.calls.length, 0);
+    assert.equal(startRun.mock.calls.length, 1);
+  });
+});

--- a/apps/chat/lib/parallel-chat-requests.ts
+++ b/apps/chat/lib/parallel-chat-requests.ts
@@ -1,3 +1,4 @@
+import type { TreeHelpers } from "@chatjs/thread/react";
 import type { AppModelId } from "@/lib/ai/app-model-id";
 import type { ChatMessage } from "@/lib/ai/types";
 import { fetchWithErrorHandlers } from "@/lib/utils";
@@ -108,65 +109,15 @@ export function markParallelRequestSpecsFailed({
   }
 }
 
-async function drainResponse(response: Response) {
-  if (!response.body) {
-    return;
-  }
-
-  const reader = response.body.getReader();
-
-  while (true) {
-    const { done } = await reader.read();
-
-    if (done) {
-      break;
-    }
-  }
-}
-
-async function drainParallelRequest({
+async function prepareParallelRequests({
   chatId,
   message,
   projectId,
-  requestSpec,
 }: {
   chatId: string;
   message: ChatMessage;
   projectId: string | null;
-  requestSpec: ParallelRequestSpec;
 }) {
-  const response = await fetchWithErrorHandlers("/api/chat", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      id: chatId,
-      message,
-      prevMessages: [],
-      projectId,
-      ...createParallelRequestBody(requestSpec, false),
-    }),
-  });
-
-  await drainResponse(response);
-}
-
-export async function runParallelRequestSpecs({
-  chatId,
-  message,
-  projectId,
-  requestSpecs,
-}: {
-  chatId: string;
-  message: ChatMessage;
-  projectId: string | null;
-  requestSpecs: ParallelRequestSpec[];
-}) {
-  if (requestSpecs.length === 0) {
-    return [];
-  }
-
   try {
     await fetchWithErrorHandlers("/api/chat/prepare", {
       method: "POST",
@@ -179,19 +130,60 @@ export async function runParallelRequestSpecs({
         projectId,
       }),
     });
+    return true;
   } catch {
+    return false;
+  }
+}
+
+export async function runParallelThreadRequestSpecs({
+  chatId,
+  message,
+  projectId,
+  requestSpecs,
+  startRun,
+  userMessagePersisted = false,
+}: {
+  chatId: string;
+  message: ChatMessage;
+  projectId: string | null;
+  requestSpecs: ParallelRequestSpec[];
+  startRun: TreeHelpers<ChatMessage>["startRun"];
+  userMessagePersisted?: boolean;
+}) {
+  if (requestSpecs.length === 0) {
+    return [];
+  }
+
+  const prepared =
+    userMessagePersisted ||
+    (await prepareParallelRequests({
+      chatId,
+      message,
+      projectId,
+    }));
+  if (!prepared) {
     return requestSpecs;
   }
 
   const results = await Promise.allSettled(
-    requestSpecs.map((requestSpec) =>
-      drainParallelRequest({
-        chatId,
-        message,
-        projectId,
-        requestSpec,
-      })
-    )
+    requestSpecs.map(async (requestSpec) => {
+      const run = await startRun({
+        follow: false,
+        from: message.id,
+        request: {
+          body: {
+            ...createParallelRequestBody(requestSpec, false),
+            projectId: projectId ?? undefined,
+          },
+        },
+      });
+      await run.finished;
+      const snapshot = run.getSnapshot();
+      if (snapshot?.status === "error") {
+        throw snapshot.error ?? new Error("Parallel response failed");
+      }
+    })
   );
 
   return requestSpecs.filter(

--- a/apps/chat/lib/provisional-chat-confirmations.test.ts
+++ b/apps/chat/lib/provisional-chat-confirmations.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "vitest";
+import type { PendingChatConfirmation } from "@/lib/stores/with-chat-persistence";
+import {
+  acknowledgeProvisionalUserMessagePersistence,
+  claimConfirmedProvisionalChat,
+  clearProvisionalChatConfirmations,
+  registerProvisionalChatConfirmation,
+} from "./provisional-chat-confirmations";
+
+const confirmation = {
+  message: {
+    id: "user-1",
+    metadata: { parallelGroupId: "group-1" },
+  },
+  projectId: null,
+  requestSpecs: [],
+} as unknown as PendingChatConfirmation;
+
+describe("provisional chat confirmations", () => {
+  afterEach(clearProvisionalChatConfirmations);
+
+  it("releases only after the expected user message and group are persisted", () => {
+    registerProvisionalChatConfirmation("chat-1", confirmation);
+
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), null);
+    assert.equal(
+      acknowledgeProvisionalUserMessagePersistence({
+        chatId: "chat-1",
+        parallelGroupId: "wrong-group",
+        userMessageId: "user-1",
+      }),
+      false
+    );
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), null);
+
+    assert.equal(
+      acknowledgeProvisionalUserMessagePersistence({
+        chatId: "chat-1",
+        parallelGroupId: "group-1",
+        userMessageId: "user-1",
+      }),
+      true
+    );
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), confirmation);
+    assert.equal(claimConfirmedProvisionalChat("chat-1"), null);
+  });
+});

--- a/apps/chat/lib/provisional-chat-confirmations.ts
+++ b/apps/chat/lib/provisional-chat-confirmations.ts
@@ -1,0 +1,61 @@
+import type { PendingChatConfirmation } from "@/lib/stores/with-chat-persistence";
+
+interface UserMessagePersistenceAcknowledgment {
+  chatId: string;
+  parallelGroupId: string | null;
+  userMessageId: string;
+}
+
+interface ProvisionalChatConfirmationEntry {
+  acknowledgment: UserMessagePersistenceAcknowledgment | null;
+  confirmation: PendingChatConfirmation;
+}
+
+const pendingConfirmations = new Map<
+  string,
+  ProvisionalChatConfirmationEntry
+>();
+
+export function registerProvisionalChatConfirmation(
+  chatId: string,
+  confirmation: PendingChatConfirmation
+) {
+  pendingConfirmations.set(chatId, {
+    acknowledgment: null,
+    confirmation,
+  });
+}
+
+export function acknowledgeProvisionalUserMessagePersistence(
+  acknowledgment: UserMessagePersistenceAcknowledgment
+) {
+  const entry = pendingConfirmations.get(acknowledgment.chatId);
+  if (!entry) {
+    return false;
+  }
+
+  const expectedParallelGroupId =
+    entry.confirmation.message.metadata.parallelGroupId ?? null;
+  if (
+    entry.confirmation.message.id !== acknowledgment.userMessageId ||
+    expectedParallelGroupId !== acknowledgment.parallelGroupId
+  ) {
+    return false;
+  }
+
+  entry.acknowledgment = acknowledgment;
+  return true;
+}
+
+export function claimConfirmedProvisionalChat(chatId: string) {
+  const entry = pendingConfirmations.get(chatId) ?? null;
+  if (entry?.acknowledgment) {
+    pendingConfirmations.delete(chatId);
+    return entry.confirmation;
+  }
+  return null;
+}
+
+export function clearProvisionalChatConfirmations() {
+  pendingConfirmations.clear();
+}

--- a/apps/chat/lib/start-provisional-chat.ts
+++ b/apps/chat/lib/start-provisional-chat.ts
@@ -9,8 +9,8 @@ import {
   addPendingAssistantMessages,
   createParallelRequestBody,
 } from "@/lib/parallel-chat-requests";
+import { registerProvisionalChatConfirmation } from "@/lib/provisional-chat-confirmations";
 import { useCustomChatStoreApi } from "@/lib/stores/custom-store-provider";
-import { useChatPersistenceActions } from "@/lib/stores/hooks-chat-persistence";
 import { useAddMessageToTree } from "@/lib/stores/hooks-threads";
 import { useModelChange } from "@/providers/default-model-provider";
 import { useSession } from "@/providers/session-provider";
@@ -46,7 +46,6 @@ export function useStartProvisionalChat(chatId: string) {
   const { data: session } = useSession();
   const addMessageToTree = useAddMessageToTree();
   const storeApi = useCustomChatStoreApi<ChatMessage>();
-  const { setPendingChatConfirmation } = useChatPersistenceActions();
 
   return useCallback(
     ({
@@ -80,7 +79,7 @@ export function useStartProvisionalChat(chatId: string) {
         return false;
       }
 
-      setPendingChatConfirmation({
+      registerProvisionalChatConfirmation(chatId, {
         message,
         projectId: currentRoute.projectId,
         requestSpecs,
@@ -126,7 +125,6 @@ export function useStartProvisionalChat(chatId: string) {
       chatId,
       currentRoute,
       session?.user,
-      setPendingChatConfirmation,
       storeApi,
     ]
   );

--- a/apps/chat/lib/stores/with-data-stream.test.ts
+++ b/apps/chat/lib/stores/with-data-stream.test.ts
@@ -7,8 +7,12 @@ describe("withDataStream", () => {
   it("stores transient stream parts on the chat store", () => {
     const store = createCustomChatStore<ChatMessage>();
     const streamPart = {
-      type: "data-chatConfirmed",
-      data: { chatId: "chat-1" },
+      type: "data-userMessagePersisted",
+      data: {
+        chatId: "chat-1",
+        parallelGroupId: "group-1",
+        userMessageId: "user-1",
+      },
     } as const;
 
     store.getState().setDataStream([streamPart]);

--- a/apps/chat/trpc/routers/chat.router.ts
+++ b/apps/chat/trpc/routers/chat.router.ts
@@ -188,19 +188,23 @@ export const chatRouter = createTRPCRouter({
   stopStream: protectedProcedure
     .input(
       z.object({
+        chatId: z.string().uuid(),
         messageId: z.string().uuid(),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const [msg] = await getMessageById({ id: input.messageId });
-      if (!msg) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Message not found",
-        });
+      // A new chat can still be generating its title when the client stops.
+      // Wait for its reserved assistant row so request ordering cannot lose cancellation.
+      const deadline = Date.now() + 30_000;
+      let retryDelay = 25;
+      let chat = await getChatById({ id: input.chatId });
+
+      while (!chat && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        retryDelay = Math.min(retryDelay * 2, 250);
+        chat = await getChatById({ id: input.chatId });
       }
 
-      const chat = await getChatById({ id: msg.chatId });
       if (!chat || chat.userId !== ctx.user.id) {
         throw new TRPCError({
           code: "NOT_FOUND",
@@ -208,10 +212,24 @@ export const chatRouter = createTRPCRouter({
         });
       }
 
-      await updateMessageCanceledAt({
-        messageId: input.messageId,
-        canceledAt: new Date(),
-      });
+      const canceledAt = new Date();
+
+      while (
+        !(await updateMessageCanceledAt({
+          messageId: input.messageId,
+          canceledAt,
+        }))
+      ) {
+        if (Date.now() >= deadline) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Message not found",
+          });
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        retryDelay = Math.min(retryDelay * 2, 250);
+      }
 
       return { success: true };
     }),


### PR DESCRIPTION
## Summary
- run parallel assistant responses as independent thread runs
- add response-group identity and optimistic response cards
- gate secondary first-message requests on primary persistence confirmation
- keep queued, streaming, completed, and canceled states branch-specific

## Verification
- `bun --filter @chatjs/chat lint`
- `bun --filter @chatjs/chat test:types`
- `bun --filter @chatjs/chat test:unit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinates parallel assistant responses by starting each response as its own thread run and only releasing secondary runs after the exact user message in the parallel group is persisted. Adds a `data-userMessagePersisted` signal with a confirmation registry, unifies queued/generating/complete statuses, and makes stopping more reliable.

- **New Features**
  - Start secondary responses via `startRun` as independent thread runs using `runParallelThreadRequestSpecs`; preflight `POST /api/chat/prepare` only when `userMessagePersisted` is false.
  - Gate secondary runs on `data-userMessagePersisted { chatId, parallelGroupId, userMessageId }`; new confirmation registry (`register/acknowledge/claim`) releases only the matching user message in the group.
  - Unified card status via `parallel-response-status` with "Generating.../Selected/Task completed"; covered by tests.
  - Parallel runs wait on `run.finished` and surface errors; confirmed provisional runs skip prepare.
  - Safer stopping: TRPC `stopStream` now requires `chatId`, waits for the chat row, and retries `canceledAt` updates; `updateMessageCanceledAt` returns a boolean.

- **Migration**
  - Replace `data-chatConfirmed` with `data-userMessagePersisted { chatId, parallelGroupId, userMessageId }`.
  - Switch to `runParallelThreadRequestSpecs`, pass `startRun`, and set `userMessagePersisted: true` for confirmed provisional runs.
  - Update TRPC `stopStream` calls to include `{ chatId, messageId }`.

<sup>Written for commit 9d147b84c211bcdeb5ed6c8fcc9542c405044ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. #221
3. #222
4. #223
5. #224
6. **#225** 👈 current
7. #226
8. #227
9. #228
10. #229
<!-- stack:links:end -->