### PR TITLE
Threads 1: Define useThread package contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,18 @@
         "ts-morph": "^27.0.2",
       },
     },
+    "packages/thread": {
+      "name": "@chatjs/thread",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/bun": "^1.3.12",
+        "ai": "^6.0.150",
+        "typescript": "6.0.2",
+      },
+      "peerDependencies": {
+        "ai": "^6.0.0",
+      },
+    },
   },
   "overrides": {
     "//@better-auth/core": "Pinned because @better-auth/electron and other @better-auth/* packages declare a strict peerDependency on @better-auth/core@1.5.6. Do not remove without auditing all @better-auth/* peer ranges.",
@@ -464,6 +476,8 @@
     "@chatjs/docs": ["@chatjs/docs@workspace:apps/docs"],
 
     "@chatjs/site": ["@chatjs/site@workspace:apps/site"],
+
+    "@chatjs/thread": ["@chatjs/thread@workspace:packages/thread"],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
 
@@ -3646,6 +3660,8 @@
     "@chatjs/site/next": ["next@16.2.0", "", { "dependencies": { "@next/env": "16.2.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.0", "@next/swc-darwin-x64": "16.2.0", "@next/swc-linux-arm64-gnu": "16.2.0", "@next/swc-linux-arm64-musl": "16.2.0", "@next/swc-linux-x64-gnu": "16.2.0", "@next/swc-linux-x64-musl": "16.2.0", "@next/swc-win32-arm64-msvc": "16.2.0", "@next/swc-win32-x64-msvc": "16.2.0", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ=="],
 
     "@chatjs/site/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "@chatjs/thread/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "@chevrotain/cst-dts-gen/@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
 

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -80,9 +80,10 @@ await chat.tree.startRun({ follow: false, from: userMessageId });
 ```
 
 `from` selects the node that receives the new user message. `follow` controls
-whether the cursor moves with the new user and assistant nodes; it defaults to
-`true` when the resolved origin equals the active cursor and `false` otherwise.
-This includes an explicit `from` whose value equals the current `cursorId`.
+whether the cursor selects the new user immediately and its assistant once
+streaming begins; it defaults to `true` when the resolved origin equals the
+active cursor and `false` otherwise. This includes an explicit `from` whose
+value equals the current `cursorId`.
 
 Top-level fields always describe the selected path:
 
@@ -168,14 +169,16 @@ role as AI SDK's `Chat.id`, remains stable as messages are added, and is sent to
 the transport as `chatId` on every request.
 
 Within that conversation, each `message.id` identifies one immutable tree node.
-An assistant message ID also identifies the run that produces that node. A
-branch does not have another stored ID: a message ID identifies its current
-head, and following parent links identifies the complete root-to-head path.
+Each run has a separate stable ID identifying its request lifecycle. A run is
+present while submitted even though no assistant message exists yet, then binds
+to the assistant ID produced by AI SDK's stream reducer. A message ID identifies
+a branch head, and following parent links identifies the complete root-to-head
+path.
 
 `cursorId` is the mutable selection of one such head. A followed send attaches
-the new user and assistant nodes beneath the selected head and advances the
-cursor to those nodes. Starting from an earlier node creates siblings without
-changing existing identities or ancestry.
+the new user beneath the selected head, then attaches and selects the assistant
+when AI SDK first publishes it. Starting from an earlier node creates siblings
+without changing existing identities or ancestry.
 
 Tree snapshots persist topology and cursor selection, but not `ThreadChat.id`.
 Callers that restore a conversation associate the snapshot with its stable
@@ -206,9 +209,10 @@ type RunRecord<TMessage extends UIMessage> = {
 };
 ```
 
-The assistant message ID is also the run ID. Requests, stream updates, stop
-operations, reconnection, and the resulting assistant node therefore share one
-stable identity.
+Run IDs and message IDs are deliberately separate. A run exists before its
+assistant message and keeps the same ID if the server supplies a canonical
+message ID. Stop and resume operations address the stable run ID; message-based
+helpers resolve the run currently associated with that node.
 
 `ThreadChat` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
 reconnection needs an AI SDK request lifecycle. Completed run records are
@@ -234,33 +238,23 @@ behavior for:
 - regeneration and reconnection
 
 The internal `ThreadChatState` presents one linear branch path to
-`AbstractChat`. It writes accumulated assistant snapshots back to the reserved
-assistant node in `ThreadChat`.
+`AbstractChat`. It writes accumulated assistant snapshots into `ThreadChat`
+when AI SDK publishes the streaming response.
 
 The supplied AI SDK `ChatTransport` remains the request and stream boundary.
 The package does not define another transport protocol or manually parse
 `UIMessageChunk` values. A delegating transport ensures new and reconnected
 runs use the latest transport configured on `ThreadChat`.
 
-Each request receives the selected linear path. Optional tree context is added
-to `ChatRequestOptions.body`:
+Each request receives the selected linear path. `ChatRequestOptions` are passed
+to the configured transport unchanged; tree controls never leak into the
+application request body.
 
-```ts
-{
-  assistantMessageId,
-  tree: {
-    assistantMessageId,
-    cursorId,
-    originCursorId,
-    parentMessageId,
-    pathIds,
-    userMessageId,
-  },
-}
-```
-
-The transport can ignore this context when its server only needs linear
-messages.
+As in AI SDK's `AbstractChat`, a submitted response remains private streaming
+state until the first stream write. A server-provided `messageId` in the AI SDK
+`start` chunk replaces the provisional ID before publication, so the tree only
+ever observes the canonical assistant node. Runs reserve an internal sibling
+position so concurrent streams remain ordered by creation rather than arrival.
 
 ## Send Lifecycle
 
@@ -269,12 +263,14 @@ A normal `sendMessage` follows this sequence:
 1. Resolve the origin from the active cursor or an explicit `tree.from` value.
 2. Check concurrency limits and reject without mutating the tree when exceeded.
 3. Create or update the user message under that origin.
-4. Reserve an assistant message ID and add an assistant shell to the tree.
+4. Create a stable run ID and reserve its sibling position without adding a
+   placeholder message.
 5. Create a `RunRecord` and its internal `ThreadRunChat`.
 6. Send the selected path through the configured `ChatTransport`.
-7. Commit each accumulated assistant snapshot to the reserved tree node.
-8. Publish status, error, and finish events for that run.
-9. Move the cursor with the run when `follow` is enabled.
+7. Let AI SDK apply a server response ID from the start chunk when provided.
+8. Insert the assistant node on AI SDK's first write and update it thereafter.
+9. Publish status, error, and finish events for that run.
+10. Move the cursor with the run when `follow` is enabled.
 
 `sendMessage` waits for the request and automatic follow-ups to finish, matching
 the AI SDK contract. `tree.startRun` returns a handle immediately for callers
@@ -376,7 +372,7 @@ useThread({
 
 `maxActiveRuns` limits the complete conversation. `maxActiveRunsPerMessage`
 limits assistant siblings generated from one user message. A rejected run does
-not leave optimistic user or assistant nodes behind.
+not leave an extra user message behind.
 
 ## Package Boundary
 
@@ -385,7 +381,7 @@ not leave optimistic user or assistant nodes behind.
 - the `useThread` React contract
 - tree topology and cursor projection
 - run creation, registration, and cancellation
-- stable assistant/run identity
+- stable run identity and server-owned assistant identity
 - routing tool and approval mutations to their owning runs
 - adaptation between the tree and AI SDK's linear `AbstractChat`
 

--- a/packages/thread/biome.jsonc
+++ b/packages/thread/biome.jsonc
@@ -1,0 +1,11 @@
+{
+	"formatter": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	}
+}

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -1,0 +1,58 @@
+{
+	"name": "@chatjs/thread",
+	"version": "0.0.0",
+	"description": "Headless threaded chat engine for AI SDK UI messages",
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/franciscomoretti/chat-js.git",
+		"directory": "packages/thread"
+	},
+	"homepage": "https://github.com/franciscomoretti/chat-js/tree/main/packages/thread",
+	"bugs": {
+		"url": "https://github.com/franciscomoretti/chat-js/issues"
+	},
+	"keywords": [
+		"chatjs",
+		"ai",
+		"ai-sdk",
+		"thread",
+		"chat"
+	],
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"bun": "./src/index.ts",
+			"development": "./src/index.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"types": "./src/index.ts",
+	"files": [
+		"dist",
+		"src",
+		"README.md",
+		"ARCHITECTURE.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external",
+		"format": "bunx @biomejs/biome@2.4.10 check --write src *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"lint": "bunx @biomejs/biome@2.4.10 check src ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"prepublishOnly": "bun run build",
+		"test": "bun test ./test",
+		"test:unit": "bun test ./test",
+		"test:types": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"ai": "^6.0.0"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.3.12",
+		"ai": "^6.0.150",
+		"typescript": "6.0.2"
+	}
+}

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -22,13 +22,13 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"types": "./src/index.ts",
+			"types": "./dist/index.d.ts",
 			"bun": "./src/index.ts",
 			"development": "./src/index.ts",
 			"default": "./dist/index.js"
 		}
 	},
-	"types": "./src/index.ts",
+	"types": "./dist/index.d.ts",
 	"files": [
 		"dist",
 		"src",
@@ -43,9 +43,9 @@
 		"format": "bunx @biomejs/biome@2.4.10 check --write src *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"lint": "bunx @biomejs/biome@2.4.10 check src ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
-		"test": "bun test ./test",
-		"test:unit": "bun test ./test",
-		"test:types": "tsc --noEmit"
+		"test": "bun test --pass-with-no-tests",
+		"test:unit": "bun test --pass-with-no-tests",
+		"test:types": "bun run build"
 	},
 	"peerDependencies": {
 		"ai": "^6.0.0"

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,0 +1,11 @@
+export type {
+	MessageTreeSnapshot,
+	ThreadChatOptions,
+	ThreadConcurrency,
+	ThreadEvent,
+	ThreadRun,
+	ThreadRunHandle,
+	ThreadStartRunOptions,
+	ThreadStateSnapshot,
+	TreeSendOptions,
+} from "./types";

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,5 +1,7 @@
 export type {
+	MessageTreeNode,
 	MessageTreeSnapshot,
+	SendMessageInput,
 	ThreadChatOptions,
 	ThreadConcurrency,
 	ThreadEvent,
@@ -8,4 +10,4 @@ export type {
 	ThreadStartRunOptions,
 	ThreadStateSnapshot,
 	TreeSendOptions,
-} from "./types";
+} from "./types.js";

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,10 +1,8 @@
 export type {
 	MessageTreeNode,
 	MessageTreeSnapshot,
-	SendMessageInput,
 	ThreadChatOptions,
 	ThreadConcurrency,
-	ThreadEvent,
 	ThreadRun,
 	ThreadRunHandle,
 	ThreadStartRunOptions,

--- a/packages/thread/src/types.ts
+++ b/packages/thread/src/types.ts
@@ -1,0 +1,98 @@
+import type {
+	AbstractChat,
+	ChatInit,
+	ChatRequestOptions,
+	ChatStatus,
+	UIMessage,
+} from "ai";
+
+export type ThreadRun = {
+	assistantMessageId: string;
+	error: Error | undefined;
+	follow: boolean;
+	id: string;
+	originCursorId: string | null;
+	parentMessageId: string | null;
+	status: ChatStatus;
+	userMessageId: string;
+};
+
+export type ThreadRunHandle = {
+	readonly assistantMessageId: string;
+	readonly finished: Promise<void>;
+	readonly id: string;
+	getSnapshot: () => ThreadRun | undefined;
+	stop: () => Promise<void>;
+};
+
+export type TreeSendOptions = ChatRequestOptions & {
+	tree?: {
+		follow?: boolean;
+		from?: string | null;
+		[key: string]: unknown;
+	};
+};
+
+export type SendMessageInput<TMessage extends UIMessage> = Parameters<
+	AbstractChat<TMessage>["sendMessage"]
+>[0];
+
+export type ThreadStartRunOptions<TMessage extends UIMessage = UIMessage> = {
+	follow?: boolean;
+	from?: string | null;
+	message?: SendMessageInput<TMessage>;
+	request?: TreeSendOptions;
+};
+
+export type ThreadConcurrency = {
+	maxActiveRuns?: number;
+	maxActiveRunsPerMessage?: number;
+};
+
+export type ThreadEvent =
+	| { cursorId: string | null; type: "cursor-changed" }
+	| { run: ThreadRun; type: "run-started" | "run-updated" }
+	| {
+			run: ThreadRun;
+			type: "run-aborted" | "run-completed" | "run-failed";
+	  };
+
+export type MessageTreeSnapshot<TMessage extends UIMessage = UIMessage> = {
+	childrenByParentId: Record<string, string[]>;
+	cursorId: string | null;
+	messagesById: Record<string, TMessage>;
+	parentById: Record<string, string | null>;
+	rootIds: string[];
+	version: 1;
+};
+
+export type ThreadStateSnapshot<TMessage extends UIMessage = UIMessage> =
+	MessageTreeSnapshot<TMessage> & {
+		error: Error | undefined;
+		lastEvent: string;
+		messages: TMessage[];
+		status: ChatStatus;
+		activeRuns: ThreadRun[];
+		runs: ThreadRun[];
+		storeVersion: number;
+		treeStatus: ChatStatus;
+	};
+
+export type ThreadChatOptions<TMessage extends UIMessage = UIMessage> = Omit<
+	ChatInit<TMessage>,
+	"messages"
+> & {
+	concurrency?: ThreadConcurrency;
+	initialTree?: MessageTreeSnapshot<TMessage>;
+	messages?: TMessage[];
+	onThreadEvent?: (event: ThreadEvent) => void;
+};
+
+export type ThreadRunSpec = {
+	assistantMessageId: string;
+	follow: boolean;
+	originCursorId: string | null;
+	parentMessageId: string | null;
+	runId: string;
+	userMessageId: string;
+};

--- a/packages/thread/src/types.ts
+++ b/packages/thread/src/types.ts
@@ -29,7 +29,6 @@ export type TreeSendOptions = ChatRequestOptions & {
 	tree?: {
 		follow?: boolean;
 		from?: string | null;
-		[key: string]: unknown;
 	};
 };
 
@@ -57,23 +56,30 @@ export type ThreadEvent =
 			type: "run-aborted" | "run-completed" | "run-failed";
 	  };
 
+export type MessageTreeNode<TMessage extends UIMessage = UIMessage> = {
+	message: TMessage;
+	parentId: string | null;
+};
+
 export type MessageTreeSnapshot<TMessage extends UIMessage = UIMessage> = {
-	childrenByParentId: Record<string, string[]>;
 	cursorId: string | null;
-	messagesById: Record<string, TMessage>;
-	parentById: Record<string, string | null>;
-	rootIds: string[];
+	nodes: MessageTreeNode<TMessage>[];
 	version: 1;
 };
 
 export type ThreadStateSnapshot<TMessage extends UIMessage = UIMessage> =
 	MessageTreeSnapshot<TMessage> & {
+		activeRuns: ThreadRun[];
+		childrenByParentId: Record<string, string[]>;
 		error: Error | undefined;
+		/** Free-form diagnostic description of the latest state transition. */
 		lastEvent: string;
 		messages: TMessage[];
-		status: ChatStatus;
-		activeRuns: ThreadRun[];
+		messagesById: Record<string, TMessage>;
+		parentById: Record<string, string | null>;
+		rootIds: string[];
 		runs: ThreadRun[];
+		status: ChatStatus;
 		storeVersion: number;
 		treeStatus: ChatStatus;
 	};

--- a/packages/thread/src/types.ts
+++ b/packages/thread/src/types.ts
@@ -7,18 +7,12 @@ import type {
 } from "ai";
 
 export type ThreadRun = {
-	assistantMessageId: string;
 	error: Error | undefined;
-	follow: boolean;
 	id: string;
-	originCursorId: string | null;
-	parentMessageId: string | null;
 	status: ChatStatus;
-	userMessageId: string;
 };
 
 export type ThreadRunHandle = {
-	readonly assistantMessageId: string;
 	readonly finished: Promise<void>;
 	readonly id: string;
 	getSnapshot: () => ThreadRun | undefined;
@@ -32,29 +26,17 @@ export type TreeSendOptions = ChatRequestOptions & {
 	};
 };
 
-export type SendMessageInput<TMessage extends UIMessage> = Parameters<
-	AbstractChat<TMessage>["sendMessage"]
->[0];
-
 export type ThreadStartRunOptions<TMessage extends UIMessage = UIMessage> = {
 	follow?: boolean;
 	from?: string | null;
-	message?: SendMessageInput<TMessage>;
-	request?: TreeSendOptions;
+	message?: Parameters<AbstractChat<TMessage>["sendMessage"]>[0];
+	request?: ChatRequestOptions;
 };
 
 export type ThreadConcurrency = {
 	maxActiveRuns?: number;
 	maxActiveRunsPerMessage?: number;
 };
-
-export type ThreadEvent =
-	| { cursorId: string | null; type: "cursor-changed" }
-	| { run: ThreadRun; type: "run-started" | "run-updated" }
-	| {
-			run: ThreadRun;
-			type: "run-aborted" | "run-completed" | "run-failed";
-	  };
 
 export type MessageTreeNode<TMessage extends UIMessage = UIMessage> = {
 	message: TMessage;
@@ -72,33 +54,22 @@ export type ThreadStateSnapshot<TMessage extends UIMessage = UIMessage> =
 		activeRuns: ThreadRun[];
 		childrenByParentId: Record<string, string[]>;
 		error: Error | undefined;
-		/** Free-form diagnostic description of the latest state transition. */
-		lastEvent: string;
 		messages: TMessage[];
 		messagesById: Record<string, TMessage>;
 		parentById: Record<string, string | null>;
 		rootIds: string[];
 		runs: ThreadRun[];
 		status: ChatStatus;
-		storeVersion: number;
 		treeStatus: ChatStatus;
 	};
+
+type ThreadInitialState<TMessage extends UIMessage> =
+	| { initialTree: MessageTreeSnapshot<TMessage>; messages?: never }
+	| { initialTree?: never; messages?: TMessage[] };
 
 export type ThreadChatOptions<TMessage extends UIMessage = UIMessage> = Omit<
 	ChatInit<TMessage>,
 	"messages"
 > & {
 	concurrency?: ThreadConcurrency;
-	initialTree?: MessageTreeSnapshot<TMessage>;
-	messages?: TMessage[];
-	onThreadEvent?: (event: ThreadEvent) => void;
-};
-
-export type ThreadRunSpec = {
-	assistantMessageId: string;
-	follow: boolean;
-	originCursorId: string | null;
-	parentMessageId: string | null;
-	runId: string;
-	userMessageId: string;
-};
+} & ThreadInitialState<TMessage>;

--- a/packages/thread/tsconfig.build.json
+++ b/packages/thread/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"noEmit": false,
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/thread/tsconfig.json
+++ b/packages/thread/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds the package manifest and public type contracts.
- Defines tree snapshots, run handles, concurrency, and tree-aware send options.
- Keeps the active-path surface compatible with AI SDK `useChat`.

## Behavior
Introduces types and package structure only; no orchestration yet.

## Verification
- `bun test:types` at the stack tip.

## Review focus
Are the public contracts minimal and sufficient for later implementation commits?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@chatjs/thread`, a type-only package that defines public contracts for a threaded chat engine aligned with `ai` `useChat`. No runtime code.

- New Features
  - Tree snapshots: `MessageTreeSnapshot` (cursorId, nodes[], version: 1) and `ThreadStateSnapshot` with maps, rootIds, messages, status, runs, activeRuns, and error.
  - Runs and handles: `ThreadRun` (id, status, error) and `ThreadRunHandle` (id, finished, getSnapshot(), stop()).
  - Sending: `TreeSendOptions` with `tree.from` and `tree.follow`; `ThreadStartRunOptions` with `message` and `request`.
  - Concurrency and options: `ThreadConcurrency` limits; `ThreadChatOptions` mirrors `useChat` plus `concurrency` and either `initialTree` or `messages`.

- Refactors
  - Separated stable run IDs from message IDs; follow selects the user immediately and the assistant on first stream write; no placeholder assistant node.
  - Removed event types to keep the public surface focused on tree, runs, send, and options.

<sup>Written for commit e9ae97fb9801a366ad9e54507d9764622dd592b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@chatjs/thread` npm package for threaded chat experiences.
  * Exposed an expanded public, type-only API for thread runs, run handles, message trees, snapshots, concurrency controls, and chat/thread options.
  * Added strongly typed inputs for sending messages and starting thread runs, including optional tree relationships.

* **Documentation**
  * Updated `useThread` behavioral contract covering cursor following, identity semantics, and how tree context interacts with the request lifecycle and concurrency.

* **Chores**
  * Added TypeScript build setup for publishing generated type declarations.
  * Enabled Biome formatting and linting with recommended rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. **#234** 👈 current
4. #235
5. #236
6. #237
7. #238
8. #239
9. #240
10. #241
11. #242
12. #243
13. #244
14. #245
15. #246
16. #247
17. #248
18. #249
19. #250
20. #251
21. #252
22. #253
23. #254
<!-- stack:links:end -->