### PR TITLE
Threads 9: Document useThread integration and usage

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
           items: [
             "/core/architecture",
             "/core/configuration",
+            "/core/use-thread",
             "/core/file-storage",
             "/core/authentication",
             "/core/tool-registry",

--- a/apps/docs/core/architecture.mdx
+++ b/apps/docs/core/architecture.mdx
@@ -20,6 +20,7 @@ The application uses:
 - **PostgreSQL** (via [Drizzle ORM](https://orm.drizzle.team)) for persistent data (users, chats, messages, documents)
 - **Redis** for ephemeral data (resumable streams, caching). See [Resumable Streams](/cookbook/resumable-streams)
 - **AI SDK** to connect to multiple AI providers through a [gateway abstraction](/gateways/overview)
+- **`useThread`** to manage the selected conversation path, message tree, and independent response runs. See [useThread](./use-thread)
 - **Files SDK** through a configured [file storage provider](./file-storage) for attachments and generated media
 - **tRPC** for end-to-end type-safe API routes between client and server
 - **Langfuse** (optional) for LLM observability, tracing, and analytics
@@ -30,15 +31,27 @@ When a user sends a message:
 
 ```mermaid
 sequenceDiagram
-    Client->>API: Send message
+    participant Client
+    participant Thread as useThread
+    participant API
+    participant DB
+    participant AI
+    participant Cache
+    Client->>Thread: Send message or start run
+    Thread->>API: Send selected path
     API->>DB: Save messages
     API->>AI: Stream response
-    AI-->>Client: Token stream (SSE)
+    AI-->>API: Model stream
+    API-->>Thread: UI message stream (SSE)
+    Thread-->>Client: Update reserved response node
     Note over API,Cache: Chunks stored in Redis for resumability
     API->>DB: Save final response
 ```
 
-Messages are stored with normalized **parts** (text, tool calls, files, reasoning) allowing efficient querying and streaming updates.
+Messages are stored with normalized **parts** (text, tool calls, files,
+reasoning) allowing efficient querying and streaming updates. Each active
+assistant response has its own run, so navigating to another branch does not
+redirect or stop that response.
 
 If [resumable streams](/cookbook/resumable-streams) are enabled, response chunks are published to Redis so clients can reconnect mid-generation without losing progress.
 

--- a/apps/docs/core/configuration.mdx
+++ b/apps/docs/core/configuration.mdx
@@ -83,7 +83,9 @@ See [Gateways](/gateways/overview) for detailed setup and comparison.
 
 ## Features
 
-Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`. `features` currently contains only attachments. Missing env vars are caught at build time via `bun run prebuild`.
+Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`.
+Application-level flags live under `features`. Missing env vars are caught at
+build time via `bun run prebuild`.
 
 | Feature               | Config Key                            | Env Dependency                                                                           |
 | --------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -96,6 +98,7 @@ Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`. `featur
 | Deep Research         | `ai.tools.deepResearch.enabled`       | `TAVILY_API_KEY` or `FIRECRAWL_API_KEY`                                                  |
 | Follow-up Suggestions | `ai.tools.followupSuggestions.enabled` | Uses your configured language model provider                                              |
 | Attachments           | `features.attachments`                | Configured file storage provider                                                         |
+| Parallel Responses    | `features.parallelResponses`          | None                                                                                     |
 
 ```typescript
 ai: {
@@ -112,6 +115,7 @@ ai: {
 },
 features: {
   attachments: true, // Requires durable file storage
+  parallelResponses: true,
 },
 ```
 

--- a/apps/docs/core/use-thread.mdx
+++ b/apps/docs/core/use-thread.mdx
@@ -1,0 +1,155 @@
+---
+title: "useThread"
+description: "Build branching AI conversations with a useChat-compatible interface"
+---
+
+`useThread` is the React interface to the `ThreadChat` engine behind branching
+conversations in ChatJS. It keeps the familiar AI SDK `useChat` interface for
+the selected conversation while storing every message and response branch in a
+complete tree.
+
+Use it when people need to edit earlier messages, compare alternative replies,
+or move between branches while responses continue streaming.
+
+## Install
+
+```bash
+bun add @chatjs/thread ai @ai-sdk/react
+```
+
+Replace the `useChat` import without changing your existing message list or
+composer:
+
+```diff
+- import { useChat } from "@ai-sdk/react";
++ import { useThread } from "@chatjs/thread/react";
+
+- const chat = useChat({ transport });
++ const chat = useThread({ transport });
+```
+
+The top-level helpers remain compatible with `UseChatHelpers`, including
+`messages`, `sendMessage`, `regenerate`, `stop`, `status`, tools, and approvals.
+
+## Mental model
+
+`useThread` separates four concepts:
+
+- **Tree:** every message and its parent-child relationship
+- **Cursor:** the message currently selected by the application
+- **Active path:** the root-to-cursor messages exposed as `chat.messages`
+- **Run:** one assistant response with its own status, error, and stop control
+
+```mermaid
+flowchart TD
+    U1[User message] --> A1[Assistant response]
+    A1 --> U2[Follow-up]
+    U2 --> A2[Selected response]
+    U2 --> A3[Alternative response]
+```
+
+Moving the cursor changes the active path. It does not delete descendants or
+stop runs on other branches.
+
+## Create a branch
+
+Select any message and send normally. The new user message becomes a child of
+the selected node.
+
+```ts
+chat.tree.setCursor(messageId);
+await chat.sendMessage({ text: "Explore another approach" });
+```
+
+Editing is an application-level operation. Select the original user message's
+parent, then send the replacement as a new message:
+
+```ts
+chat.tree.setCursorToParentOf(originalMessageId);
+await chat.sendMessage({
+  id: crypto.randomUUID(),
+  role: "user",
+  parts: [{ type: "text", text: editedText }],
+});
+```
+
+See [Branching](../features/branching) for the ChatJS user experience.
+
+## Run parallel responses
+
+Each assistant response is an independent run. Start the first response with a
+new user message, then start alternatives from that same user node:
+
+```ts
+const primary = await chat.tree.startRun({
+  message: { text: "Give me three options" },
+  follow: true,
+});
+
+const userMessageId = primary.getSnapshot()?.userMessageId;
+
+if (userMessageId) {
+  const alternatives = await Promise.all([
+    chat.tree.startRun({ from: userMessageId, follow: false }),
+    chat.tree.startRun({ from: userMessageId, follow: false }),
+  ]);
+
+  await Promise.all([
+    primary.finished,
+    ...alternatives.map((run) => run.finished),
+  ]);
+}
+```
+
+`follow: false` leaves the cursor unchanged while the response streams into its
+reserved assistant node. ChatJS uses this model for multiple replies from the
+same model and for comparisons across different models.
+
+See [Parallel Responses](../features/parallel-responses) for the product flow.
+
+## Status and controls
+
+Top-level state describes the selected path:
+
+```ts
+chat.status;
+chat.error;
+await chat.stop();
+```
+
+Tree state describes all runs:
+
+```ts
+chat.tree.status;
+chat.tree.activeRuns;
+chat.tree.runs;
+
+await chat.tree.stopRun(runId);
+await chat.tree.stopAll();
+```
+
+Statuses use the AI SDK values `submitted`, `streaming`, `ready`, and `error`.
+
+## Persist the tree
+
+Save the complete tree instead of only the selected `chat.messages` path:
+
+```ts
+const snapshot = chat.tree.getSnapshot();
+await saveThread(snapshot);
+```
+
+Restore it with `initialTree`:
+
+```ts
+const chat = useThread({
+  initialTree: savedSnapshot,
+  transport,
+});
+```
+
+Snapshots contain messages, parent links, child ordering, roots, and the
+cursor. Active request objects are not persisted.
+
+The package README documents the complete interface, transport metadata, and
+`ThreadChat` exports.

--- a/apps/docs/features/branching.mdx
+++ b/apps/docs/features/branching.mdx
@@ -3,64 +3,59 @@ title: Branching
 description: Explore alternative conversation paths without losing context
 ---
 
-Branching lets you fork a conversation at any point and explore different directions. When you re-submit a message or the AI generates a new response, a branch is created automatically. You can navigate between branches using the sibling controls that appear on messages.
+Branching lets you fork a conversation at any message and explore another
+direction without replacing the original path. Editing a message or generating
+another response creates a sibling that you can return to later.
 
 <Frame>
   <img src="/docs/images/branching.gif" alt="Navigating between conversation branches" />
 </Frame>
 
-## How It Works
+## How it works
 
-Every message stores a `parentMessageId` that forms a tree structure. When you edit a message or regenerate a response, a new child is added under the same parent, creating siblings. The UI displays the active thread (a single root-to-leaf path through the tree) while keeping all branches available.
+Every message has a parent, which forms a conversation tree. ChatJS displays
+one root-to-message path at a time while keeping the other branches available.
 
-## Navigating Branches
+```mermaid
+flowchart TD
+    U1[User: Plan a launch] --> A1[Assistant: Start with architecture]
+    A1 --> U2[User: Make it technical]
+    U2 --> A2[Assistant: Define service indicators]
+    U2 --> A3[Assistant: Use staged environments]
+```
 
-When a message has siblings (alternative versions), arrow controls appear next to it showing the current position (e.g., "2/3"). Click the left or right arrows to switch between branches.
+The selected message is the cursor. Sending a message continues from that
+cursor, so selecting an earlier node before sending creates a new branch.
+
+## Navigate branches
+
+When a message has siblings, arrow controls show the current position, such as
+`2/3`. Use the arrows to move to the previous or next branch.
 
 Switching branches:
 
-- Stops any active stream
-- Clears buffered data
-- Closes artifacts that belong to the previous branch
-- Loads the full thread from the selected sibling down to its most recent leaf
+- changes the active conversation path
+- preserves responses that are still streaming on other branches
+- clears transient data that belongs to the previous path
+- closes an open artifact when its message is not in the selected path
+- follows the selected branch to its latest descendant
 
-## Data Model
+## Edit a message
 
-Messages are stored with a `parentMessageId` column in the database. Root messages have a `null` parent. This creates a tree where each node can have multiple children (siblings).
+Editing creates a replacement branch. The original message and all of its
+descendants remain in the tree, so you can switch back with the same sibling
+controls.
 
-```mermaid
-graph TD
-    A[User: Hello] --> B[AI: Hi there!]
-    A --> C[AI: Hey! How can I help?]
-    B --> D[User: Tell me about X]
-    C --> E[User: Tell me about Y]
-    D --> F[AI: X is...]
-    E --> G[AI: Y is...]
-```
+## Data model
 
-## Architecture
+Messages are persisted with a parent message ID. Root messages have no parent.
+The client uses `useThread` to project the selected path and to keep each active
+assistant response attached to its own reserved node.
 
-The branching system has three layers:
+See [useThread](../core/use-thread) for the tree, cursor, active-path, and run
+model.
 
-### Tree Utilities (`lib/thread-utils.ts`)
+## Related
 
-Pure functions that operate on the message tree:
-
-- `buildThreadFromLeaf` - walks `parentMessageId` links from a leaf to the root to construct the active thread
-- `buildChildrenMap` - creates a parent-to-children index sorted by creation time
-- `getDefaultThread` - finds the most recent leaf and builds the thread to it
-- `findLeafDfsToRightFromMessageId` - DFS to find the rightmost leaf from a given node (used when switching branches)
-
-### Zustand Middleware (`lib/stores/with-threads.ts`)
-
-A `withThreads` middleware wraps the base chat store and adds:
-
-- `allMessages` - the complete message tree (all branches)
-- `childrenMap` - reactive parent-to-children index, rebuilt when `allMessages` changes
-- `getMessageSiblingInfo` - looks up siblings and current index for any message
-- `switchToSibling` - finds the target sibling, walks to its rightmost leaf, builds the new thread, and swaps it in
-- `threadEpoch` - a counter that bumps on thread switches, used as a React key to remount `useChat`
-
-### Server Sync (`components/message-tree-sync.tsx`)
-
-`MessageTreeSync` is a renderless component that fetches the full message tree from the server via React Query and feeds it into the Zustand store with `setAllMessages`. It also handles resetting state when navigating to the home page.
+- [Parallel Responses](./parallel-responses)
+- [Architecture](../core/architecture)

--- a/apps/docs/features/parallel-responses.mdx
+++ b/apps/docs/features/parallel-responses.mdx
@@ -1,52 +1,64 @@
 ---
 title: Parallel Responses
-description: Send one message to multiple models simultaneously and compare their answers side by side
+description: Generate independent replies from one or more models and compare them as conversation branches
 ---
 
-Parallel responses let you select more than one model before submitting a message. ChatJS fans the request out to every selected model at the same time and displays each answer as a clickable card. You can then pick the response you want to continue the conversation with.
+Parallel responses let you request several replies to one user message. You can
+compare different models, ask one model for multiple alternatives, or combine
+both approaches in the same response group.
 
-## How to Use
+## Request responses
 
 1. Open the model selector in the chat input.
-2. Toggle **Use Multiple Models**.
-3. Select two or more models. Each model shows a count badge when it is part of the parallel set.
-4. Type your message and submit.
+2. Enable **Use Multiple Models**.
+3. Select the models you want to use.
+4. Set the response count for each selected model.
+5. Send your message.
 
-Each model starts streaming immediately. A row of cards appears above the message showing the model name and current status. Click any card to switch the active thread to that response.
+The total response count must be greater than one. Selecting one model with a
+count of three creates three independent replies from that model. Selecting
+three models with a count of one creates one reply from each model.
 
 <Callout type="note">
   Parallel responses require authentication. Anonymous sessions are limited to a
   single model per request.
 </Callout>
 
-## Response Cards
+## Independent runs
 
-Each card in the batch displays:
-
-- The model label
-- A streaming indicator while the response is being generated
-- One of three states: **Generating**, **Task completed**, or **Selected**
-
-Clicking a card runs `switchToMessage`, which rebuilds the visible thread from that assistant branch down to its most recent leaf. The previously selected branch is preserved and you can return to it at any time by clicking its card again.
+ChatJS reserves a message ID for each response and attaches it to an
+independent branch. In an active conversation, secondary responses use
+`useThread` runs with their own streaming state and stop control.
 
 ```mermaid
-graph TD
-    U[User message] --> A[Claude response]
-    U --> B[GPT-4o response]
-    U --> C[Gemini response]
-    A -->|Selected| D[Next user message]
+flowchart TD
+    U[User message] --> A[Model A, response 1]
+    U --> B[Model A, response 2]
+    U --> C[Model B, response 1]
 ```
 
-## Continuing the Conversation
+The first response becomes the selected path. Other responses use background
+runs, so they continue streaming when you select another response or navigate
+to a different branch.
 
-After you select a card, the conversation continues from that branch as a normal single-model thread. Subsequent messages go only to the model of the selected branch. You can always navigate back up and pick a different card before sending a follow-up.
+## Response cards
 
-## Current Constraints
+A card appears for each requested response and shows its model and current
+state. Select a card to make that response the active conversation path.
 
-- Parallel responses are not available when the message includes attachments. Mixed model capabilities across attachment types are not yet supported.
-- Each model in the parallel set is billed as a separate request.
+After selecting a response, new messages continue from that branch. The other
+responses remain available, including any that are still generating.
+
+## Current constraints
+
+- Attachments cannot be combined with parallel responses yet.
+- Each response is billed as a separate model request.
+- Stopping the selected response does not stop other active runs. Use the
+  branch controls to select another response, or stop all runs through the
+  `ThreadChat` engine.
 
 ## Related
 
-- [Branching](/features/branching) - how the underlying thread tree works
-- [Multi-Model Support](/core/multi-model) - configuring which models are available
+- [useThread](../core/use-thread)
+- [Branching](./branching)
+- [Multi-Model Support](../core/multi-model)

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -112,3 +112,4 @@ npx @chat-js/cli@latest create my-app
 - [Streamdown](https://streamdown.ai/) - Markdown for AI streaming
 - [AI Elements](https://ai-sdk.dev/elements/overview) - AI-native Components
 - [AI SDK Tools](https://ai-sdk-tools.dev/) - Developer tools for AI SDK
+- [`@chatjs/thread`](./core/use-thread) - Branching conversations with a `useChat`-compatible interface

--- a/apps/docs/reference/config.mdx
+++ b/apps/docs/reference/config.mdx
@@ -134,6 +134,8 @@ export type Config = {
   features: {
     /** File attachments (requires durable file storage) */
     attachments: boolean;
+    /** Generate multiple independent responses for one message */
+    parallelResponses: boolean;
   };
 
   pricing?: PricingConfig;
@@ -205,6 +207,7 @@ Feature flags live under `ai.tools`, `features`, and `authentication`. They're v
 ### Features
 
 - **`features.attachments`**: requires a configured file storage provider - file uploads (images and PDFs)
+- **`features.parallelResponses`**: no extra environment variables - generate multiple independent responses for one message
 
 ### Authentication
 

--- a/packages/thread/README.md
+++ b/packages/thread/README.md
@@ -1,0 +1,481 @@
+# @chatjs/thread
+
+Build branching AI chats without giving up the `useChat` API.
+
+`@chatjs/thread` turns a linear AI SDK conversation into a message tree. Users
+can edit an earlier message, compare multiple responses, move between branches,
+and keep streams running on branches that are not currently visible.
+
+```tsx
+const chat = useThread({ transport });
+
+chat.messages; // The selected conversation path, just like useChat
+chat.tree.setCursor(messageId); // Select any point in the tree
+await chat.sendMessage({ text: "Try another direction" }); // Branch from it
+```
+
+The package is headless. It owns message topology and request lifecycles, while
+your application owns the conversation UI, branch controls, and persistence.
+
+## Why useThread?
+
+- **A familiar migration path.** `useThread` is assignable to AI SDK's
+  `UseChatHelpers`. Existing chat rendering and composer code can keep using
+  `messages`, `sendMessage`, `regenerate`, `stop`, `status`, and `error`.
+- **Branch from any message.** Move a cursor to an earlier node and send as
+  usual. Existing descendants are preserved as another branch.
+- **Run branches concurrently.** Every response has an isolated AI SDK request
+  lifecycle. Switching branches does not abort streams on hidden branches.
+- **Keep AI SDK behavior.** `ThreadChat` uses the caller's `ChatTransport` and
+  AI SDK's request orchestration, including tools, approvals, data parts,
+  automatic follow-ups, cancellation, and reconnection.
+- **Bring your own UI and storage.** The public tree is plain messages, IDs, and
+  edges. No component library or database model is imposed.
+
+## Installation
+
+Install the package and its AI SDK peer dependencies:
+
+```bash
+bun add @chatjs/thread ai @ai-sdk/react
+```
+
+Or copy the source into an application with the ChatJS shadcn registry:
+
+```bash
+bunx shadcn@latest add FranciscoMoretti/chat-js/thread#main
+```
+
+The optional registry demo includes an application-owned conversation and tree
+UI:
+
+```bash
+bunx shadcn@latest add FranciscoMoretti/chat-js/thread-demo#main
+```
+
+## Quick start
+
+Use the same transport you would pass to `useChat`:
+
+```tsx
+"use client";
+
+import { DefaultChatTransport } from "ai";
+import { useThread } from "@chatjs/thread/react";
+import { useState } from "react";
+
+const transport = new DefaultChatTransport({ api: "/api/chat" });
+
+export function Chat() {
+  const [input, setInput] = useState("");
+  const chat = useThread({ transport });
+
+  return (
+    <main>
+      {chat.messages.map((message) => (
+        <article key={message.id}>
+          <strong>{message.role}</strong>
+          {message.parts.map((part, index) =>
+            part.type === "text" ? <p key={index}>{part.text}</p> : null
+          )}
+        </article>
+      ))}
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!input.trim()) return;
+          chat.sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input
+          onChange={(event) => setInput(event.target.value)}
+          value={input}
+        />
+        <button disabled={chat.status !== "ready"} type="submit">
+          Send
+        </button>
+      </form>
+    </main>
+  );
+}
+```
+
+At the top level, the hook behaves like a normal linear chat. The difference is
+that `messages` is a projection of the tree from its root to `tree.cursorId`.
+
+## The mental model
+
+`ThreadChat` stores every message once and records its parent:
+
+```text
+user: Plan a launch
+└── assistant: Start with architecture
+    └── user: Make it technical
+        ├── assistant: Define service-level indicators  <- selected cursor
+        └── assistant: Use staged environments
+```
+
+There are three distinct concepts:
+
+1. **Tree:** all messages and parent-child relationships.
+2. **Cursor:** the last message in the path currently shown by `chat.messages`.
+3. **Run:** one assistant request, with its own status, error, and abort
+   controller.
+
+Moving the cursor only changes the visible path. It does not delete descendants
+or stop active runs.
+
+## Create a branch
+
+Select the message to continue from, then call `sendMessage` normally:
+
+```ts
+chat.tree.setCursor(messageId);
+await chat.sendMessage({ text: "Explore a different approach" });
+```
+
+The new user message becomes a child of `messageId`, followed by its assistant
+response. Because `sendMessage` follows the selected cursor by default, the new
+branch becomes the active conversation.
+
+This is also the edit-message pattern. Editing is an application-level action:
+select the edited message's parent and send the replacement as a new message.
+The original message and its descendants remain available.
+
+```ts
+chat.tree.setCursorToParentOf(originalUserMessageId);
+await chat.sendMessage({
+  id: crypto.randomUUID(),
+  role: "user",
+  parts: [{ type: "text", text: editedText }],
+});
+```
+
+To display sibling controls:
+
+```ts
+const siblings = chat.tree.getSiblings(messageId);
+const index = siblings.findIndex((message) => message.id === messageId);
+
+function showSibling(offset: number) {
+  const sibling = siblings[index + offset];
+  if (sibling) chat.tree.setCursor(sibling.id);
+}
+```
+
+## Request parallel responses
+
+`sendMessage` intentionally keeps the AI SDK completion contract: its promise
+resolves when the request and automatic tool follow-ups finish. Use
+`tree.startRun` when you need an immediate run handle or multiple responses.
+
+First add a user message and start its primary response:
+
+```ts
+const primary = await chat.tree.startRun({
+  message: { text: "Give me three implementation plans" },
+  follow: true,
+});
+```
+
+Then start more assistant responses from the same user node:
+
+```ts
+const alternativeA = await chat.tree.startRun({
+  from: primary.getSnapshot()?.userMessageId,
+  follow: false,
+});
+
+const alternativeB = await chat.tree.startRun({
+  from: primary.getSnapshot()?.userMessageId,
+  follow: false,
+});
+
+await Promise.all([
+  primary.finished,
+  alternativeA.finished,
+  alternativeB.finished,
+]);
+```
+
+`follow: false` leaves the cursor where it is while the response streams into
+the tree. Each returned handle can be inspected or stopped independently:
+
+```ts
+primary.id;
+primary.assistantMessageId;
+primary.getSnapshot();
+await primary.stop();
+```
+
+Set concurrency limits when creating the hook:
+
+```ts
+const chat = useThread({
+  transport,
+  concurrency: {
+    maxActiveRuns: 4,
+    maxActiveRunsPerMessage: 3,
+  },
+});
+```
+
+## Active path versus whole tree
+
+The top-level API always describes the selected path and selected run:
+
+```ts
+chat.messages;
+chat.status;
+chat.error;
+await chat.stop();
+chat.clearError();
+await chat.resumeStream();
+```
+
+Whole-tree state and controls live under `tree`:
+
+```ts
+chat.tree.cursorId;
+chat.tree.status;
+chat.tree.activeRuns;
+chat.tree.runs;
+
+chat.tree.messagesById;
+chat.tree.parentById;
+chat.tree.childrenByParentId;
+chat.tree.rootIds;
+
+chat.tree.getMessage(messageId);
+chat.tree.getParent(messageId);
+chat.tree.getChildren(messageId);
+chat.tree.getSiblings(messageId);
+chat.tree.getLeaves(messageId);
+chat.tree.getPath(messageId);
+```
+
+`chat.status` uses AI SDK's `submitted`, `streaming`, `ready`, and `error`
+states for the selected path. `chat.tree.status` aggregates every run. A run is
+included in `activeRuns` while it is `submitted` or `streaming`.
+
+Target a specific run without moving the cursor:
+
+```ts
+const run = chat.tree.getRun(runId);
+const messageRun = chat.tree.getRunForMessage(assistantMessageId);
+
+await chat.tree.stopRun(runId);
+await chat.tree.stopRunForMessage(assistantMessageId);
+await chat.tree.resumeRun(runId);
+await chat.tree.stopAll();
+```
+
+## Migrating from useChat
+
+For a conventional chat component, the initial migration is usually an import
+change:
+
+```diff
+- import { useChat } from "@ai-sdk/react";
++ import { useThread } from "@chatjs/thread/react";
+
+- const chat = useChat({ transport });
++ const chat = useThread({ transport });
+```
+
+`UseThreadHelpers<TMessage>` extends `UseChatHelpers<TMessage>`. These standard
+helpers retain their normal signatures:
+
+- `messages`, `sendMessage`, and `setMessages`
+- `status`, `error`, `stop`, and `clearError`
+- `regenerate` and `resumeStream`
+- `addToolOutput`, `addToolResult`, and `addToolApprovalResponse`
+
+There are two tree-specific behavioral details:
+
+- Top-level state refers to the selected path, not every active branch.
+- `setMessages` reconciles the selected path. Truncating it moves the cursor
+  backward without deleting hidden descendants; changing its suffix creates a
+  branch. A message ID cannot be reused under a different parent.
+
+## Tools and approvals
+
+Tool outputs and approval responses use the standard `useChat` signatures.
+`ThreadChat` records which run emitted each tool call or approval ID and routes
+the response back to that run, even when another branch is selected.
+
+Tool call and approval IDs must be unique across active runs.
+
+## Persistence
+
+Save the complete tree rather than only `chat.messages`:
+
+```ts
+const snapshot = chat.tree.getSnapshot();
+await saveThread(snapshot);
+```
+
+Restore it when creating the hook:
+
+```ts
+const chat = useThread({
+  initialTree: savedSnapshot,
+  transport,
+});
+```
+
+Snapshots contain serializable message and topology state:
+
+```ts
+type MessageTreeSnapshot<TMessage> = {
+  version: 1;
+  cursorId: string | null;
+  messagesById: Record<string, TMessage>;
+  parentById: Record<string, string | null>;
+  childrenByParentId: Record<string, string[]>;
+  rootIds: string[];
+};
+```
+
+Runs are request-lifecycle state and are not persisted in the tree snapshot.
+Resumable assistant messages can be restored and resumed through
+`resumeStream` or `tree.resumeRun`.
+
+## Transport and server integration
+
+`useThread` accepts AI SDK `ChatTransport` implementations directly. It does
+not define another transport protocol or parse stream chunks itself.
+
+Every request includes branch context in its body while preserving your custom
+request body fields:
+
+```ts
+{
+  assistantMessageId,
+  tree: {
+    assistantMessageId,
+    cursorId,
+    originCursorId,
+    parentMessageId,
+    pathIds,
+    userMessageId
+  }
+}
+```
+
+Servers that only need a linear model history can ignore this metadata; the
+transport still receives the selected path. Persist the IDs when the server
+also needs to reconstruct branches or associate streams with message nodes.
+
+For resumable HTTP streams, reconnect by assistant message ID using AI SDK's
+native transport hook. Your server can resolve that stable message identity to
+an infrastructure-specific stream ID:
+
+```ts
+const transport = new DefaultChatTransport({
+  api: "/api/chat",
+  prepareReconnectToStreamRequest({ body, id }) {
+    const messageId = body?.assistantMessageId;
+    return {
+      api: `/api/chat/${id}/stream?messageId=${messageId}`,
+    };
+  },
+});
+```
+
+## Externally owned ThreadChat
+
+Create `ThreadChat` outside React when it must outlive a component or be shared
+with application infrastructure:
+
+```tsx
+import { createThreadChat } from "@chatjs/thread";
+import { useThread } from "@chatjs/thread/react";
+
+const threadChat = createThreadChat({ transport });
+
+function Chat() {
+  const chat = useThread({ chat: threadChat });
+  // ...
+}
+```
+
+This is the instance-level equivalent of supplying an externally owned chat to
+`useChat`.
+
+## How it works
+
+`ThreadChat` uses a canonical tree plus one isolated AI SDK chat engine per
+active request:
+
+```text
+useThread
+  └── ThreadChat
+      ├── message tree (nodes, edges, cursor)
+      ├── run registry
+      │   ├── run A -> AI SDK AbstractChat -> ChatTransport
+      │   ├── run B -> AI SDK AbstractChat -> ChatTransport
+      │   └── run C -> AI SDK AbstractChat -> ChatTransport
+      └── React subscription snapshot
+```
+
+`ThreadChat` owns tree topology, cursor selection, run identity, and
+concurrency policy. Each run owns one AI SDK request lifecycle and abort
+controller. All runs use the caller-provided transport.
+
+This design matters because one linear `useChat` instance has one active
+message array and request lifecycle. Replacing that array during branch
+navigation can abort, reconnect, or misroute an in-flight response. Isolated
+runs continue writing to their reserved assistant nodes regardless of which
+path is visible.
+
+The implementation deliberately reuses AI SDK's `AbstractChat` orchestration
+instead of maintaining a custom stream reducer. That preserves standard stream
+parts, tools, approvals, callbacks, automatic sends, cancellation, and resume
+behavior while the package adds tree ownership around it.
+
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the ownership model, evaluated
+alternatives, and the differential coverage behind this decision.
+
+## Exports
+
+React APIs are exported from `@chatjs/thread/react`:
+
+```ts
+useThread;
+type UseThreadOptions;
+type UseThreadHelpers;
+type TreeHelpers;
+```
+
+Chat engine APIs and types are exported from `@chatjs/thread`:
+
+```ts
+createThreadChat;
+ThreadChat;
+getMessageText;
+ROOT_PARENT_ID;
+
+type MessageTreeSnapshot;
+type ThreadConcurrency;
+type ThreadEvent;
+type ThreadRun;
+type ThreadRunHandle;
+type ThreadChatOptions;
+type ThreadStartRunOptions;
+type TreeSendOptions;
+type ThreadStateSnapshot;
+```
+
+## Scope
+
+The package does not include chat components, branch controls, tree diagrams,
+storage adapters, or server routes. Those remain application concerns because
+their design and persistence requirements vary substantially. The package
+provides the headless state and controls needed to build them.
+
+## License
+
+Apache-2.0

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -46,8 +46,8 @@
 	},
 	"scripts": {
 		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external && bun build ./src/react.ts --outfile ./dist/react.js --target=browser --format=esm --packages external --banner='\"use client\";'",
-		"format": "bunx @biomejs/biome@2.4.10 check --write src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
-		"lint": "bunx @biomejs/biome@2.4.10 check src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"format": "bunx @biomejs/biome@2.4.10 check --write src test *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"lint": "bunx @biomejs/biome@2.4.10 check src test README.md ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
 		"test": "bun test ./test",
 		"test:unit": "bun test ./test",


### PR DESCRIPTION
## Summary
- add the package README and useThread integration guide
- document ChatJS configuration, branching, parallel responses, and migration
- add the useThread guide to the Blume navigation

## Verification
- `bun --filter @chatjs/thread lint`
- `bun --filter @chatjs/thread test:types`
- `bun --filter @chatjs/thread build`
- `bun docs:links`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive docs for `useThread` and how it fits into the app architecture, plus clearer guides for branching and parallel responses. Also adds a full `@chatjs/thread` README and documents the `features.parallelResponses` flag.

- **New Features**
  - New `useThread` guide: install, mental model (tree/cursor/active path/run), branching/editing, parallel runs with `tree.startRun`, status/controls, concurrency, snapshots (`initialTree`), transport metadata, and reconnect by assistant message ID.
  - Architecture updated: data flow and sequence diagram include `useThread`; explains independent runs that keep streaming across branches.
  - Branching docs rewritten: cursor-based navigation, sibling arrows, switching behavior (preserves other runs, clears transient UI, follows latest leaf), and edit-as-branch.
  - Parallel Responses expanded: per-model counts, background runs, response cards, and constraints (no attachments, per-response billing, stopping one run doesn’t stop others).
  - Added `@chatjs/thread` README: design overview, API/exports, run model, concurrency, persistence, transport integration, resumable streams, and external ownership via `createThreadChat`.
  - Docs nav/index link to `@chatjs/thread`; config and reference document `features.parallelResponses`.
  - Package scripts updated to lint/format markdown files (wildcard `*.md`, `README.md`, `ARCHITECTURE.md`).

<sup>Written for commit 12ba968397446b89a1f9ffbc050a5ed8b1a5eb34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #220
2. #221
3. #222
4. #223
5. #224
6. #225
7. #226
8. #227
9. **#228** 👈 current
10. #229
<!-- stack:links:end -->