### PR TITLE
Threads 8: Showcase AI SDK message threads

### DIFF
--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -17,6 +17,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: siteLinks.threads,
+      lastModified: new Date("2026-07-10T00:00:00.000Z"),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
       url: siteLinks.docsGettingStarted,
       lastModified: siteLastModified,
       changeFrequency: "weekly",

--- a/apps/site/app/threads/page.tsx
+++ b/apps/site/app/threads/page.tsx
@@ -1,0 +1,346 @@
+import {
+  ArrowRight,
+  Braces,
+  Check,
+  CircleStop,
+  GitBranch,
+  GitFork,
+  Layers3,
+  Radio,
+  RefreshCw,
+  Route,
+  Workflow,
+} from "lucide-react";
+import type { Metadata } from "next";
+
+import { Footer } from "@/components/footer";
+import { Navbar } from "@/components/navbar";
+import {
+  ThreadInstallCommand,
+  ThreadPlayground,
+} from "@/components/thread-registry-showcase";
+import { siteLinks } from "@/lib/site-config";
+
+export const metadata: Metadata = {
+  title: "useThread — Branching Chats for AI SDK",
+  description:
+    "Keep the useChat interface and add message trees, branch navigation, and concurrent AI SDK response streams.",
+  alternates: {
+    canonical: siteLinks.threads,
+  },
+  openGraph: {
+    url: siteLinks.threads,
+    title: "useThread — Branching Chats for AI SDK",
+    description:
+      "A useChat-compatible active path backed by a complete message tree.",
+  },
+};
+
+const compatibility = [
+  "messages",
+  "sendMessage",
+  "setMessages",
+  "regenerate",
+  "stop",
+  "status + error",
+  "tools + approvals",
+  "ChatTransport",
+] as const;
+
+const additions = [
+  {
+    icon: Route,
+    title: "Cursor navigation",
+    description:
+      "Select any message and expose its root-to-node path as chat.messages.",
+  },
+  {
+    icon: GitFork,
+    title: "Message topology",
+    description:
+      "Read parents, children, siblings, leaves, and complete tree snapshots.",
+  },
+  {
+    icon: Radio,
+    title: "Independent runs",
+    description:
+      "Stream, stop, and resume responses without coupling them to the visible path.",
+  },
+  {
+    icon: Layers3,
+    title: "Parallel responses",
+    description:
+      "Start multiple assistant runs from one user message and follow only the one you choose.",
+  },
+] as const;
+
+const architectureRows = [
+  {
+    label: "Tree",
+    detail: "Canonical messages, parent-child edges, and the selected cursor.",
+  },
+  {
+    label: "Active path",
+    detail: "A useChat-compatible projection from the root to the cursor.",
+  },
+  {
+    label: "Branch runs",
+    detail:
+      "One isolated AI SDK request lifecycle and abort controller per response.",
+  },
+  {
+    label: "Transport",
+    detail:
+      "Your existing AI SDK ChatTransport, shared without a new wire protocol.",
+  },
+] as const;
+
+export default function ThreadsPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1">
+        <section className="border-border/50 border-b">
+          <div className="mx-auto max-w-6xl px-6 pt-16 pb-14 sm:pt-24 sm:pb-20">
+            <div className="grid gap-12 lg:grid-cols-[minmax(0,1.12fr)_minmax(23rem,0.88fr)] lg:items-end">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 font-mono text-muted-foreground text-xs uppercase tracking-[0.18em]">
+                  <GitBranch className="size-4" />
+                  useThread for AI SDK
+                </div>
+                <h1 className="mt-7 max-w-4xl font-display text-4xl leading-[0.98] tracking-tight sm:text-7xl">
+                  Branching conversations for AI SDK.
+                </h1>
+                <p className="mt-7 max-w-2xl text-foreground/72 text-lg leading-8 sm:text-xl">
+                  Keep the{" "}
+                  <code className="font-mono text-[0.9em] text-foreground">
+                    useChat
+                  </code>{" "}
+                  interface. Add a complete message tree, branch navigation, and
+                  concurrent responses that keep streaming when users move
+                  elsewhere.
+                </p>
+                <div className="mt-8 flex flex-wrap items-center gap-5">
+                  <a
+                    className="inline-flex min-h-11 items-center gap-2 bg-primary px-5 font-medium text-primary-foreground text-sm transition-opacity hover:opacity-85"
+                    href="#playground"
+                  >
+                    Try the playground
+                    <ArrowRight className="size-4" />
+                  </a>
+                  <a
+                    className="inline-flex min-h-11 items-center gap-2 border-border border-b text-foreground/75 text-sm transition-colors hover:text-foreground"
+                    href={`${siteLinks.github}/tree/main/packages/thread`}
+                  >
+                    Read the package
+                    <ArrowRight className="size-3.5" />
+                  </a>
+                </div>
+              </div>
+
+              <div className="min-w-0 border-border border-y bg-card">
+                <div className="flex items-center justify-between border-border border-b px-4 py-3">
+                  <span className="font-mono text-muted-foreground text-xs">
+                    Chat.tsx
+                  </span>
+                  <span className="flex items-center gap-1.5 font-mono text-[10px] text-muted-foreground uppercase">
+                    <Check className="size-3" /> useChat compatible
+                  </span>
+                </div>
+                <pre className="overflow-x-auto px-4 py-5 font-mono text-[13px] leading-7">
+                  <code>
+                    <span className="text-muted-foreground">- </span>
+                    <span className="text-foreground/55">
+                      import {"{ useChat }"} from &quot;@ai-sdk/react&quot;;
+                    </span>
+                    {"\n"}
+                    <span className="text-foreground">
+                      + import {"{ useThread }"} from
+                      &quot;@chatjs/thread/react&quot;;
+                    </span>
+                    {"\n\n"}
+                    <span className="text-muted-foreground">- </span>
+                    <span className="text-foreground/55">
+                      const chat = useChat({"{ transport }"});
+                    </span>
+                    {"\n"}
+                    <span className="text-foreground">
+                      + const chat = useThread({"{ transport }"});
+                    </span>
+                    {"\n\n"}
+                    <span className="text-foreground">chat.messages;</span>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      {"// selected path"}
+                    </span>
+                    {"\n"}
+                    <span className="text-foreground">chat.tree;</span>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      {"// complete tree"}
+                    </span>
+                  </code>
+                </pre>
+              </div>
+            </div>
+
+            <ThreadInstallCommand />
+          </div>
+        </section>
+
+        <section className="scroll-mt-20 py-16 sm:py-20" id="playground">
+          <div className="mx-auto max-w-6xl px-6">
+            <div className="mb-8 flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
+              <div className="max-w-2xl">
+                <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.18em]">
+                  The package, not a mockup
+                </p>
+                <h2 className="mt-4 font-display text-3xl tracking-tight sm:text-5xl">
+                  Move through the tree while it streams.
+                </h2>
+              </div>
+              <p className="max-w-sm text-foreground/65 text-sm leading-6">
+                Branch from any message, request parallel replies, switch paths
+                mid-stream, and stop individual runs. The canvas reads directly
+                from useThread state.
+              </p>
+            </div>
+            <ThreadPlayground />
+          </div>
+        </section>
+
+        <section className="border-border/50 border-y bg-card py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-6">
+            <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr] lg:gap-20">
+              <div>
+                <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.18em]">
+                  A strict extension
+                </p>
+                <h2 className="mt-5 font-display text-3xl tracking-tight sm:text-5xl">
+                  Your chat stays linear. Its history does not.
+                </h2>
+                <p className="mt-5 text-foreground/68 leading-7">
+                  Existing message lists and composers keep using the selected
+                  path. Tree-specific state is additive and namespaced under{" "}
+                  <code className="font-mono text-foreground text-sm">
+                    chat.tree
+                  </code>
+                  .
+                </p>
+              </div>
+
+              <div>
+                <div className="flex items-center gap-2 border-border border-b pb-4">
+                  <Braces className="size-4 text-muted-foreground" />
+                  <h3 className="font-medium text-sm">Same AI SDK surface</h3>
+                </div>
+                <div className="grid grid-cols-2 border-border border-b sm:grid-cols-4">
+                  {compatibility.map((item) => (
+                    <div
+                      className="flex min-h-14 items-center gap-2 border-border border-r px-3 font-mono text-xs last:border-r-0 sm:[&:nth-child(4n)]:border-r-0"
+                      key={item}
+                    >
+                      <Check className="size-3.5 shrink-0 text-muted-foreground" />
+                      {item}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-10 grid sm:grid-cols-2">
+                  {additions.map((item) => (
+                    <article
+                      className="border-border border-b py-6 sm:even:border-l sm:even:pl-7 sm:odd:pr-7"
+                      key={item.title}
+                    >
+                      <item.icon className="size-4 text-muted-foreground" />
+                      <h3 className="mt-4 font-medium">{item.title}</h3>
+                      <p className="mt-2 text-foreground/65 text-sm leading-6">
+                        {item.description}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-6">
+            <div className="grid gap-14 lg:grid-cols-[0.92fr_1.08fr] lg:items-start lg:gap-20">
+              <div>
+                <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.18em]">
+                  Why it keeps working
+                </p>
+                <h2 className="mt-5 font-display text-3xl tracking-tight sm:text-5xl">
+                  One tree. One AI SDK lifecycle per response.
+                </h2>
+                <p className="mt-5 max-w-xl text-foreground/68 leading-7">
+                  A single linear chat engine cannot safely own several branch
+                  streams. useThread isolates each response while routing every
+                  update into its reserved assistant node.
+                </p>
+                <div className="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-foreground/65 text-sm">
+                  <span className="flex items-center gap-2">
+                    <RefreshCw className="size-3.5" /> Resume per run
+                  </span>
+                  <span className="flex items-center gap-2">
+                    <CircleStop className="size-3.5" /> Stop per run
+                  </span>
+                  <span className="flex items-center gap-2">
+                    <Workflow className="size-3.5" /> Navigate independently
+                  </span>
+                </div>
+              </div>
+
+              <div className="border-border border-t">
+                {architectureRows.map((row, index) => (
+                  <div
+                    className="grid gap-2 border-border border-b py-5 sm:grid-cols-[8rem_1fr] sm:gap-6"
+                    key={row.label}
+                  >
+                    <div className="flex items-center gap-3 font-mono text-xs">
+                      <span className="text-muted-foreground">
+                        0{index + 1}
+                      </span>
+                      {row.label}
+                    </div>
+                    <p className="text-foreground/68 text-sm leading-6">
+                      {row.detail}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-border/50 border-y bg-card py-20 sm:py-24">
+          <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-10 px-6 lg:flex-row lg:items-end">
+            <div className="max-w-2xl">
+              <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.18em]">
+                Headless by design
+              </p>
+              <h2 className="mt-5 font-display text-3xl tracking-tight sm:text-5xl">
+                Own the experience. Choose how you integrate it.
+              </h2>
+              <p className="mt-5 text-foreground/68 leading-7">
+                Install the versioned package or copy the source through the
+                registry. Your conversation UI, branch controls, persistence,
+                and server routes remain application-owned.
+              </p>
+            </div>
+            <a
+              className="inline-flex min-h-11 shrink-0 items-center gap-2 bg-primary px-5 font-medium text-primary-foreground text-sm transition-opacity hover:opacity-85"
+              href={`${siteLinks.github}/blob/main/packages/thread/README.md`}
+            >
+              Read the integration guide
+              <ArrowRight className="size-4" />
+            </a>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/site/components/footer.tsx
+++ b/apps/site/components/footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { siteLinks } from "@/lib/site-config";
 
 const PRODUCT_LINKS = [
+  { label: "useThread", href: "/threads" },
   { label: "Demo", href: siteLinks.demo },
   { label: "Desktop App", href: siteLinks.desktop },
   { label: "Documentation", href: siteLinks.docs },

--- a/apps/site/components/navbar.tsx
+++ b/apps/site/components/navbar.tsx
@@ -4,6 +4,7 @@ import { siteLinks } from "@/lib/site-config";
 import { ThemeToggle } from "./theme-toggle";
 
 const NAV_LINKS = [
+  { label: "Threads", href: "/threads" },
   { label: "Demo", href: siteLinks.demo },
   { label: "Docs", href: siteLinks.docs },
   {

--- a/apps/site/components/thread-registry-showcase.tsx
+++ b/apps/site/components/thread-registry-showcase.tsx
@@ -1,0 +1,746 @@
+"use client";
+
+import {
+  getMessageText,
+  type MessageTreeSnapshot,
+  type ThreadRunHandle,
+} from "@chatjs/thread";
+import { type UseThreadHelpers, useThread } from "@chatjs/thread/react";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Files,
+  GitBranch,
+  Package,
+  Send,
+  Square,
+} from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+type InstallMode = "registry" | "package";
+interface PlaygroundMetadata {
+  activeStreamId: string | null;
+  createdAt: string;
+  title?: string;
+}
+type PlaygroundMessage = UIMessage<PlaygroundMetadata>;
+type PlaygroundChat = UseThreadHelpers<PlaygroundMessage>;
+
+interface StreamBody {
+  tree?: {
+    assistantMessageId?: string;
+    responseLabel?: string;
+  };
+}
+
+interface LayoutNode {
+  depth: number;
+  id: string;
+  x: number;
+  y: number;
+}
+
+const INSTALL_COMMANDS: Record<InstallMode, string> = {
+  registry: "bunx shadcn@latest add FranciscoMoretti/chat-js/thread#main",
+  package: "bun add @chatjs/thread ai @ai-sdk/react",
+};
+
+function createMessage({
+  id,
+  role,
+  text,
+  title,
+}: {
+  id: string;
+  role: "assistant" | "user";
+  text: string;
+  title: string;
+}): PlaygroundMessage {
+  return {
+    id,
+    metadata: {
+      activeStreamId: null,
+      createdAt: new Date().toISOString(),
+      title,
+    },
+    parts: [{ text, type: "text" }],
+    role,
+  };
+}
+
+const initialMessages = [
+  createMessage({
+    id: "msg_01",
+    role: "user",
+    text: "Plan a production launch.",
+    title: "Initial prompt",
+  }),
+  createMessage({
+    id: "msg_02",
+    role: "assistant",
+    text: "Start with architecture, rollout, and observability as separate workstreams.",
+    title: "Initial answer",
+  }),
+  createMessage({
+    id: "msg_03",
+    role: "user",
+    text: "Make the plan technical.",
+    title: "Follow-up",
+  }),
+  createMessage({
+    id: "msg_04a",
+    role: "assistant",
+    text: "Use staged environments, immutable builds, and progressive traffic shifting.",
+    title: "Deployment branch",
+  }),
+  createMessage({
+    id: "msg_05a",
+    role: "user",
+    text: "Add the deployment sequence.",
+    title: "Deployment follow-up",
+  }),
+  createMessage({
+    id: "msg_04b",
+    role: "assistant",
+    text: "Define service-level indicators before rollout and attach alerts to user impact.",
+    title: "Observability branch",
+  }),
+  createMessage({
+    id: "msg_05b",
+    role: "user",
+    text: "Focus on monitoring first.",
+    title: "Observability follow-up",
+  }),
+] satisfies PlaygroundMessage[];
+
+const initialTree: MessageTreeSnapshot<PlaygroundMessage> = {
+  childrenByParentId: {
+    __root__: ["msg_01"],
+    msg_01: ["msg_02"],
+    msg_02: ["msg_03"],
+    msg_03: ["msg_04a", "msg_04b"],
+    msg_04a: ["msg_05a"],
+    msg_04b: ["msg_05b"],
+  },
+  cursorId: "msg_05a",
+  messagesById: Object.fromEntries(
+    initialMessages.map((message) => [message.id, message])
+  ),
+  parentById: {
+    msg_01: null,
+    msg_02: "msg_01",
+    msg_03: "msg_02",
+    msg_04a: "msg_03",
+    msg_04b: "msg_03",
+    msg_05a: "msg_04a",
+    msg_05b: "msg_04b",
+  },
+  rootIds: ["msg_01"],
+  version: 1,
+};
+
+function delay(ms: number, signal?: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+
+    const timeout = window.setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timeout);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true }
+    );
+  });
+}
+
+class PlaygroundTransport implements ChatTransport<PlaygroundMessage> {
+  sendMessages({
+    abortSignal,
+    body,
+    messages,
+  }: Parameters<ChatTransport<PlaygroundMessage>["sendMessages"]>[0]) {
+    const requestBody = body as StreamBody | undefined;
+    const assistantMessageId =
+      requestBody?.tree?.assistantMessageId ?? "assistant";
+    const runId = assistantMessageId;
+    const responseLabel = requestBody?.tree?.responseLabel ?? "Assistant";
+    const userMessage = messages.at(-1);
+    const prompt = userMessage ? getMessageText(userMessage) : "this branch";
+    const response = `${responseLabel}: I am streaming independently from "${prompt}". Select another node while I run, or start more responses from the same prompt.`;
+    const words = response.split(" ");
+
+    return Promise.resolve(
+      new ReadableStream<UIMessageChunk<PlaygroundMetadata>>({
+        async start(controller) {
+          try {
+            controller.enqueue({
+              messageId: assistantMessageId,
+              messageMetadata: {
+                activeStreamId: runId,
+                createdAt: new Date().toISOString(),
+                title: responseLabel,
+              },
+              type: "start",
+            });
+            controller.enqueue({ id: "text", type: "text-start" });
+
+            for (const [index, word] of words.entries()) {
+              await delay(55, abortSignal);
+              controller.enqueue({
+                delta: index === 0 ? word : ` ${word}`,
+                id: "text",
+                type: "text-delta",
+              });
+            }
+
+            controller.enqueue({ id: "text", type: "text-end" });
+            controller.enqueue({
+              finishReason: "stop",
+              messageMetadata: {
+                activeStreamId: null,
+                createdAt: new Date().toISOString(),
+                title: responseLabel,
+              },
+              type: "finish",
+            });
+            controller.close();
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+      })
+    );
+  }
+
+  reconnectToStream() {
+    return Promise.resolve(null);
+  }
+}
+
+function buildTreeLayout({
+  childrenByParentId,
+  rootIds,
+}: {
+  childrenByParentId: Record<string, string[]>;
+  rootIds: string[];
+}) {
+  const positions = new Map<string, LayoutNode>();
+  let nextLeaf = 0;
+  let maxDepth = 0;
+
+  function visit(id: string, depth: number): number {
+    maxDepth = Math.max(maxDepth, depth);
+    const children = childrenByParentId[id] ?? [];
+    let column: number;
+
+    if (children.length === 0) {
+      column = nextLeaf;
+      nextLeaf += 1;
+    } else {
+      const childColumns = children.map((childId) => visit(childId, depth + 1));
+      column =
+        childColumns.reduce((total, childColumn) => total + childColumn, 0) /
+        childColumns.length;
+    }
+
+    positions.set(id, { depth, id, x: column * 172 + 92, y: depth * 104 + 54 });
+    return column;
+  }
+
+  for (const rootId of rootIds) {
+    visit(rootId, 0);
+    nextLeaf += 1;
+  }
+
+  return {
+    height: Math.max(420, (maxDepth + 1) * 104 + 48),
+    nodes: [...positions.values()],
+    positions,
+    width: Math.max(430, Math.max(1, nextLeaf - 1) * 172 + 184),
+  };
+}
+
+export function ThreadInstallCommand() {
+  const [mode, setMode] = useState<InstallMode>("registry");
+  const [copied, setCopied] = useState(false);
+  const command = INSTALL_COMMANDS[mode];
+
+  async function copyCommand() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="mt-8 max-w-3xl border border-border bg-card">
+      <div className="flex items-center justify-between border-border border-b px-3 py-2">
+        <fieldset className="flex items-center gap-1">
+          <legend className="sr-only">Installation method</legend>
+          <button
+            className={`flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ${
+              mode === "registry"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setMode("registry")}
+            type="button"
+          >
+            <Files className="size-3.5" />
+            Registry
+          </button>
+          <button
+            className={`flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ${
+              mode === "package"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setMode("package")}
+            type="button"
+          >
+            <Package className="size-3.5" />
+            Package
+          </button>
+        </fieldset>
+        <button
+          aria-label="Copy installation command"
+          className="grid size-8 place-items-center text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+          onClick={copyCommand}
+          type="button"
+        >
+          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+        </button>
+      </div>
+      <div className="overflow-x-auto px-4 py-4">
+        <code className="whitespace-nowrap font-mono text-sm">
+          <span className="select-none text-muted-foreground">$ </span>
+          {command}
+        </code>
+      </div>
+    </div>
+  );
+}
+
+function Conversation({
+  chat,
+  draft,
+  onBranch,
+  onDraftChange,
+  onResponseCountChange,
+  onSend,
+  responseCount,
+}: {
+  chat: PlaygroundChat;
+  draft: string;
+  onBranch: (messageId: string) => void;
+  onDraftChange: (draft: string) => void;
+  onResponseCountChange: (count: number) => void;
+  onSend: () => void;
+  responseCount: number;
+}) {
+  return (
+    <section className="flex min-h-[43rem] min-w-0 flex-col">
+      <header className="flex min-h-16 flex-wrap items-center justify-between gap-3 border-border border-b px-5 py-3">
+        <div>
+          <p className="font-medium text-sm">Active conversation</p>
+          <p className="font-mono text-[11px] text-muted-foreground">
+            messages = tree.getPath(cursorId)
+          </p>
+        </div>
+        <div className="flex items-center gap-4 font-mono text-[10px]">
+          <span>{chat.messages.length} path nodes</span>
+          <span className="flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
+            <span className="size-1.5 rounded-full bg-current" /> {chat.status}
+          </span>
+        </div>
+      </header>
+
+      <div className="flex-1 space-y-5 overflow-y-auto p-5 sm:p-7">
+        {chat.messages.map((message) => {
+          const isUser = message.role === "user";
+          const siblings = chat.tree.getSiblings(message.id);
+          const siblingIndex = siblings.findIndex(
+            (sibling) => sibling.id === message.id
+          );
+          const hasSiblings = siblings.length > 1 && siblingIndex >= 0;
+
+          function navigateToSibling(nextIndex: number) {
+            const sibling = siblings[nextIndex];
+            if (!sibling) {
+              return;
+            }
+            const leaf = chat.tree.getLeaves(sibling.id).at(-1);
+            chat.tree.setCursor(leaf?.id ?? sibling.id);
+          }
+
+          return (
+            <article
+              className={
+                isUser
+                  ? "group ml-auto max-w-[82%] bg-foreground px-4 py-3 text-background"
+                  : "group max-w-[90%] border-foreground/20 border-l-2 px-4 py-1"
+              }
+              key={message.id}
+            >
+              <div className="mb-1 flex items-center gap-2 text-[10px] uppercase opacity-60">
+                <span>{message.role}</span>
+                <span className="font-mono normal-case">{message.id}</span>
+              </div>
+              <p className="whitespace-pre-wrap text-sm leading-6">
+                {getMessageText(message) || "Streaming..."}
+              </p>
+              <div className="mt-2 flex min-h-7 items-center gap-1 opacity-60 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                <button
+                  className="inline-flex h-7 items-center gap-1.5 px-1 text-[11px] hover:bg-background/10 disabled:opacity-30"
+                  onClick={() => onBranch(message.id)}
+                  type="button"
+                >
+                  <GitBranch className="size-3" />
+                  Branch here
+                </button>
+                {hasSiblings ? (
+                  <fieldset className="ml-auto flex items-center gap-0.5">
+                    <legend className="sr-only">
+                      Branch navigation for {message.id}
+                    </legend>
+                    <button
+                      aria-label={`Previous branch for ${message.id}`}
+                      className="grid size-7 place-items-center hover:bg-background/10 disabled:opacity-30"
+                      disabled={siblingIndex === 0}
+                      onClick={() => navigateToSibling(siblingIndex - 1)}
+                      title="Previous version"
+                      type="button"
+                    >
+                      <ChevronLeft className="size-3.5" />
+                    </button>
+                    <span className="min-w-8 text-center font-mono text-[10px]">
+                      {siblingIndex + 1}/{siblings.length}
+                    </span>
+                    <button
+                      aria-label={`Next branch for ${message.id}`}
+                      className="grid size-7 place-items-center hover:bg-background/10 disabled:opacity-30"
+                      disabled={siblingIndex === siblings.length - 1}
+                      onClick={() => navigateToSibling(siblingIndex + 1)}
+                      title="Next version"
+                      type="button"
+                    >
+                      <ChevronRight className="size-3.5" />
+                    </button>
+                  </fieldset>
+                ) : null}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+
+      <form
+        className="border-border border-t p-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSend();
+        }}
+      >
+        <div className="border border-border focus-within:border-foreground/40">
+          <textarea
+            aria-label="Message this branch"
+            className="block min-h-16 w-full resize-none bg-transparent px-3 py-3 text-sm outline-none"
+            onChange={(event) => onDraftChange(event.target.value)}
+            placeholder={`Continue from ${chat.tree.cursorId ?? "root"}`}
+            rows={2}
+            value={draft}
+          />
+          <div className="flex items-center justify-between gap-2 border-border border-t p-1.5">
+            <label className="flex h-8 items-center gap-1.5 px-2 text-muted-foreground text-xs">
+              <GitBranch className="size-3.5" />
+              <span>Responses</span>
+              <select
+                aria-label="Number of responses"
+                className="bg-transparent font-mono text-foreground outline-none"
+                onChange={(event) =>
+                  onResponseCountChange(Number(event.target.value))
+                }
+                value={responseCount}
+              >
+                {[1, 2, 3, 4].map((count) => (
+                  <option key={count} value={count}>
+                    {count}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="flex items-center gap-1.5">
+              <button
+                aria-label="Stop all responses"
+                className="grid size-8 place-items-center text-muted-foreground hover:bg-secondary hover:text-foreground disabled:opacity-30"
+                disabled={chat.tree.activeRuns.length === 0}
+                onClick={() => chat.tree.stopAll()}
+                title="Stop all responses"
+                type="button"
+              >
+                <Square className="size-3.5" />
+              </button>
+              <button
+                aria-label={`Send message with ${responseCount} ${
+                  responseCount === 1 ? "response" : "responses"
+                }`}
+                className="grid size-8 place-items-center bg-primary text-primary-foreground disabled:opacity-40"
+                disabled={!draft.trim()}
+                title="Send message"
+                type="submit"
+              >
+                <Send className="size-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+        <p className="mt-2 truncate font-mono text-[10px] text-muted-foreground">
+          {chat.lastEvent}
+        </p>
+      </form>
+    </section>
+  );
+}
+
+function TreeCanvas({ chat }: { chat: PlaygroundChat }) {
+  const layout = useMemo(
+    () =>
+      buildTreeLayout({
+        childrenByParentId: chat.tree.childrenByParentId,
+        rootIds: chat.tree.rootIds,
+      }),
+    [chat.tree.childrenByParentId, chat.tree.rootIds]
+  );
+  const activeIds = new Set(chat.messages.map((message) => message.id));
+  const runByMessageId = new Map(
+    chat.tree.activeRuns.map((run) => [run.assistantMessageId, run])
+  );
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <div
+        className="relative"
+        style={{ height: layout.height, width: layout.width }}
+      >
+        <svg
+          aria-hidden="true"
+          className="absolute inset-0 text-border"
+          height={layout.height}
+          width={layout.width}
+        >
+          {layout.nodes.flatMap((node) => {
+            const children = chat.tree.childrenByParentId[node.id] ?? [];
+            return children.map((childId) => {
+              const child = layout.positions.get(childId);
+              if (!child) {
+                return null;
+              }
+              return (
+                <path
+                  d={`M${node.x} ${node.y + 25} V${node.y + 52} H${child.x} V${child.y - 25}`}
+                  fill="none"
+                  key={`${node.id}-${childId}`}
+                  stroke="currentColor"
+                />
+              );
+            });
+          })}
+        </svg>
+
+        {layout.nodes.map((node) => {
+          const message = chat.tree.messagesById[node.id];
+          if (!message) {
+            return null;
+          }
+          const run = runByMessageId.get(node.id);
+          const isActive = activeIds.has(node.id);
+          const isCursor = chat.tree.cursorId === node.id;
+          let nodeClass =
+            "border-border bg-card/90 text-muted-foreground hover:border-foreground/40 hover:text-foreground";
+          if (isActive) {
+            nodeClass = "border-foreground/30 bg-card text-foreground";
+          }
+          if (isCursor) {
+            nodeClass = "border-foreground bg-foreground text-background";
+          }
+
+          return (
+            <button
+              className={`absolute w-36 -translate-x-1/2 -translate-y-1/2 border px-2.5 py-2 text-left shadow-sm transition-colors ${nodeClass}`}
+              key={node.id}
+              onClick={() => chat.tree.setCursor(node.id)}
+              style={{ left: node.x, top: node.y }}
+              type="button"
+            >
+              <span className="flex items-center justify-between gap-2">
+                <span className="truncate font-medium text-[10px] uppercase">
+                  {message.role}
+                </span>
+                <span className="shrink-0 font-mono text-[9px] opacity-60">
+                  {run?.status ?? "ready"}
+                </span>
+              </span>
+              <span className="mt-1 block truncate text-[11px]">
+                {getMessageText(message) || "Streaming..."}
+              </span>
+              <span className="mt-1 block font-mono text-[9px] opacity-55">
+                {node.id} · {getMessageText(message).length} chars
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function ThreadPlayground() {
+  const [draft, setDraft] = useState("");
+  const [responseCount, setResponseCount] = useState(1);
+  const idCounter = useRef(100);
+
+  function generateMessageId() {
+    idCounter.current += 1;
+    return `msg_${idCounter.current}`;
+  }
+
+  const chat = useThread<PlaygroundMessage>({
+    concurrency: { maxActiveRuns: 8 },
+    generateId: generateMessageId,
+    initialTree,
+    transport: new PlaygroundTransport(),
+  });
+
+  function messageInput(text: string, title: string, messageId?: string) {
+    return {
+      messageId,
+      metadata: {
+        activeStreamId: null,
+        createdAt: new Date().toISOString(),
+        title,
+      },
+      text,
+    };
+  }
+
+  async function sendDraft() {
+    const text = draft.trim();
+    if (!text) {
+      return;
+    }
+    const userMessageId = generateMessageId();
+    setDraft("");
+    const primaryRun = await chat.tree.startRun({
+      message: messageInput(text, "Playground message", userMessageId),
+      request: {
+        tree: {
+          responseLabel:
+            responseCount === 1
+              ? "Assistant reply"
+              : `Response 1 of ${responseCount}`,
+        },
+      },
+    });
+
+    const siblingRuns: ThreadRunHandle[] = [];
+    for (let index = 1; index < responseCount; index += 1) {
+      siblingRuns.push(
+        await chat.tree.startRun({
+          follow: false,
+          from: userMessageId,
+          request: {
+            tree: {
+              responseLabel: `Response ${index + 1} of ${responseCount}`,
+            },
+          },
+        })
+      );
+    }
+    await Promise.all([
+      primaryRun.finished,
+      ...siblingRuns.map((run) => run.finished),
+    ]);
+  }
+
+  function branchFrom(messageId: string) {
+    const message = chat.tree.messagesById[messageId];
+    if (!message) {
+      return;
+    }
+    chat.tree.setCursor(messageId);
+    if (message.role === "user") {
+      chat.sendMessage(undefined, {
+        tree: { responseLabel: "Alternative response" },
+      });
+      return;
+    }
+    chat.sendMessage(
+      messageInput(
+        `Take another direction from ${messageId}.`,
+        "Branch prompt"
+      ),
+      { tree: { responseLabel: "Branch response" } }
+    );
+  }
+
+  return (
+    <div className="mt-12 overflow-hidden border border-border bg-card shadow-2xl shadow-foreground/5">
+      <div className="flex min-h-16 flex-wrap items-center justify-between gap-3 border-border border-b px-4 py-3">
+        <div>
+          <p className="font-medium text-sm">useThread playground</p>
+          <p className="text-muted-foreground text-xs">
+            Real tree state with simulated local streams
+          </p>
+        </div>
+        <p className="font-mono text-[10px] text-muted-foreground">
+          {chat.tree.activeRuns.length} active runs
+        </p>
+      </div>
+
+      <div className="grid lg:grid-cols-[minmax(0,0.95fr)_minmax(28rem,1.05fr)]">
+        <Conversation
+          chat={chat}
+          draft={draft}
+          onBranch={branchFrom}
+          onDraftChange={setDraft}
+          onResponseCountChange={setResponseCount}
+          onSend={sendDraft}
+          responseCount={responseCount}
+        />
+        <aside className="flex min-h-[43rem] min-w-0 flex-col border-border border-t bg-muted/15 lg:border-t-0 lg:border-l">
+          <header className="flex min-h-16 items-center justify-between border-border border-b px-5 py-3">
+            <div>
+              <p className="font-medium text-sm">Message tree</p>
+              <p className="font-mono text-[11px] text-muted-foreground">
+                {Object.keys(chat.tree.messagesById).length} nodes ·{" "}
+                {chat.tree.activeRuns.length} runs
+              </p>
+            </div>
+            <GitBranch className="size-4 text-muted-foreground" />
+          </header>
+          <TreeCanvas chat={chat} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export function ThreadRegistryShowcase() {
+  return (
+    <>
+      <ThreadPlayground />
+      <ThreadInstallCommand />
+    </>
+  );
+}

--- a/apps/site/lib/site-config.ts
+++ b/apps/site/lib/site-config.ts
@@ -24,6 +24,7 @@ export const siteConfig = {
 
 export const siteLinks = {
   home: siteConfig.url,
+  threads: `${siteConfig.url}/threads`,
   docs: siteConfig.docsUrl,
   docsGettingStarted: `${siteConfig.docsUrl}/quickstart`,
   desktop: siteConfig.desktopUrl,

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -11,7 +11,10 @@
     "format": "ultracite fix"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.152",
+    "@chatjs/thread": "workspace:*",
     "@vercel/analytics": "^1.5.0",
+    "ai": "^6.0.150",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "0.553.0",

--- a/bun.lock
+++ b/bun.lock
@@ -188,7 +188,10 @@
       "name": "@chatjs/site",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.152",
+        "@chatjs/thread": "workspace:*",
         "@vercel/analytics": "^1.5.0",
+        "ai": "^6.0.150",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "0.553.0",


### PR DESCRIPTION
## Summary
- add a value-first threads page to the website
- demonstrate active-path `useChat` compatibility and full-tree controls
- center the interactive playground and registry installation flow

## Verification
- `bun --filter @chatjs/site lint`
- `bun --filter @chatjs/site test:types`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Threads page that showcases `@chatjs/thread` with a live `useThread` playground for branching conversations on the `ai` SDK `useChat` surface. Includes copyable install commands, canonical/OG metadata, and updated nav, footer, and sitemap links.

- New Features
  - New `/threads` page with canonical and OpenGraph metadata.
  - Interactive playground using `useThread`: branch from any message, navigate the active path, run parallel assistant replies with independent lifecycles, switch sibling versions, stop all runs, and view a live tree canvas backed by real state and a simulated `ChatTransport`.
  - Install widget with copyable `registry` or `package` commands and a link to the README; Navbar/Footer links to Threads and a sitemap entry.

- Dependencies
  - Added `@chatjs/thread`, `@ai-sdk/react`, and `ai` to `@chatjs/site`.

<sup>Written for commit f83c0b57cd524beb3c57ea3097716e3e2e3b492e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. #221
3. #222
4. #223
5. #224
6. #225
7. #226
8. **#227** 👈 current
9. #228
10. #229
<!-- stack:links:end -->