### PR TITLE
Fix Blume docs review findings

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -24,7 +24,7 @@ Send one message to multiple models at the same time and compare their answers s
 
 ### Video Generation
 
-Generate short video clips from text prompts directly in chat, with inline playback. Enable via `config.ai.tools.videoGeneration.enabled` (requires a gateway with video model support).
+Generate short video clips from text prompts directly in chat, with inline playback. Enable via `config.ai.tools.video.enabled` (requires a gateway with video model support).
 
 ### Interactive Charts
 

--- a/apps/docs/cookbook/follow-up-questions.mdx
+++ b/apps/docs/cookbook/follow-up-questions.mdx
@@ -30,24 +30,31 @@ import type { StreamWriter } from "@/lib/ai/types";
 import { config } from "@/lib/config";
 import { generateUUID } from "@/lib/utils";
 
+const FOLLOWUP_CONTEXT_MESSAGES = 2;
+
 export async function generateFollowupSuggestions(
   modelMessages: ModelMessage[]
 ) {
+  const maxQuestionCount = 5;
+  const minQuestionCount = 3;
+  const maxCharactersPerQuestion = 80;
+  const recentMessages = modelMessages.slice(-FOLLOWUP_CONTEXT_MESSAGES);
+
   return streamText({
-    model: await getLanguageModel(
-      config.models.defaults.followupSuggestions
-    ),
+    model: await getLanguageModel(config.ai.tools.followupSuggestions.default),
     messages: [
-      ...modelMessages,
+      ...recentMessages,
       {
         role: "user",
-        content:
-          "What question should I ask next? Return an array of 3-5 suggestions, max 80 chars each.",
+        content: `What question should I ask next? Return an array of suggested questions (minimum ${minQuestionCount}, maximum ${maxQuestionCount}). Each question should be no more than ${maxCharactersPerQuestion} characters.`,
       },
     ],
     output: Output.object({
       schema: z.object({
-        suggestions: z.array(z.string()).min(3).max(5),
+        suggestions: z
+          .array(z.string())
+          .min(minQuestionCount)
+          .max(maxQuestionCount),
       }),
     }),
   });
@@ -85,25 +92,28 @@ await result.consumeStream();
 const response = await result.response;
 const responseMessages = response.messages;
 
-// Generate and stream follow-up suggestions
-const followupSuggestionsResult = generateFollowupSuggestions([
-  ...contextForLLM,
-  ...responseMessages,
-]);
-await streamFollowupSuggestions({
-  followupSuggestionsResult,
-  writer: dataStream,
-});
+if (config.ai.tools.followupSuggestions.enabled) {
+  const followupSuggestionsResult = generateFollowupSuggestions([
+    ...contextForLLM,
+    ...responseMessages,
+  ]);
+  await streamFollowupSuggestions({
+    followupSuggestionsResult,
+    writer: dataStream,
+  });
+}
 ```
 
 ### 3. Ignore Data Parts in Conversion
 
 ```ts title="lib/ai/core-chat-agent.ts"
 import { convertToModelMessages } from "ai";
+import { filterPartsForLLM } from "@/app/(chat)/api/chat/filter-reasoning-parts";
 
 // Convert to model messages, ignoring data-* parts (UI-only)
-const modelMessages = await convertToModelMessages(messages, {
-  convertDataPart: () => undefined, // Ignores all data-* parts
+const filteredMessages = filterPartsForLLM(messages);
+const modelMessages = await convertToModelMessages(filteredMessages, {
+  convertDataPart: (_part): undefined => undefined,
 });
 ```
 
@@ -112,14 +122,57 @@ const modelMessages = await convertToModelMessages(messages, {
 ```tsx title="components/followup-suggestions.tsx"
 "use client";
 
-import { useChatStoreApi } from "@ai-sdk-tools/store";
+import { useCallback } from "react";
+import { useChatStoreApi } from "@/lib/stores/base";
 import { useMessageIds } from "@/lib/stores/hooks-base";
 import {
   useMessagePartByPartIdx,
   useMessagePartTypesById,
 } from "@/lib/stores/hooks-message-parts";
-import type { ChatMessage } from "@/lib/ai/types";
+import type { ChatMessage, UiToolName } from "@/lib/ai/types";
 import { generateUUID } from "@/lib/utils";
+import { useChatInput } from "@/providers/chat-input-provider";
+
+function FollowUpSuggestions({ suggestions }: { suggestions: string[] }) {
+  const storeApi = useChatStoreApi();
+  const { selectedModelId, selectedTool } = useChatInput();
+
+  const handleClick = useCallback(
+    (suggestion: string) => {
+      const sendMessage = storeApi.getState().sendMessage;
+      if (!sendMessage) return;
+
+      const message: ChatMessage = {
+        id: generateUUID(),
+        role: "user",
+        parts: [{ type: "text", text: suggestion }],
+        metadata: {
+          createdAt: new Date(),
+          parentMessageId: storeApi.getState().getLastMessageId(),
+          selectedModel: selectedModelId,
+          activeStreamId: null,
+          selectedTool: (selectedTool as UiToolName | null) || undefined,
+        },
+      };
+
+      sendMessage(message);
+    },
+    [storeApi, selectedModelId, selectedTool]
+  );
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div>
+      <div>Related</div>
+      {suggestions.map((suggestion) => (
+        <button key={suggestion} onClick={() => handleClick(suggestion)}>
+          {suggestion}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export function FollowUpSuggestionsParts({ messageId }: { messageId: string }) {
   const types = useMessagePartTypesById(messageId);
@@ -153,50 +206,5 @@ function FollowUpSuggestionsPart({
   );
 
   return <FollowUpSuggestions suggestions={part.data.suggestions} />;
-}
-
-export function FollowUpSuggestions({
-  suggestions,
-}: {
-  suggestions: string[];
-}) {
-  const storeApi = useChatStoreApi();
-
-  const handleClick = (suggestion: string) => {
-    const sendMessage = storeApi.getState().sendMessage;
-    const parentMessageId = storeApi.getState().getLastMessageId();
-
-    const message: ChatMessage = {
-      id: generateUUID(),
-      role: "user",
-      parts: [{ type: "text", text: suggestion }],
-      metadata: {
-        createdAt: new Date(),
-        parentMessageId,
-        selectedModel: "your-default-model", // Get from context
-      },
-    };
-
-    sendMessage(message);
-  };
-
-  if (!suggestions?.length) return null;
-
-  return (
-    <div className="mt-2 flex flex-col gap-2">
-      <div className="text-xs text-muted-foreground">Related</div>
-      <div className="flex flex-wrap gap-1.5">
-        {suggestions.map((s) => (
-          <button
-            key={s}
-            onClick={() => handleClick(s)}
-            className="rounded-md border px-2 py-1 text-sm hover:bg-muted"
-          >
-            {s}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
 }
 ```

--- a/apps/docs/core/authentication.mdx
+++ b/apps/docs/core/authentication.mdx
@@ -157,7 +157,7 @@ anonymous: {
 Available models for anonymous users are set separately:
 
 ```typescript title="chat.config.ts"
-models: {
+ai: {
   anonymousModels: [
     "google/gemini-2.5-flash-lite",
     "openai/gpt-5-nano",
@@ -187,4 +187,4 @@ Better Auth supports many OAuth 2.0 / OIDC providers (Discord, Twitter/X, Apple,
 4. Register the OAuth app with the provider, setting the redirect URI to `/api/auth/callback/[provider]`.
 5. Optionally, gate it behind a new flag in `authenticationConfigSchema` in `apps/chat/lib/config-schema.ts`.
 
-See the [Better Auth social providers docs](https://better-auth.com/docs/authentication/social-providers) for the full list and provider-specific options.
+See the [Better Auth OAuth guide](https://better-auth.com/docs/concepts/oauth) for the social-provider configuration model, then choose a provider from the Authentication section of the Better Auth docs for provider-specific options.

--- a/apps/docs/core/multi-model.mdx
+++ b/apps/docs/core/multi-model.mdx
@@ -3,7 +3,7 @@ title: "Multi-Model Support"
 description: "Access hundreds of AI models through a pluggable gateway abstraction"
 ---
 
-ChatJS provides access to hundreds of models from multiple providers through a pluggable [gateway system](/gateways/overview). Set `models.gateway` in `chat.config.ts` to choose your backend, then configure which models are available and how they behave.
+ChatJS provides access to hundreds of models from multiple providers through a pluggable [gateway system](/gateways/overview). Set `ai.gateway` in `chat.config.ts` to choose your backend, then configure which models are available and how they behave.
 
 <Frame>
   <img src="/docs/images/ai-models.gif" alt="Switching between AI models in the model selector" />
@@ -13,10 +13,11 @@ See [Gateways](/gateways/overview) for setup instructions and the full gateway c
 
 ## Model Configuration
 
-All model settings live in `chat.config.ts` under the `models` key:
+All model settings live in `chat.config.ts` under the `ai` key:
 
 ```typescript title="chat.config.ts"
-models: {
+ai: {
+  gateway: "vercel",
   providerOrder: ["openai", "google", "anthropic", "xai"],
   disabledModels: ["morph/morph-v3-large", "morph/morph-v3-fast"],
   curatedDefaults: [
@@ -31,26 +32,33 @@ models: {
     "openai/gpt-5-mini",
     // ...
   ],
-  defaults: {
+  workflows: {
     chat: "openai/gpt-5-nano",
     title: "google/gemini-2.5-flash-lite",
     pdf: "openai/gpt-5-mini",
-    artifact: "openai/gpt-5-nano",
-    // ...
+    chatImageCompatible: "openai/gpt-4o-mini",
+  },
+  tools: {
+    image: {
+      enabled: true,
+      default: "google/gemini-3-pro-image",
+    },
   },
 },
 ```
 
-| Setting           | Description                             |
-| ----------------- | --------------------------------------- |
-| `providerOrder`   | Provider sort order in model selector   |
-| `disabledModels`  | Models hidden from all users            |
-| `curatedDefaults` | Models enabled by default for new users |
-| `anonymousModels` | Models available to anonymous users     |
-| `defaults.*`      | Default model for each task type        |
+| Setting                    | Description                                      |
+| -------------------------- | ------------------------------------------------ |
+| `ai.gateway`               | Active AI gateway                                |
+| `ai.providerOrder`         | Provider sort order in the model selector        |
+| `ai.disabledModels`        | Models hidden from all users                     |
+| `ai.curatedDefaults`       | Models enabled by default for new users          |
+| `ai.anonymousModels`       | Models available to anonymous users              |
+| `ai.workflows.*`           | Default models for shared application workflows  |
+| `ai.tools.*`               | Tool enablement and tool-specific model defaults |
 
 <Callout type="note">
-Image generation uses a separate `defaults.image` setting. Language models with the `image-generation` tag can also generate images inline. See [Image Generation](/features/image-generation) for details.
+Image generation uses `ai.tools.image.default`. Language models with the `image-generation` tag can also generate images inline. See [Image Generation](/features/image-generation) for details.
 </Callout>
 
 ## Reasoning Variants
@@ -68,14 +76,14 @@ Model visibility is determined through a pipeline:
 
 ### Authenticated Users
 
-1. **Remove** disabled models (`models.disabledModels`)
-2. **Apply defaults** (`models.curatedDefaults` + any new API models not in `models.generated.ts`)
+1. **Remove** disabled models (`ai.disabledModels`)
+2. **Apply defaults** (`ai.curatedDefaults` plus any new API models not in `models.generated.ts`)
 3. **Apply user overrides** from saved preferences
 
 ### Anonymous Users
 
 1. **Remove** disabled models
-2. **Filter** to `models.anonymousModels` only
+2. **Filter** to `ai.anonymousModels` only
 
 ## User Settings
 

--- a/apps/docs/features/attachments.mdx
+++ b/apps/docs/features/attachments.mdx
@@ -93,4 +93,4 @@ if (model.input?.pdf) {
 }
 ```
 
-When a user attaches a file that the current model doesn't support, ChatJS automatically switches to a compatible model (configured via `config.models.defaults.pdf` and `config.models.defaults.chatImageCompatible`).
+When a user attaches a file that the current model doesn't support, ChatJS automatically switches to the compatible model configured in `config.ai.workflows.pdf` or `config.ai.workflows.chatImageCompatible`.

--- a/apps/docs/features/overview.mdx
+++ b/apps/docs/features/overview.mdx
@@ -7,7 +7,7 @@ ChatJS ships with production-ready features. Toggle them in `chat.config.ts`.
 
 <CardGroup cols={2}>
   <Card title="Web Search" icon="globe" href="/features/web-search">
-    Real-time search via Tavily or Exa. Ground responses in current information.
+    Real-time search via Tavily or Firecrawl. Ground responses in current information.
   </Card>
   <Card title="Deep Research" icon="search" href="/features/deep-research">
     Multi-step research agent that investigates topics and produces comprehensive reports.

--- a/apps/docs/gateways/custom.mdx
+++ b/apps/docs/gateways/custom.mdx
@@ -19,16 +19,28 @@ For providers with a dedicated SDK (like `@ai-sdk/openai` or `@openrouter/ai-sdk
 
 ### 2. Add environment variables
 
-Register the required env vars in `lib/env.ts`:
+Register the required env vars in `lib/env-schema.ts`:
 
-```ts title="lib/env.ts"
-server: {
+```ts title="lib/env-schema.ts"
+export const serverEnvSchema = {
   // ... existing vars
 
-  // My Gateway (one required depending on config.models.gateway)
+  // My Gateway (required when config.ai.gateway is "my-gateway")
   MY_GATEWAY_BASE_URL: z.string().url().optional(),
   MY_GATEWAY_API_KEY: z.string().optional(),
-}
+};
+```
+
+Register the build-time requirement in `lib/config-requirements.ts` as well. The `Record<GatewayType, EnvRequirement>` type reports a missing entry after you add the gateway to the registry:
+
+```ts title="lib/config-requirements.ts"
+export const gatewayEnvRequirements: Record<GatewayType, EnvRequirement> = {
+  // ... existing gateways
+  "my-gateway": {
+    options: [["MY_GATEWAY_BASE_URL", "MY_GATEWAY_API_KEY"]],
+    description: "MY_GATEWAY_BASE_URL, MY_GATEWAY_API_KEY",
+  },
+};
 ```
 
 ### 3. Create the gateway class
@@ -36,10 +48,16 @@ server: {
 Create `lib/ai/gateways/my-gateway.ts`. Every gateway implements the `GatewayProvider` interface:
 
 ```ts
-type GatewayProvider<TGateway, TModelId, TImageModelId> = {
+type GatewayProvider<
+  TGateway,
+  TModelId,
+  TImageModelId,
+  TVideoModelId
+> = {
   readonly type: TGateway;
   createLanguageModel(modelId: TModelId): LanguageModel;
   createImageModel(modelId: TImageModelId): ImageModel | null;
+  createVideoModel(modelId: TVideoModelId): Experimental_VideoModelV3 | null;
   fetchModels(): Promise<AiGatewayModel[]>;
 };
 ```
@@ -48,6 +66,7 @@ Full example:
 
 ```ts title="lib/ai/gateways/my-gateway.ts"
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { Experimental_VideoModelV3 } from "@ai-sdk/provider";
 import type { ImageModel, LanguageModel } from "ai";
 import { createModuleLogger } from "@/lib/logger";
 import type { AiGatewayModel } from "../ai-gateway-models-schemas";
@@ -81,6 +100,7 @@ function toAiGatewayModel(model: MyProviderModelResponse): AiGatewayModel {
 export class MyGateway implements GatewayProvider<
   "my-gateway",
   string,
+  string,
   string
 > {
   readonly type = "my-gateway" as const;
@@ -107,6 +127,10 @@ export class MyGateway implements GatewayProvider<
     // Return null if your provider does not support image generation.
     const provider = this.getProvider();
     return provider.imageModel(modelId);
+  }
+
+  createVideoModel(_modelId: string): Experimental_VideoModelV3 | null {
+    return null;
   }
 
   private getApiKey(): string | undefined {
@@ -163,7 +187,7 @@ export class MyGateway implements GatewayProvider<
 <Callout type="tip">
   If your provider uses a dedicated SDK (not OpenAI-compatible), replace
   `createOpenAICompatible` with the provider-specific factory. See the [OpenAI
-  gateway](https://github.com/franciscomoretti/chat-js/blob/main/lib/ai/gateways/openai-gateway.ts)
+  gateway](https://github.com/franciscomoretti/chat-js/blob/main/apps/chat/lib/ai/gateways/openai-gateway.ts)
   for an example that uses `createOpenAI`.
 </Callout>
 
@@ -179,11 +203,31 @@ export const gatewayRegistry = {
   openrouter: () => new OpenRouterGateway(),
   openai: () => new OpenAIGateway(),
   "openai-compatible": () => new OpenAICompatibleGateway(),
+  litellm: () => new LiteLLMGateway(),
   "my-gateway": () => new MyGateway(), // add here
 } as const satisfies Record<string, () => GatewayProviderBase>;
 ```
 
-### 5. Add the schema variant
+### 5. Add gateway defaults
+
+Add a `myGatewayDefaults` block to `lib/ai/gateway-model-defaults.ts` and register it in `GATEWAY_MODEL_DEFAULTS`:
+
+```ts title="lib/ai/gateway-model-defaults.ts"
+export const GATEWAY_MODEL_DEFAULTS: {
+  [G in GatewayType]: ModelDefaultsFor<G>;
+} = {
+  vercel: vercelDefaults,
+  openrouter: openrouterDefaults,
+  openai: openaiDefaults,
+  "openai-compatible": openaiCompatibleDefaults,
+  litellm: litellmDefaults,
+  "my-gateway": myGatewayDefaults,
+};
+```
+
+Use the closest existing defaults block as a starting point. Update every model-backed workflow and tool default to IDs that your gateway accepts. The mapped `ModelDefaultsFor<"my-gateway">` type checks that the block is complete.
+
+### 6. Add the schema variant
 
 In `lib/config-schema.ts`, add your gateway to two places:
 
@@ -191,24 +235,26 @@ In `lib/config-schema.ts`, add your gateway to two places:
 
 ```ts title="lib/config-schema.ts"
 const gatewaySchemaMap: {
-  [G in GatewayType]: ReturnType<typeof createModelsSchema<G>>;
+  [G in GatewayType]: ReturnType<typeof createAiSchema<G>>;
 } = {
-  vercel: createModelsSchema("vercel"),
-  openrouter: createModelsSchema("openrouter"),
-  openai: createModelsSchema("openai"),
-  "openai-compatible": createModelsSchema("openai-compatible"),
-  "my-gateway": createModelsSchema("my-gateway"), // add here
+  vercel: createAiSchema("vercel"),
+  openrouter: createAiSchema("openrouter"),
+  openai: createAiSchema("openai"),
+  "openai-compatible": createAiSchema("openai-compatible"),
+  litellm: createAiSchema("litellm"),
+  "my-gateway": createAiSchema("my-gateway"), // add here
 };
 ```
 
 **The discriminated union** (runtime validation):
 
 ```ts title="lib/config-schema.ts"
-export const modelsConfigSchema = z.discriminatedUnion("gateway", [
+export const aiConfigSchema = z.discriminatedUnion("gateway", [
   gatewaySchemaMap.vercel,
   gatewaySchemaMap.openrouter,
   gatewaySchemaMap.openai,
   gatewaySchemaMap["openai-compatible"],
+  gatewaySchemaMap.litellm,
   gatewaySchemaMap["my-gateway"], // add here
 ]);
 ```
@@ -218,24 +264,14 @@ export const modelsConfigSchema = z.discriminatedUnion("gateway", [
   shows an error if you add a gateway to the registry but forget to add it here.
 </Callout>
 
-### 6. Configure your app
+### 7. Configure your app
 
-Set the gateway and model defaults in `chat.config.ts`:
+Set the gateway in `chat.config.ts`. Values omitted here come from the defaults you registered in the previous step:
 
 ```ts title="chat.config.ts"
 const config: ConfigInput = {
-  models: {
+  ai: {
     gateway: "my-gateway",
-    providerOrder: ["my-provider"],
-    disabledModels: [],
-    curatedDefaults: ["my-model-a", "my-model-b"],
-    anonymousModels: ["my-model-a"],
-    defaults: {
-      chat: "my-model-a",
-      title: "my-model-a",
-      // ... fill in all task defaults
-      image: "my-image-model",
-    },
   },
 };
 ```
@@ -247,22 +283,23 @@ MY_GATEWAY_BASE_URL=https://api.my-provider.com/v1
 MY_GATEWAY_API_KEY=sk-...
 ```
 
-### 7. Verify
+### 8. Verify
 
 ```bash
-bunx tsc --noEmit
+bun test:types
 bun fetch:models
 ```
 
 ## Checklist
 
 1. Install the provider SDK (`bun add ...`)
-2. Add env vars to `lib/env.ts`
+2. Add env vars to `lib/env-schema.ts` and their requirement to `lib/config-requirements.ts`
 3. Create the gateway class in `lib/ai/gateways/`
 4. Add it to `gatewayRegistry` in `registry.ts`
-5. Add the schema variant to `gatewaySchemaMap` and the discriminated union in `config-schema.ts`
-6. Set `gateway` in `chat.config.ts` and fill in model defaults
-7. Run `bunx tsc --noEmit` to verify types
+5. Add complete gateway defaults in `gateway-model-defaults.ts`
+6. Add the schema variant to `gatewaySchemaMap` and `aiConfigSchema` in `config-schema.ts`
+7. Set `ai.gateway` in `chat.config.ts`
+8. Run `bun test:types` and `bun fetch:models`
 
 ## Related
 

--- a/apps/docs/gateways/openai-compatible.mdx
+++ b/apps/docs/gateways/openai-compatible.mdx
@@ -12,7 +12,7 @@ This gateway works with:
 - [Ollama](https://ollama.com) — local models on your machine
 - [LM Studio](https://lmstudio.ai) — local model management with a GUI
 - [vLLM](https://docs.vllm.ai) — high-throughput self-hosted inference
-- [Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service) — OpenAI models on Azure
+- [Azure OpenAI](https://learn.microsoft.com/azure/ai-foundry/openai/overview) — OpenAI models on Azure
 - Any other endpoint that implements `/v1/chat/completions` and `/v1/models`
 
 ## Setup

--- a/apps/docs/gateways/openai.mdx
+++ b/apps/docs/gateways/openai.mdx
@@ -7,7 +7,7 @@ The OpenAI gateway connects ChatJS directly to the [OpenAI API](https://platform
 
 ## Setup
 
-1. Get an API key from [OpenAI Platform](https://platform.openai.com/api-keys)
+1. Follow the [OpenAI quickstart](https://developers.openai.com/api/docs/quickstart) to create an API key
 2. Add to `.env.local`:
 
 ```bash

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Introduction"
 description: "The prod-ready AI chat app"
+seo:
+  title: "Build Production-Ready AI Chat Applications"
+  description: "Complete documentation for ChatJS, the production-ready AI chat app. Learn authentication, streaming, tool calling, multi-model support, and deployment best practices."
 ---
 
 <img

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "build": "blume build",
     "dev": "blume dev --port ${PORT:-4321}",
-    "docs:links": "blume validate --strict",
+    "docs:links": "blume validate --external --strict",
     "lint": "blume doctor"
   },
   "devDependencies": {
-    "blume": "^1.0.3"
+    "blume": "^1.0.4"
   }
 }

--- a/apps/docs/platforms/desktop.mdx
+++ b/apps/docs/platforms/desktop.mdx
@@ -7,7 +7,7 @@ The desktop integration wraps your ChatJS web app in an Electron shell. The Elec
 
 ## Installing a prebuilt release
 
-Prebuilt installers for the ChatJS reference app are published on the [GitHub Releases page](https://github.com/franciscomoretti/chat-js/releases/latest).
+Prebuilt installers for the ChatJS reference app are published with the Electron package. The current installers are in the [`@chat-js/electron@0.3.2` release](https://github.com/FranciscoMoretti/chat-js/releases/tag/%40chat-js%2Felectron%400.3.2).
 
 <Callout type="warning">
   The current releases are **not code-signed or notarized**. Your operating system will show a security warning on first launch. This is expected for unsigned builds and does not mean the app is malicious, but you should only install builds from a source you trust.
@@ -17,7 +17,7 @@ Pick your platform below for the install steps.
 
 ### macOS
 
-1. Download [`ChatJS-mac.dmg`](https://github.com/franciscomoretti/chat-js/releases/latest/download/ChatJS-mac.dmg) (or browse [all assets](https://github.com/franciscomoretti/chat-js/releases/latest)).
+1. Download `ChatJS-mac.dmg` from the Electron release linked above.
 2. Open the `.dmg` and drag **ChatJS** into `Applications`.
 3. The first time you launch it, macOS will say the app "cannot be opened because Apple cannot check it for malicious software". Close that dialog.
 4. Open **System Settings** and go to **Privacy & Security**. Scroll to the **Security** section. You will see a message about ChatJS being blocked, with an **Open Anyway** button. Click it.
@@ -33,25 +33,24 @@ Only run that command on a build you downloaded yourself from the official relea
 
 ### Windows
 
-1. Download [`ChatJS-windows.exe`](https://github.com/franciscomoretti/chat-js/releases/latest/download/ChatJS-windows.exe) (or browse [all assets](https://github.com/franciscomoretti/chat-js/releases/latest)).
+1. Download `ChatJS-windows.exe` from the Electron release linked above.
 2. Windows SmartScreen will show a **Windows protected your PC** dialog because the installer is unsigned.
 3. Click **More info**, then **Run anyway**.
 4. Complete the installer as usual.
 
 ### Linux
 
-1. Download [`ChatJS-linux.AppImage`](https://github.com/franciscomoretti/chat-js/releases/latest/download/ChatJS-linux.AppImage) or [`ChatJS-linux.deb`](https://github.com/franciscomoretti/chat-js/releases/latest/download/ChatJS-linux.deb) (or browse [all assets](https://github.com/franciscomoretti/chat-js/releases/latest)).
-2. For the `.AppImage`, make it executable and run it:
+1. Download `chat-js-electron_0.3.2_amd64.deb` or `chat-js-electron-0.3.2-1.x86_64.rpm` from the Electron release linked above.
+2. Install the `.deb` on Debian or Ubuntu:
 
    ```bash
-   chmod +x ChatJS-linux.AppImage
-   ./ChatJS-linux.AppImage
+   sudo apt install ./chat-js-electron_0.3.2_amd64.deb
    ```
 
-3. For the `.deb`, install it with `apt` or your package manager of choice:
+3. Install the `.rpm` on Fedora or another RPM-based distribution:
 
    ```bash
-   sudo apt install ./ChatJS-linux.deb
+   sudo dnf install ./chat-js-electron-0.3.2-1.x86_64.rpm
    ```
 
 Linux does not enforce code signing for desktop apps the same way macOS and Windows do, so there is usually no extra warning step.

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -88,7 +88,7 @@ Expand the sections below for setup instructions:
     3. Copy the key → `OPENROUTER_API_KEY`
 
     **Option C: OpenAI**
-    1. Go to [OpenAI API Keys](https://platform.openai.com/api-keys)
+    1. Follow the [OpenAI quickstart](https://developers.openai.com/api/docs/quickstart) to create an API key
     2. Create an API key
     3. Copy the key → `OPENAI_API_KEY`
 
@@ -147,7 +147,7 @@ This pushes the Drizzle schema directly to your database. For production migrati
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000). You should see the ChatJS interface with a model selector and chat input.
+Open `http://localhost:3000`. You should see the ChatJS interface with a model selector and chat input.
 
 ## Deploying to Production
 

--- a/apps/docs/reference/cli.mdx
+++ b/apps/docs/reference/cli.mdx
@@ -9,7 +9,7 @@ description: "@chat-js/cli command reference"
 
 ## Installation
 
-No installation required — run it directly with `npx`:
+No installation is required. Run it directly with `npx`:
 
 ```bash
 npx @chat-js/cli@latest create my-app
@@ -26,7 +26,7 @@ chat-js create my-app
 
 ### `create`
 
-Scaffold a new ChatJS app. This is the default command — you can omit the word `create` and pass the directory directly.
+Scaffold a new ChatJS app. This is the default command, so you can omit the word `create` and pass the directory directly.
 
 ```bash
 npx @chat-js/cli@latest create [directory] [options]
@@ -41,29 +41,57 @@ npx @chat-js/cli@latest [directory] [options]
 
 **Options**
 
-| Flag               | Default | Description                                                                         |
-| ------------------ | ------- | ----------------------------------------------------------------------------------- |
-| `-y, --yes`                         | `false` | Skip all prompts and use defaults (Vercel gateway, GitHub auth, no extra features). |
-| `--no-install`                      | —       | Skip automatic dependency installation.                                             |
-| `--package-manager <bun\|npm\|pnpm\|yarn>` | —       | Override which package manager the CLI uses for install + next steps.               |
-| `--from-git <url>`                  | —       | Clone from a git repository instead of the built-in template.                       |
-| `-v, --version`                     | —       | Print the CLI version.                                                              |
+| Flag                                      | Default  | Description                                                                  |
+| ----------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `-y, --yes`                               | `false`  | Skip prompts and use the scaffold defaults.                                  |
+| `--no-install`                            | —        | Skip automatic dependency installation.                                      |
+| `--electron` / `--no-electron`            | Prompted | Include or exclude the Electron desktop app.                                 |
+| `-r, --registry <url>`                    | Default registry | Use a registry URL or local path template.                            |
+| `--package-manager <bun\|npm\|pnpm\|yarn>` | Inferred | Override the package manager used for installation and next steps.       |
+| `--from-git <url>`                        | Built-in scaffold | Clone from a Git repository instead of the built-in scaffold.         |
+| `--storage-provider <provider>`           | Prompted when needed | Select a Files SDK provider such as `vercel-blob`, `s3`, `r2`, or `gcs`. |
+| `--storage-config <json>`                 | —        | Supply non-secret Files SDK adapter options as JSON.                         |
 
-The CLI keeps `pnpm`, `yarn`, and `bun` when launched from those tools. If you launch through `npx`/npm, it defaults the generated app to Bun unless you pass `--package-manager`.
+The CLI first checks for a package-manager lockfile, then checks the invoking tool. Running through `npx` or npm selects npm. If neither signal exists, npm is the default. Pass `--package-manager` to override the result.
 
 After scaffolding, the CLI prints the exact environment variables required for your chosen configuration.
+
+Use `npx @chat-js/cli@latest --version` or `chat-js --version` after a global installation to print the CLI version.
 
 ---
 
 ### `add`
 
 ```bash
-npx @chat-js/cli@latest add [components...]
+npx @chat-js/cli@latest add [tools...]
 ```
 
-Add a component or feature to an existing ChatJS project.
+Install one or more registry tools into an existing ChatJS project. The command reads the tool destination from `chat.config.ts`.
 
-**Status: not yet implemented.** This command is reserved for a future release that will let you add features, auth providers, and gateways to existing projects without re-scaffolding.
+| Flag                   | Default           | Description                                      |
+| ---------------------- | ----------------- | ------------------------------------------------ |
+| `-y, --yes`            | `false`           | Skip the installation confirmation.              |
+| `-o, --overwrite`      | `false`           | Overwrite existing tool files without prompting. |
+| `-c, --cwd <cwd>`      | Current directory | Run against another ChatJS project.               |
+| `-r, --registry <url>` | Default registry  | Use a registry URL or local path template.        |
+
+```bash
+npx @chat-js/cli@latest add word-count
+```
+
+---
+
+### `config`
+
+Print the fully resolved `chat.config.ts`, including gateway defaults.
+
+```bash
+npx @chat-js/cli@latest config
+```
+
+| Flag              | Default           | Description                        |
+| ----------------- | ----------------- | ---------------------------------- |
+| `-c, --cwd <cwd>` | Current directory | Read another ChatJS project config. |
 
 ## What gets generated
 
@@ -104,7 +132,7 @@ npx @chat-js/cli@latest create my-chat-app
 npx @chat-js/cli@latest create my-chat-app --yes
 ```
 
-Defaults: Vercel AI Gateway, GitHub OAuth, Follow-up Suggestions only, bun install.
+Defaults include Vercel AI Gateway, GitHub OAuth, parallel responses, document tools, no Electron app, and npm when invoked through `npx`.
 
 **Create without installing dependencies**
 
@@ -127,10 +155,10 @@ npx @chat-js/cli@latest create my-chat-app --from-git https://github.com/your-or
 **Full flow after scaffolding**
 
 ```bash
-npx @chat-js/cli@latest create my-chat-app
+npx @chat-js/cli@latest create my-chat-app --package-manager npm
 cd my-chat-app
 cp .env.example .env.local
 # Fill in the env vars printed by the CLI
-bun run db:push
-bun run dev
+npm run db:push
+npm run dev
 ```

--- a/apps/docs/reference/env-vars.mdx
+++ b/apps/docs/reference/env-vars.mdx
@@ -20,7 +20,7 @@ These two variables must always be set. Without them the app will not start.
 | `DATABASE_URL` | PostgreSQL connection string | [Neon](https://neon.tech), [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres/quickstart), or any Postgres provider |
 | `AUTH_SECRET` | Secret used to sign and encrypt session tokens (Better Auth) | Run `openssl rand -base64 32` or use [generate-secret.vercel.app/32](https://generate-secret.vercel.app/32) |
 
-In addition to the two variables above, **at least one AI gateway key** and **at least one OAuth provider** must be configured. See the sections below.
+In addition to the two variables above, **at least one AI gateway credential** and **at least one OAuth provider** must be configured. See the sections below.
 
 ---
 
@@ -108,7 +108,7 @@ Direct connection to the OpenAI API. Use when you only need OpenAI models.
 |----------|----------|-------------|
 | `OPENAI_API_KEY` | Yes | Your OpenAI API key (`sk-...`) |
 
-**Setup:** Go to [OpenAI Platform](https://platform.openai.com/api-keys) and create an API key.
+**Setup:** Follow the [OpenAI quickstart](https://developers.openai.com/api/docs/quickstart) to create an API key.
 
 ### OpenAI Compatible
 
@@ -136,16 +136,18 @@ Routes requests through a LiteLLM proxy for centralized model access, key manage
 
 ## Features
 
-Feature flags live under `features` in `chat.config.ts`. Each flag has an associated environment variable requirement validated at build time.
+Tool flags live under `ai.tools` in `chat.config.ts`. File attachments remain under `features.attachments`. Each enabled capability has an associated environment variable requirement validated at build time.
 
 ### Web Search
 
 Enable real-time web search with citations. Requires at least one search provider key.
 
 ```typescript title="chat.config.ts"
-features: {
-  webSearch: true,    // Requires TAVILY_API_KEY or FIRECRAWL_API_KEY
-  urlRetrieval: true, // Requires FIRECRAWL_API_KEY
+ai: {
+  tools: {
+    webSearch: { enabled: true },    // Requires TAVILY_API_KEY or FIRECRAWL_API_KEY
+    urlRetrieval: { enabled: true }, // Requires FIRECRAWL_API_KEY
+  },
 }
 ```
 
@@ -153,7 +155,7 @@ features: {
 |----------|---------|-------------|--------|
 | `TAVILY_API_KEY` | `webSearch` | Tavily API key for web search (recommended) | [app.tavily.com](https://app.tavily.com) |
 | `FIRECRAWL_API_KEY` | `webSearch`, `urlRetrieval` | Firecrawl API key for web search and URL content extraction | [firecrawl.dev](https://www.firecrawl.dev) |
-| `EXA_API_KEY` | _none_ | Recognized by env schema but not used by build-time `webSearch` validation | [dashboard.exa.ai](https://dashboard.exa.ai) |
+| `EXA_API_KEY` | _none_ | Recognized by env schema but not used by build-time `webSearch` validation | [Exa API key guide](https://docs.exa.ai/reference/getting-started) |
 
 <Callout type="note">
   If both `TAVILY_API_KEY` and `FIRECRAWL_API_KEY` are set, Tavily is used for regular chat web search. Firecrawl is always used for URL retrieval.
@@ -164,8 +166,10 @@ features: {
 Enable [Model Context Protocol](https://modelcontextprotocol.io) server connections to expose custom tools and data sources to the AI.
 
 ```typescript title="chat.config.ts"
-features: {
-  mcp: true, // Requires MCP_ENCRYPTION_KEY
+ai: {
+  tools: {
+    mcp: { enabled: true }, // Requires MCP_ENCRYPTION_KEY
+  },
 }
 ```
 
@@ -215,11 +219,13 @@ requirements of your selected provider.
 
 ### Code Execution Sandbox
 
-Enable secure Python code execution using [Vercel Sandbox](https://vercel.com/docs/functions/runtimes/vercel-sandbox).
+Enable secure Python and JavaScript execution using [Vercel Sandbox](https://vercel.com/docs/sandbox).
 
 ```typescript title="chat.config.ts"
-features: {
-  sandbox: true,
+ai: {
+  tools: {
+    codeExecution: { enabled: true },
+  },
 }
 ```
 
@@ -229,7 +235,9 @@ features: {
 | `VERCEL_TEAM_ID` | Self-hosted only | Your Vercel team ID (`team_...`) |
 | `VERCEL_PROJECT_ID` | Self-hosted only | Your Vercel project ID (`prj_...`) |
 | `VERCEL_TOKEN` | Self-hosted only | Vercel API token with sandbox permissions |
-| `VERCEL_SANDBOX_RUNTIME` | Optional | Sandbox runtime identifier (default: `python3.13`) |
+| `VERCEL_SANDBOX_RUNTIME_PYTHON` | Optional | Python runtime identifier (default: `python3.13`) |
+| `VERCEL_SANDBOX_RUNTIME_JAVASCRIPT` | Optional | JavaScript runtime identifier (default: `node22`) |
+| `VERCEL_SANDBOX_RUNTIME` | Optional | Legacy Python runtime fallback. Prefer `VERCEL_SANDBOX_RUNTIME_PYTHON` |
 
 <Callout type="note">
   On Vercel deployments, sandbox authentication happens automatically via OIDC,
@@ -312,14 +320,16 @@ All variables in one place:
 | `VERCEL_APP_CLIENT_ID` | Auth | If `authentication.vercel: true` |
 | `VERCEL_APP_CLIENT_SECRET` | Auth | If `authentication.vercel: true` |
 | `BLOB_READ_WRITE_TOKEN` | Storage | When Vercel Blob is the selected provider |
-| `TAVILY_API_KEY` | Feature | If `webSearch` enabled (one search key required) |
-| `FIRECRAWL_API_KEY` | Feature | If `webSearch` or `urlRetrieval` enabled |
+| `TAVILY_API_KEY` | Feature | If `ai.tools.webSearch.enabled` (one search key required) |
+| `FIRECRAWL_API_KEY` | Feature | If `ai.tools.webSearch.enabled` or `ai.tools.urlRetrieval.enabled` |
 | `EXA_API_KEY` | Optional | Recognized by env schema but not required by current validation |
-| `MCP_ENCRYPTION_KEY` | Feature | If `mcp` enabled |
-| `VERCEL_TEAM_ID` | Feature | If `sandbox` enabled on non-Vercel hosting |
-| `VERCEL_PROJECT_ID` | Feature | If `sandbox` enabled on non-Vercel hosting |
-| `VERCEL_TOKEN` | Feature | If `sandbox` enabled on non-Vercel hosting |
-| `VERCEL_SANDBOX_RUNTIME` | Feature | Optional sandbox runtime override |
+| `MCP_ENCRYPTION_KEY` | Feature | If `ai.tools.mcp.enabled` |
+| `VERCEL_TEAM_ID` | Feature | If `ai.tools.codeExecution.enabled` on non-Vercel hosting |
+| `VERCEL_PROJECT_ID` | Feature | If `ai.tools.codeExecution.enabled` on non-Vercel hosting |
+| `VERCEL_TOKEN` | Feature | If `ai.tools.codeExecution.enabled` on non-Vercel hosting |
+| `VERCEL_SANDBOX_RUNTIME_PYTHON` | Feature | Optional Python sandbox runtime override |
+| `VERCEL_SANDBOX_RUNTIME_JAVASCRIPT` | Feature | Optional JavaScript sandbox runtime override |
+| `VERCEL_SANDBOX_RUNTIME` | Feature | Legacy Python sandbox runtime override |
 | `REDIS_URL` | Optional | Resumable streams |
 | `CRON_SECRET` | Optional | Secure cleanup cron endpoint |
 | `APP_URL` | Optional | Required on non-Vercel deployments |

--- a/bun.lock
+++ b/bun.lock
@@ -157,8 +157,8 @@
     },
     "apps/docs": {
       "name": "@chatjs/docs",
-      "dependencies": {
-        "blume": "^1.0.3",
+      "devDependencies": {
+        "blume": "^1.0.4",
       },
     },
     "apps/electron": {
@@ -1587,7 +1587,7 @@
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
-    "blume": ["blume@1.0.3", "", { "dependencies": { "@astrojs/check": "^0.9.0", "@astrojs/markdown-satteri": "^0.3.2", "@astrojs/mdx": "^7.0.0", "@astrojs/node": "^11.0.0", "@astrojs/react": "^6.0.0", "@astrojs/vercel": "^11.0.0", "@clack/prompts": "^1.7.0", "@iconify-json/lucide": "^1.2.115", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.3", "@modelcontextprotocol/sdk": "^1.29.0", "@orama/orama": "^3.1.18", "@pierre/diffs": "^1.2.11", "@scalar/astro": "^0.4.5", "@scalar/openapi-parser": "^0.28.8", "@scalar/openapi-types": "^0.9.1", "@shikijs/transformers": "^4.2.0", "@shikijs/twoslash": "^4.2.0", "@tailwindcss/typography": "^0.5.20", "@tailwindcss/vite": "^4", "@takumi-rs/core": "^1.8.7", "@takumi-rs/helpers": "^1.8.7", "@vercel/analytics": "^2.0.1", "ai": "^5.0.0", "astro": "^7.0.2", "babel-plugin-react-compiler": "^1.0.0", "citty": "^0.1.6", "consola": "^3.4.0", "dompurify": "^3.4.11", "epub-gen-memory": "^1.1.2", "github-slugger": "^2.0.0", "gray-matter": "^4.0.3", "jiti": "^2.4.0", "js-yaml": "^4.1.0", "katex": "^0.17.0", "marked": "^18.0.5", "mermaid": "^11.15.0", "pagefind": "^1.3.0", "pathe": "^2.0.0", "react": "^19.0.0", "react-dom": "^19.0.0", "satteri": "^0.9.5", "shiki": "^4.2.0", "simple-icons": "^13.0.0", "tailwindcss": "^4", "tinyglobby": "^0.2.10", "typescript": "^6.0.3", "undici": "^8.6.0", "zod": "^3.24.0" }, "peerDependencies": { "@ai-sdk/openai-compatible": "^1.0.41", "@astrojs/cloudflare": "^14.0.0", "@astrojs/netlify": "^8.0.0", "@astrojs/svelte": "^9.0.0", "@astrojs/vue": "^7.0.0", "@mixedbread/sdk": "^0.76.0", "@notionhq/client": "^2.2.15", "@openrouter/ai-sdk-provider": "^1.5.4", "@oramacloud/client": "^2.1.0", "@sanity/client": "^6.21.0", "algoliasearch": "^5.55.0", "flexsearch": "^0.8.0", "typesense": "^3.0.0" }, "optionalPeers": ["@ai-sdk/openai-compatible", "@astrojs/cloudflare", "@astrojs/netlify", "@astrojs/svelte", "@astrojs/vue", "@mixedbread/sdk", "@notionhq/client", "@openrouter/ai-sdk-provider", "@oramacloud/client", "@sanity/client", "algoliasearch", "flexsearch", "typesense"], "bin": { "blume": "bin/blume.mjs" } }, "sha512-rPp+KSFBjxlz7SodQt2h4AbZygQrcYn+p+WR+3NctkJcIIs+OXlqXACv7iFAzLDk774Cb5uo7LrQ5/3/GyQ2uA=="],
+    "blume": ["blume@1.0.4", "", { "dependencies": { "@astrojs/check": "^0.9.0", "@astrojs/markdown-satteri": "^0.3.2", "@astrojs/mdx": "^7.0.0", "@astrojs/node": "^11.0.0", "@astrojs/react": "^6.0.0", "@astrojs/vercel": "^11.0.0", "@clack/prompts": "^1.7.0", "@iconify-json/lucide": "^1.2.115", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.3", "@modelcontextprotocol/sdk": "^1.29.0", "@orama/orama": "^3.1.18", "@pierre/diffs": "^1.2.11", "@scalar/astro": "^0.4.5", "@scalar/openapi-parser": "^0.28.8", "@scalar/openapi-types": "^0.9.1", "@shikijs/transformers": "^4.2.0", "@shikijs/twoslash": "^4.2.0", "@tailwindcss/typography": "^0.5.20", "@tailwindcss/vite": "^4", "@takumi-rs/core": "^1.8.7", "@takumi-rs/helpers": "^1.8.7", "@vercel/analytics": "^2.0.1", "ai": "^5.0.0", "astro": "^7.0.2", "babel-plugin-react-compiler": "^1.0.0", "citty": "^0.1.6", "consola": "^3.4.0", "dompurify": "^3.4.11", "epub-gen-memory": "^1.1.2", "github-slugger": "^2.0.0", "gray-matter": "^4.0.3", "jiti": "^2.4.0", "js-yaml": "^4.1.0", "katex": "^0.17.0", "marked": "^18.0.5", "mermaid": "^11.15.0", "pagefind": "^1.3.0", "pathe": "^2.0.0", "react": "^19.0.0", "react-dom": "^19.0.0", "satteri": "^0.9.5", "shiki": "^4.2.0", "simple-icons": "^13.0.0", "tailwindcss": "^4", "tinyglobby": "^0.2.10", "typescript": "^6.0.3", "undici": "^8.6.0", "zod": "^3.24.0" }, "peerDependencies": { "@ai-sdk/openai-compatible": "^1.0.41", "@astrojs/cloudflare": "^14.0.0", "@astrojs/netlify": "^8.0.0", "@astrojs/svelte": "^9.0.0", "@astrojs/vue": "^7.0.0", "@mixedbread/sdk": "^0.76.0", "@notionhq/client": "^2.2.15", "@openrouter/ai-sdk-provider": "^1.5.4", "@oramacloud/client": "^2.1.0", "@sanity/client": "^6.21.0", "algoliasearch": "^5.55.0", "flexsearch": "^0.8.0", "typesense": "^3.0.0" }, "optionalPeers": ["@ai-sdk/openai-compatible", "@astrojs/cloudflare", "@astrojs/netlify", "@astrojs/svelte", "@astrojs/vue", "@mixedbread/sdk", "@notionhq/client", "@openrouter/ai-sdk-provider", "@oramacloud/client", "@sanity/client", "algoliasearch", "flexsearch", "typesense"], "bin": { "blume": "bin/blume.mjs" } }, "sha512-sJmmm3MJ1am+4ubZPXlrgE4rx4vn+N92Aqyo9zxDL5+T4a3w5Hpv0FqxF3iMlv6qYOHp+Ts7d72rx348SePxSg=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -1723,7 +1723,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -3597,7 +3597,7 @@
 
     "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
@@ -3714,6 +3714,8 @@
     "@electron/packager/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "@electron/packager/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
+
+    "@electron/packager/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@electron/rebuild/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3903,8 +3905,6 @@
 
     "astro/@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
-    "astro/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "astro/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "astro/get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
@@ -3915,8 +3915,6 @@
 
     "astro/vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
 
-    "astro/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
-
     "blume/@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "blume/@tailwindcss/typography": ["@tailwindcss/typography@0.5.20", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders" } }, "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw=="],
@@ -3925,6 +3923,8 @@
 
     "blume/ai": ["ai@5.0.212", "", { "dependencies": { "@ai-sdk/gateway": "2.0.111", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.28", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NmSi5BHrQpWNzCeisFqXLWyxyDbERIdvlJ7rNeIk8CB/GUqkKAPoEDn75uTuL3h9SCfFGVW5HTrRE8nX+ydqAg=="],
 
+    "blume/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
     "blume/katex": ["katex@0.17.0", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw=="],
 
     "blume/marked": ["marked@18.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w=="],
@@ -3932,6 +3932,10 @@
     "blume/mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
 
     "blume/shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
+
+    "blume/tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
+
+    "blume/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "blume/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -4023,6 +4027,8 @@
 
     "express/content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "external-editor/chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
 
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -4060,8 +4066,6 @@
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
-    "light-my-request/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
@@ -4209,6 +4213,8 @@
 
     "@astrojs/check/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "@astrojs/check/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
     "@astrojs/internal-helpers/shiki/@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 
     "@astrojs/internal-helpers/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
@@ -4220,6 +4226,8 @@
     "@astrojs/internal-helpers/shiki/@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
 
     "@astrojs/internal-helpers/shiki/@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
+
+    "@astrojs/react/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "@astrojs/react/vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
@@ -4390,6 +4398,8 @@
     "@electron/rebuild/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@electron/rebuild/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@electron/rebuild/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@electron/universal/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -4649,6 +4659,8 @@
 
     "blume/shiki/@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
 
+    "blume/tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "cacache/glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
@@ -4830,6 +4842,58 @@
     "@astrojs/check/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@astrojs/internal-helpers/shiki/@shikijs/engine-javascript/oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@astrojs/react/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 


### PR DESCRIPTION
## Summary

- address the remaining content and code-example findings from the Mintlify-to-Blume docs review
- validate internal and external documentation links in strict mode
- update Blume from `1.0.3` to `1.0.4`
- pick up the native scrollbar theme fix for the ChatJS docs sidebar

## Why

The migrated docs still contained several stale paths, incomplete gateway and CLI examples, and wording that no longer matched the current implementation. Blume `1.0.3` also predated the root `color-scheme` fix, leaving native scrollbars in the browser's default light appearance during dark mode.

## Validation

- `bun install --frozen-lockfile`
- `bun lint`
- `bun test:types`
- `bun docs:links` — strict internal and external validation passed
- `bun --filter @chatjs/docs build` — 72 pages built
- browser QA at `http://localhost:3043/docs` (1280×720)
  - overflowing sidebar: 2,359px content inside a 656px viewport
  - dark theme computes to `color-scheme: dark`
  - theme toggle changes it to `color-scheme: light`
  - no browser console warnings or errors

## Screenshots

### Dark theme

![Dark ChatJS docs sidebar](https://raw.githubusercontent.com/FranciscoMoretti/blume/b7cc74ef03e0ba8c973f88f2d1f49f6164d7f763/dark-theme.png)

### Light theme

![Light ChatJS docs sidebar](https://raw.githubusercontent.com/FranciscoMoretti/blume/b7cc74ef03e0ba8c973f88f2d1f49f6164d7f763/light-theme.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remaining Mintlify-to-Blume docs review items and turns on strict internal/external link validation. Also upgrades `blume` to `1.0.4`, which fixes native scrollbar theming in the docs sidebar.

- **Bug Fixes**
  - Updated config references from `models.*` to `ai.*` (gateway, workflows, tools, anonymous models) across multi-model, attachments, authentication, and changelog pages.
  - Improved follow-up suggestions example: recent-context only, min/max limits, character cap, config gating, and sending with the selected model/tool.
  - Gateway docs: moved env vars to `lib/env-schema.ts`, added gateway env requirements map, gateway defaults, `aiConfigSchema`, and registry updates; included LiteLLM entry and video model method; refreshed OpenAI/Azure links.
  - CLI docs: clarified defaults, added `add` and `config` commands and flags, explained package-manager detection, and updated examples.
  - Desktop docs: linked `@chat-js/electron@0.3.2` release and revised Linux install steps.
  - Env vars: moved feature flags under `ai.tools.*`, added Sandbox JS/Python runtime vars, and clarified web search provider keys.

- **Dependencies**
  - Bumped `blume` from `^1.0.3` to `^1.0.4`.

<sup>Written for commit 004ffdeb970b24bb2f69242d667e6fbe4ce8e572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration examples and guidance to use the current `ai.*` schema.
  - Clarified model selection for attachments, image generation, tools, workflows, and anonymous access.
  - Refreshed gateway, OAuth, OpenAI setup, CLI, environment variable, and desktop installation instructions.
  - Updated web search provider information and related documentation links.
  - Improved landing-page SEO metadata.
  - Expanded follow-up suggestion guidance and clarified tool-dependent behavior.
- **Chores**
  - Strengthened documentation link validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->