### PR TITLE
Threads 2: Add the canonical message tree

### DIFF
--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -40,8 +40,8 @@
 	},
 	"scripts": {
 		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external",
-		"format": "bunx @biomejs/biome@2.4.10 check --write src *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
-		"lint": "bunx @biomejs/biome@2.4.10 check src ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"format": "bunx @biomejs/biome@2.4.10 check --write src test *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"lint": "bunx @biomejs/biome@2.4.10 check src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
 		"test": "bun test --pass-with-no-tests",
 		"test:unit": "bun test --pass-with-no-tests",

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,3 +1,5 @@
+export { getMessageText, ROOT_PARENT_ID } from "./message-tree";
+
 export type {
 	MessageTreeNode,
 	MessageTreeSnapshot,

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,4 +1,4 @@
-export { getMessageText, ROOT_PARENT_ID } from "./message-tree";
+export { getMessageText } from "./message-tree";
 
 export type {
 	MessageTreeNode,

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,4 +1,4 @@
-export { getMessageText } from "./message-tree";
+export { getMessageText } from "./message-utils";
 
 export type {
 	MessageTreeNode,

--- a/packages/thread/src/message-tree.ts
+++ b/packages/thread/src/message-tree.ts
@@ -1,0 +1,316 @@
+import type { UIMessage } from "ai";
+import type { MessageTreeSnapshot } from "./types";
+
+export const ROOT_PARENT_ID = "__root__";
+
+function parentKey(parentId: string | null) {
+	return parentId ?? ROOT_PARENT_ID;
+}
+
+function clone<T>(value: T): T {
+	return structuredClone(value);
+}
+
+export function getMessageText(message: UIMessage) {
+	return message.parts
+		.map((part) => (part.type === "text" ? part.text : ""))
+		.join("");
+}
+
+export class MessageTree<TMessage extends UIMessage = UIMessage> {
+	readonly #childrenByParentId = new Map<string, string[]>();
+	readonly #messagesById = new Map<string, TMessage>();
+	readonly #parentById = new Map<string, string | null>();
+	#cursorId: string | null = null;
+
+	constructor(
+		options: {
+			messages?: TMessage[];
+			snapshot?: MessageTreeSnapshot<TMessage>;
+		} = {},
+	) {
+		if (options.snapshot) {
+			this.restore(options.snapshot);
+		} else if (options.messages) {
+			this.replacePath(options.messages);
+		}
+	}
+
+	get cursorId() {
+		return this.#cursorId;
+	}
+
+	has(messageId: string) {
+		return this.#messagesById.has(messageId);
+	}
+
+	getMessage(messageId: string) {
+		const message = this.#messagesById.get(messageId);
+		return message ? clone(message) : undefined;
+	}
+
+	getParentId(messageId: string) {
+		return this.#parentById.get(messageId);
+	}
+
+	getParent(messageId: string) {
+		const parentId = this.#parentById.get(messageId);
+		return parentId ? this.getMessage(parentId) : undefined;
+	}
+
+	getChildren(messageId: string | null) {
+		return (this.#childrenByParentId.get(parentKey(messageId)) ?? [])
+			.map((id) => this.#messagesById.get(id))
+			.filter((message): message is TMessage => Boolean(message))
+			.map(clone);
+	}
+
+	getSiblings(messageId: string) {
+		if (!this.#messagesById.has(messageId)) {
+			return [];
+		}
+		return this.getChildren(this.#parentById.get(messageId) ?? null);
+	}
+
+	getLeaves(messageId: string | null = null) {
+		const leaves: TMessage[] = [];
+		const visit = (id: string) => {
+			const children = this.#childrenByParentId.get(parentKey(id)) ?? [];
+			if (children.length === 0) {
+				const message = this.#messagesById.get(id);
+				if (message) {
+					leaves.push(clone(message));
+				}
+				return;
+			}
+			for (const childId of children) {
+				visit(childId);
+			}
+		};
+
+		for (const childId of this.#childrenByParentId.get(parentKey(messageId)) ??
+			[]) {
+			visit(childId);
+		}
+		return leaves;
+	}
+
+	getPathIds(messageId: string | null | undefined = this.#cursorId) {
+		if (!messageId) {
+			return [];
+		}
+		const ids: string[] = [];
+		let currentId: string | null = messageId;
+		while (currentId) {
+			if (!this.#messagesById.has(currentId)) {
+				break;
+			}
+			ids.unshift(currentId);
+			currentId = this.#parentById.get(currentId) ?? null;
+		}
+		return ids;
+	}
+
+	getPath(messageId: string | null | undefined = this.#cursorId) {
+		return this.getPathIds(messageId)
+			.map((id) => this.#messagesById.get(id))
+			.filter((message): message is TMessage => Boolean(message))
+			.map(clone);
+	}
+
+	getSnapshot(): MessageTreeSnapshot<TMessage> {
+		return {
+			childrenByParentId: Object.fromEntries(
+				Array.from(this.#childrenByParentId.entries(), ([id, children]) => [
+					id,
+					[...children],
+				]),
+			),
+			cursorId: this.#cursorId,
+			messagesById: Object.fromEntries(
+				Array.from(this.#messagesById.entries(), ([id, message]) => [
+					id,
+					clone(message),
+				]),
+			),
+			parentById: Object.fromEntries(this.#parentById.entries()),
+			rootIds: [...(this.#childrenByParentId.get(ROOT_PARENT_ID) ?? [])],
+			version: 1,
+		};
+	}
+
+	setCursor(messageId: string | null) {
+		if (messageId !== null && !this.#messagesById.has(messageId)) {
+			throw new Error(`Unknown message ${messageId}`);
+		}
+		this.#cursorId = messageId;
+	}
+
+	setCursorToParentOf(messageId: string) {
+		if (!this.#messagesById.has(messageId)) {
+			throw new Error(`Unknown message ${messageId}`);
+		}
+		this.setCursor(this.#parentById.get(messageId) ?? null);
+	}
+
+	upsertMessage(message: TMessage, parentId: string | null) {
+		if (parentId !== null && !this.#messagesById.has(parentId)) {
+			throw new Error(`Unknown parent message ${parentId}`);
+		}
+		let ancestorId = parentId;
+		while (ancestorId !== null) {
+			if (ancestorId === message.id) {
+				throw new Error(`Cannot create a cycle involving ${message.id}`);
+			}
+			ancestorId = this.#parentById.get(ancestorId) ?? null;
+		}
+
+		const existingParentId = this.#parentById.get(message.id);
+		if (existingParentId !== undefined && existingParentId !== parentId) {
+			throw new Error(
+				`Cannot move message ${message.id} from ${existingParentId ?? "root"} to ${parentId ?? "root"}`,
+			);
+		}
+
+		this.#messagesById.set(message.id, clone(message));
+		this.#parentById.set(message.id, parentId);
+		const key = parentKey(parentId);
+		const children = this.#childrenByParentId.get(key) ?? [];
+		if (!children.includes(message.id)) {
+			this.#childrenByParentId.set(key, [...children, message.id]);
+		}
+	}
+
+	removeLeaf(messageId: string) {
+		if (!this.#messagesById.has(messageId)) {
+			return;
+		}
+		const children = this.#childrenByParentId.get(parentKey(messageId)) ?? [];
+		if (children.length > 0) {
+			throw new Error(`Cannot remove non-leaf message ${messageId}`);
+		}
+		const parentId = this.#parentById.get(messageId) ?? null;
+		this.#messagesById.delete(messageId);
+		this.#parentById.delete(messageId);
+		this.#childrenByParentId.delete(parentKey(messageId));
+		this.#childrenByParentId.set(
+			parentKey(parentId),
+			(this.#childrenByParentId.get(parentKey(parentId)) ?? []).filter(
+				(id) => id !== messageId,
+			),
+		);
+		if (this.#cursorId === messageId) {
+			this.#cursorId = parentId;
+		}
+	}
+
+	replacePath(messages: TMessage[]) {
+		this.validatePath(messages);
+		this.clear();
+		let parentId: string | null = null;
+		for (const message of messages) {
+			this.upsertMessage(message, parentId);
+			parentId = message.id;
+		}
+		this.#cursorId = messages.at(-1)?.id ?? null;
+	}
+
+	reconcilePath(messages: TMessage[], options: { moveCursor?: boolean } = {}) {
+		this.validatePath(messages, true);
+		let parentId: string | null = null;
+		for (const message of messages) {
+			this.upsertMessage(message, parentId);
+			parentId = message.id;
+		}
+		if (options.moveCursor ?? true) {
+			this.#cursorId = messages.at(-1)?.id ?? null;
+		}
+	}
+
+	restore(snapshot: MessageTreeSnapshot<TMessage>) {
+		const restored = new MessageTree<TMessage>();
+		for (const id of Object.keys(snapshot.messagesById)) {
+			const message = snapshot.messagesById[id];
+			if (!message) {
+				continue;
+			}
+			const parentId = snapshot.parentById[id];
+			if (parentId === undefined) {
+				throw new Error(`Missing parent for message ${id}`);
+			}
+			if (parentId !== null && !snapshot.messagesById[parentId]) {
+				throw new Error(`Unknown parent message ${parentId}`);
+			}
+		}
+
+		const visit = (id: string, ancestors: Set<string>) => {
+			if (ancestors.has(id)) {
+				throw new Error(`Cannot restore a cycle involving ${id}`);
+			}
+			const nextAncestors = new Set(ancestors).add(id);
+			for (const childId of snapshot.childrenByParentId[id] ?? []) {
+				visit(childId, nextAncestors);
+			}
+		};
+		for (const rootId of snapshot.rootIds) {
+			visit(rootId, new Set());
+		}
+
+		restored.#messagesById.clear();
+		for (const [id, message] of Object.entries(snapshot.messagesById)) {
+			restored.#messagesById.set(id, clone(message));
+		}
+		for (const [id, parentId] of Object.entries(snapshot.parentById)) {
+			restored.#parentById.set(id, parentId);
+		}
+		for (const [id, children] of Object.entries(snapshot.childrenByParentId)) {
+			restored.#childrenByParentId.set(id, [...children]);
+		}
+		if (
+			snapshot.cursorId !== null &&
+			!restored.#messagesById.has(snapshot.cursorId)
+		) {
+			throw new Error(`Unknown message ${snapshot.cursorId}`);
+		}
+		restored.#cursorId = snapshot.cursorId;
+
+		this.clear();
+		for (const [id, message] of restored.#messagesById) {
+			this.#messagesById.set(id, message);
+		}
+		for (const [id, parentId] of restored.#parentById) {
+			this.#parentById.set(id, parentId);
+		}
+		for (const [id, children] of restored.#childrenByParentId) {
+			this.#childrenByParentId.set(id, children);
+		}
+		this.#cursorId = restored.#cursorId;
+	}
+
+	clear() {
+		this.#childrenByParentId.clear();
+		this.#messagesById.clear();
+		this.#parentById.clear();
+		this.#cursorId = null;
+	}
+
+	private validatePath(messages: TMessage[], validateExistingParents = false) {
+		const ids = new Set<string>();
+		let parentId: string | null = null;
+		for (const message of messages) {
+			if (ids.has(message.id)) {
+				throw new Error(`Duplicate message id ${message.id} in path`);
+			}
+			ids.add(message.id);
+			if (validateExistingParents) {
+				const existingParentId = this.#parentById.get(message.id);
+				if (existingParentId !== undefined && existingParentId !== parentId) {
+					throw new Error(
+						`Cannot move message ${message.id} from ${existingParentId ?? "root"} to ${parentId ?? "root"}`,
+					);
+				}
+			}
+			parentId = message.id;
+		}
+	}
+}

--- a/packages/thread/src/message-tree.ts
+++ b/packages/thread/src/message-tree.ts
@@ -1,7 +1,7 @@
 import type { UIMessage } from "ai";
 import type { MessageTreeSnapshot } from "./types";
 
-export const ROOT_PARENT_ID = "__root__";
+const ROOT_PARENT_ID = "__root__";
 
 function parentKey(parentId: string | null) {
 	return parentId ?? ROOT_PARENT_ID;
@@ -119,14 +119,33 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 	}
 
 	getSnapshot(): MessageTreeSnapshot<TMessage> {
+		const nodes: MessageTreeSnapshot<TMessage>["nodes"] = [];
+		const visit = (messageId: string, parentId: string | null) => {
+			const message = this.#messagesById.get(messageId);
+			if (!message) return;
+			nodes.push({ message: clone(message), parentId });
+			for (const childId of this.#childrenByParentId.get(messageId) ?? []) {
+				visit(childId, messageId);
+			}
+		};
+		for (const rootId of this.#childrenByParentId.get(ROOT_PARENT_ID) ?? []) {
+			visit(rootId, null);
+		}
+
+		return {
+			cursorId: this.#cursorId,
+			nodes,
+			version: 1,
+		};
+	}
+
+	getIndexes() {
 		return {
 			childrenByParentId: Object.fromEntries(
-				Array.from(this.#childrenByParentId.entries(), ([id, children]) => [
-					id,
-					[...children],
-				]),
+				Array.from(this.#childrenByParentId.entries())
+					.filter(([id]) => id !== ROOT_PARENT_ID)
+					.map(([id, children]) => [id, [...children]]),
 			),
-			cursorId: this.#cursorId,
 			messagesById: Object.fromEntries(
 				Array.from(this.#messagesById.entries(), ([id, message]) => [
 					id,
@@ -135,7 +154,6 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 			),
 			parentById: Object.fromEntries(this.#parentById.entries()),
 			rootIds: [...(this.#childrenByParentId.get(ROOT_PARENT_ID) ?? [])],
-			version: 1,
 		};
 	}
 
@@ -153,7 +171,11 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		this.setCursor(this.#parentById.get(messageId) ?? null);
 	}
 
-	upsertMessage(message: TMessage, parentId: string | null) {
+	upsertMessage(
+		message: TMessage,
+		parentId: string | null,
+		options: { index?: number } = {},
+	) {
 		if (parentId !== null && !this.#messagesById.has(parentId)) {
 			throw new Error(`Unknown parent message ${parentId}`);
 		}
@@ -177,7 +199,12 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		const key = parentKey(parentId);
 		const children = this.#childrenByParentId.get(key) ?? [];
 		if (!children.includes(message.id)) {
-			this.#childrenByParentId.set(key, [...children, message.id]);
+			const index = Math.min(options.index ?? children.length, children.length);
+			this.#childrenByParentId.set(key, [
+				...children.slice(0, index),
+				message.id,
+				...children.slice(index),
+			]);
 		}
 	}
 
@@ -229,50 +256,13 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 
 	restore(snapshot: MessageTreeSnapshot<TMessage>) {
 		const restored = new MessageTree<TMessage>();
-		for (const id of Object.keys(snapshot.messagesById)) {
-			const message = snapshot.messagesById[id];
-			if (!message) {
-				continue;
+		for (const { message, parentId } of snapshot.nodes) {
+			if (restored.has(message.id)) {
+				throw new Error(`Duplicate message id ${message.id} in snapshot`);
 			}
-			const parentId = snapshot.parentById[id];
-			if (parentId === undefined) {
-				throw new Error(`Missing parent for message ${id}`);
-			}
-			if (parentId !== null && !snapshot.messagesById[parentId]) {
-				throw new Error(`Unknown parent message ${parentId}`);
-			}
+			restored.upsertMessage(message, parentId);
 		}
-
-		const visit = (id: string, ancestors: Set<string>) => {
-			if (ancestors.has(id)) {
-				throw new Error(`Cannot restore a cycle involving ${id}`);
-			}
-			const nextAncestors = new Set(ancestors).add(id);
-			for (const childId of snapshot.childrenByParentId[id] ?? []) {
-				visit(childId, nextAncestors);
-			}
-		};
-		for (const rootId of snapshot.rootIds) {
-			visit(rootId, new Set());
-		}
-
-		restored.#messagesById.clear();
-		for (const [id, message] of Object.entries(snapshot.messagesById)) {
-			restored.#messagesById.set(id, clone(message));
-		}
-		for (const [id, parentId] of Object.entries(snapshot.parentById)) {
-			restored.#parentById.set(id, parentId);
-		}
-		for (const [id, children] of Object.entries(snapshot.childrenByParentId)) {
-			restored.#childrenByParentId.set(id, [...children]);
-		}
-		if (
-			snapshot.cursorId !== null &&
-			!restored.#messagesById.has(snapshot.cursorId)
-		) {
-			throw new Error(`Unknown message ${snapshot.cursorId}`);
-		}
-		restored.#cursorId = snapshot.cursorId;
+		restored.setCursor(snapshot.cursorId);
 
 		this.clear();
 		for (const [id, message] of restored.#messagesById) {

--- a/packages/thread/src/message-tree.ts
+++ b/packages/thread/src/message-tree.ts
@@ -5,12 +5,6 @@ function clone<T>(value: T): T {
 	return structuredClone(value);
 }
 
-export function getMessageText(message: UIMessage) {
-	return message.parts
-		.map((part) => (part.type === "text" ? part.text : ""))
-		.join("");
-}
-
 export class MessageTree<TMessage extends UIMessage = UIMessage> {
 	readonly #childrenByParentId = new Map<string | null, string[]>();
 	readonly #messagesById = new Map<string, TMessage>();
@@ -26,7 +20,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		if (options.snapshot) {
 			this.restore(options.snapshot);
 		} else if (options.messages) {
-			this.replacePath(options.messages);
+			this.mergePath(options.messages);
 		}
 	}
 
@@ -223,18 +217,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		}
 	}
 
-	replacePath(messages: TMessage[]) {
-		this.validatePath(messages);
-		this.clear();
-		let parentId: string | null = null;
-		for (const message of messages) {
-			this.upsertMessage(message, parentId);
-			parentId = message.id;
-		}
-		this.#cursorId = messages.at(-1)?.id ?? null;
-	}
-
-	reconcilePath(messages: TMessage[], options: { moveCursor?: boolean } = {}) {
+	mergePath(messages: TMessage[], options: { moveCursor?: boolean } = {}) {
 		this.validatePath(messages, true);
 		let parentId: string | null = null;
 		for (const message of messages) {

--- a/packages/thread/src/message-tree.ts
+++ b/packages/thread/src/message-tree.ts
@@ -20,7 +20,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		if (options.snapshot) {
 			this.restore(options.snapshot);
 		} else if (options.messages) {
-			this.mergePath(options.messages);
+			this.setPath(options.messages);
 		}
 	}
 
@@ -217,15 +217,17 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		}
 	}
 
-	mergePath(messages: TMessage[], options: { moveCursor?: boolean } = {}) {
+	setPath(messages: TMessage[]) {
+		this.updatePath(messages);
+		this.#cursorId = messages.at(-1)?.id ?? null;
+	}
+
+	updatePath(messages: TMessage[]) {
 		this.validatePath(messages, true);
 		let parentId: string | null = null;
 		for (const message of messages) {
 			this.upsertMessage(message, parentId);
 			parentId = message.id;
-		}
-		if (options.moveCursor ?? true) {
-			this.#cursorId = messages.at(-1)?.id ?? null;
 		}
 	}
 

--- a/packages/thread/src/message-tree.ts
+++ b/packages/thread/src/message-tree.ts
@@ -1,12 +1,6 @@
 import type { UIMessage } from "ai";
 import type { MessageTreeSnapshot } from "./types";
 
-const ROOT_PARENT_ID = "__root__";
-
-function parentKey(parentId: string | null) {
-	return parentId ?? ROOT_PARENT_ID;
-}
-
 function clone<T>(value: T): T {
 	return structuredClone(value);
 }
@@ -18,7 +12,7 @@ export function getMessageText(message: UIMessage) {
 }
 
 export class MessageTree<TMessage extends UIMessage = UIMessage> {
-	readonly #childrenByParentId = new Map<string, string[]>();
+	readonly #childrenByParentId = new Map<string | null, string[]>();
 	readonly #messagesById = new Map<string, TMessage>();
 	readonly #parentById = new Map<string, string | null>();
 	#cursorId: string | null = null;
@@ -59,7 +53,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 	}
 
 	getChildren(messageId: string | null) {
-		return (this.#childrenByParentId.get(parentKey(messageId)) ?? [])
+		return (this.#childrenByParentId.get(messageId) ?? [])
 			.map((id) => this.#messagesById.get(id))
 			.filter((message): message is TMessage => Boolean(message))
 			.map(clone);
@@ -75,7 +69,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 	getLeaves(messageId: string | null = null) {
 		const leaves: TMessage[] = [];
 		const visit = (id: string) => {
-			const children = this.#childrenByParentId.get(parentKey(id)) ?? [];
+			const children = this.#childrenByParentId.get(id) ?? [];
 			if (children.length === 0) {
 				const message = this.#messagesById.get(id);
 				if (message) {
@@ -88,8 +82,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 			}
 		};
 
-		for (const childId of this.#childrenByParentId.get(parentKey(messageId)) ??
-			[]) {
+		for (const childId of this.#childrenByParentId.get(messageId) ?? []) {
 			visit(childId);
 		}
 		return leaves;
@@ -128,7 +121,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 				visit(childId, messageId);
 			}
 		};
-		for (const rootId of this.#childrenByParentId.get(ROOT_PARENT_ID) ?? []) {
+		for (const rootId of this.#childrenByParentId.get(null) ?? []) {
 			visit(rootId, null);
 		}
 
@@ -143,7 +136,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		return {
 			childrenByParentId: Object.fromEntries(
 				Array.from(this.#childrenByParentId.entries())
-					.filter(([id]) => id !== ROOT_PARENT_ID)
+					.filter((entry): entry is [string, string[]] => entry[0] !== null)
 					.map(([id, children]) => [id, [...children]]),
 			),
 			messagesById: Object.fromEntries(
@@ -153,7 +146,7 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 				]),
 			),
 			parentById: Object.fromEntries(this.#parentById.entries()),
-			rootIds: [...(this.#childrenByParentId.get(ROOT_PARENT_ID) ?? [])],
+			rootIds: [...(this.#childrenByParentId.get(null) ?? [])],
 		};
 	}
 
@@ -196,11 +189,10 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 
 		this.#messagesById.set(message.id, clone(message));
 		this.#parentById.set(message.id, parentId);
-		const key = parentKey(parentId);
-		const children = this.#childrenByParentId.get(key) ?? [];
+		const children = this.#childrenByParentId.get(parentId) ?? [];
 		if (!children.includes(message.id)) {
 			const index = Math.min(options.index ?? children.length, children.length);
-			this.#childrenByParentId.set(key, [
+			this.#childrenByParentId.set(parentId, [
 				...children.slice(0, index),
 				message.id,
 				...children.slice(index),
@@ -212,17 +204,17 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		if (!this.#messagesById.has(messageId)) {
 			return;
 		}
-		const children = this.#childrenByParentId.get(parentKey(messageId)) ?? [];
+		const children = this.#childrenByParentId.get(messageId) ?? [];
 		if (children.length > 0) {
 			throw new Error(`Cannot remove non-leaf message ${messageId}`);
 		}
 		const parentId = this.#parentById.get(messageId) ?? null;
 		this.#messagesById.delete(messageId);
 		this.#parentById.delete(messageId);
-		this.#childrenByParentId.delete(parentKey(messageId));
+		this.#childrenByParentId.delete(messageId);
 		this.#childrenByParentId.set(
-			parentKey(parentId),
-			(this.#childrenByParentId.get(parentKey(parentId)) ?? []).filter(
+			parentId,
+			(this.#childrenByParentId.get(parentId) ?? []).filter(
 				(id) => id !== messageId,
 			),
 		);

--- a/packages/thread/src/message-tree.ts
+++ b/packages/thread/src/message-tree.ts
@@ -62,23 +62,17 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 
 	getLeaves(messageId: string | null = null) {
 		const leaves: TMessage[] = [];
-		const visit = (id: string) => {
+
+		for (const id of this.walkDescendantIds(messageId)) {
 			const children = this.#childrenByParentId.get(id) ?? [];
 			if (children.length === 0) {
 				const message = this.#messagesById.get(id);
 				if (message) {
 					leaves.push(clone(message));
 				}
-				return;
 			}
-			for (const childId of children) {
-				visit(childId);
-			}
-		};
-
-		for (const childId of this.#childrenByParentId.get(messageId) ?? []) {
-			visit(childId);
 		}
+
 		return leaves;
 	}
 
@@ -107,16 +101,15 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 
 	getSnapshot(): MessageTreeSnapshot<TMessage> {
 		const nodes: MessageTreeSnapshot<TMessage>["nodes"] = [];
-		const visit = (messageId: string, parentId: string | null) => {
+
+		for (const messageId of this.walkDescendantIds(null)) {
 			const message = this.#messagesById.get(messageId);
-			if (!message) return;
-			nodes.push({ message: clone(message), parentId });
-			for (const childId of this.#childrenByParentId.get(messageId) ?? []) {
-				visit(childId, messageId);
+			if (message) {
+				nodes.push({
+					message: clone(message),
+					parentId: this.#parentById.get(messageId) ?? null,
+				});
 			}
-		};
-		for (const rootId of this.#childrenByParentId.get(null) ?? []) {
-			visit(rootId, null);
 		}
 
 		return {
@@ -259,6 +252,13 @@ export class MessageTree<TMessage extends UIMessage = UIMessage> {
 		this.#messagesById.clear();
 		this.#parentById.clear();
 		this.#cursorId = null;
+	}
+
+	private *walkDescendantIds(parentId: string | null): Generator<string> {
+		for (const childId of this.#childrenByParentId.get(parentId) ?? []) {
+			yield childId;
+			yield* this.walkDescendantIds(childId);
+		}
 	}
 
 	private validatePath(messages: TMessage[], validateExistingParents = false) {

--- a/packages/thread/src/message-utils.ts
+++ b/packages/thread/src/message-utils.ts
@@ -1,0 +1,7 @@
+import type { UIMessage } from "ai";
+
+export function getMessageText(message: UIMessage) {
+	return message.parts
+		.map((part) => (part.type === "text" ? part.text : ""))
+		.join("");
+}

--- a/packages/thread/test/message-tree.test.ts
+++ b/packages/thread/test/message-tree.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import { MessageTree, ROOT_PARENT_ID } from "../src/message-tree";
+
+function message(id: string, role: UIMessage["role"] = "user"): UIMessage {
+	return { id, parts: [{ text: id, type: "text" }], role };
+}
+
+describe("MessageTree", () => {
+	test("derives the selected path without deleting sibling branches", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+		tree.upsertMessage(message("u2"), "a1");
+		tree.upsertMessage(message("a2", "assistant"), "u2");
+		tree.upsertMessage(message("a3", "assistant"), "u2");
+
+		tree.setCursor("a2");
+
+		expect(tree.getPath().map(({ id }) => id)).toEqual([
+			"u1",
+			"a1",
+			"u2",
+			"a2",
+		]);
+		expect(tree.getSiblings("a2").map(({ id }) => id)).toEqual(["a2", "a3"]);
+		expect(tree.getSnapshot().messagesById.a3?.id).toBe("a3");
+	});
+
+	test("reconciles a selected path without deleting hidden descendants", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+		tree.upsertMessage(message("u2"), "a1");
+		tree.upsertMessage(message("a2", "assistant"), "u2");
+
+		tree.reconcilePath([
+			message("u1"),
+			message("a1", "assistant"),
+			message("u3"),
+		]);
+
+		expect(tree.getPath().map(({ id }) => id)).toEqual(["u1", "a1", "u3"]);
+		expect(tree.getSnapshot().messagesById.a2?.id).toBe("a2");
+	});
+
+	test("validates a path before changing existing nodes", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+		tree.upsertMessage(message("u2"), "a1");
+
+		expect(() => tree.reconcilePath([message("u1"), message("u2")])).toThrow(
+			"Cannot move message u2",
+		);
+		expect(tree.getParentId("u2")).toBe("a1");
+	});
+
+	test("rejects missing parents and cycles", () => {
+		const tree = new MessageTree({ messages: [message("u1")] });
+
+		expect(() => tree.upsertMessage(message("u2"), "missing")).toThrow(
+			"Unknown parent message missing",
+		);
+		expect(() => tree.upsertMessage(message("u1"), "u1")).toThrow(
+			"Cannot create a cycle involving u1",
+		);
+	});
+
+	test("only removes leaves and moves the selected cursor to the parent", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+
+		expect(() => tree.removeLeaf("u1")).toThrow(
+			"Cannot remove non-leaf message u1",
+		);
+		tree.removeLeaf("a1");
+
+		expect(tree.cursorId).toBe("u1");
+		expect(tree.getSnapshot().messagesById.a1).toBeUndefined();
+	});
+
+	test("round-trips a serializable snapshot", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+		const restored = new MessageTree({ snapshot: tree.getSnapshot() });
+
+		expect(restored.getSnapshot()).toEqual(tree.getSnapshot());
+		expect(restored.getSnapshot().childrenByParentId[ROOT_PARENT_ID]).toEqual([
+			"u1",
+		]);
+	});
+});

--- a/packages/thread/test/message-tree.test.ts
+++ b/packages/thread/test/message-tree.test.ts
@@ -27,17 +27,48 @@ describe("MessageTree", () => {
 		expect(tree.getMessage("a3")?.id).toBe("a3");
 	});
 
-	test("merges a selected path without deleting hidden descendants", () => {
+	test("sets the selected path without deleting hidden descendants", () => {
 		const tree = new MessageTree({
 			messages: [message("u1"), message("a1", "assistant")],
 		});
 		tree.upsertMessage(message("u2"), "a1");
 		tree.upsertMessage(message("a2", "assistant"), "u2");
 
-		tree.mergePath([message("u1"), message("a1", "assistant"), message("u3")]);
+		tree.setPath([message("u1"), message("a1", "assistant"), message("u3")]);
 
 		expect(tree.getPath().map(({ id }) => id)).toEqual(["u1", "a1", "u3"]);
 		expect(tree.getMessage("a2")?.id).toBe("a2");
+	});
+
+	test("clears the selected path without deleting tree nodes", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+
+		tree.setPath([]);
+
+		expect(tree.cursorId).toBeNull();
+		expect(tree.getPath()).toEqual([]);
+		expect(tree.getMessage("a1")?.id).toBe("a1");
+	});
+
+	test("updates a path without changing the selected path", () => {
+		const tree = new MessageTree({
+			messages: [message("u1"), message("a1", "assistant")],
+		});
+		tree.upsertMessage(message("u2"), "a1");
+		tree.setCursor("u2");
+
+		tree.updatePath([
+			message("u1"),
+			message("a1", "assistant"),
+			message("u3"),
+			message("a3", "assistant"),
+		]);
+
+		expect(tree.cursorId).toBe("u2");
+		expect(tree.getPath().map(({ id }) => id)).toEqual(["u1", "a1", "u2"]);
+		expect(tree.getMessage("a3")?.id).toBe("a3");
 	});
 
 	test("validates a path before changing existing nodes", () => {
@@ -46,7 +77,7 @@ describe("MessageTree", () => {
 		});
 		tree.upsertMessage(message("u2"), "a1");
 
-		expect(() => tree.mergePath([message("u1"), message("u2")])).toThrow(
+		expect(() => tree.setPath([message("u1"), message("u2")])).toThrow(
 			"Cannot move message u2",
 		);
 		expect(tree.getParentId("u2")).toBe("a1");

--- a/packages/thread/test/message-tree.test.ts
+++ b/packages/thread/test/message-tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
-import { MessageTree, ROOT_PARENT_ID } from "../src/message-tree";
+import { MessageTree } from "../src/message-tree";
 
 function message(id: string, role: UIMessage["role"] = "user"): UIMessage {
 	return { id, parts: [{ text: id, type: "text" }], role };
@@ -24,7 +24,7 @@ describe("MessageTree", () => {
 			"a2",
 		]);
 		expect(tree.getSiblings("a2").map(({ id }) => id)).toEqual(["a2", "a3"]);
-		expect(tree.getSnapshot().messagesById.a3?.id).toBe("a3");
+		expect(tree.getMessage("a3")?.id).toBe("a3");
 	});
 
 	test("reconciles a selected path without deleting hidden descendants", () => {
@@ -41,7 +41,7 @@ describe("MessageTree", () => {
 		]);
 
 		expect(tree.getPath().map(({ id }) => id)).toEqual(["u1", "a1", "u3"]);
-		expect(tree.getSnapshot().messagesById.a2?.id).toBe("a2");
+		expect(tree.getMessage("a2")?.id).toBe("a2");
 	});
 
 	test("validates a path before changing existing nodes", () => {
@@ -78,7 +78,17 @@ describe("MessageTree", () => {
 		tree.removeLeaf("a1");
 
 		expect(tree.cursorId).toBe("u1");
-		expect(tree.getSnapshot().messagesById.a1).toBeUndefined();
+		expect(tree.getMessage("a1")).toBeUndefined();
+	});
+
+	test("inserts a message at an explicit sibling position", () => {
+		const tree = new MessageTree({
+			messages: [message("u1")],
+		});
+		tree.upsertMessage(message("a2", "assistant"), "u1", { index: 1 });
+		tree.upsertMessage(message("a1", "assistant"), "u1", { index: 0 });
+
+		expect(tree.getChildren("u1").map(({ id }) => id)).toEqual(["a1", "a2"]);
 	});
 
 	test("round-trips a serializable snapshot", () => {
@@ -88,8 +98,36 @@ describe("MessageTree", () => {
 		const restored = new MessageTree({ snapshot: tree.getSnapshot() });
 
 		expect(restored.getSnapshot()).toEqual(tree.getSnapshot());
-		expect(restored.getSnapshot().childrenByParentId[ROOT_PARENT_ID]).toEqual([
-			"u1",
-		]);
+		expect(
+			restored.getSnapshot().nodes.map(({ message }) => message.id),
+		).toEqual(["u1", "a1"]);
+		expect(restored.getIndexes().rootIds).toEqual(["u1"]);
+	});
+
+	test("rejects unordered and duplicate snapshot nodes", () => {
+		expect(
+			() =>
+				new MessageTree({
+					snapshot: {
+						cursorId: null,
+						nodes: [{ message: message("a1"), parentId: "u1" }],
+						version: 1,
+					},
+				}),
+		).toThrow("Unknown parent message u1");
+
+		expect(
+			() =>
+				new MessageTree({
+					snapshot: {
+						cursorId: null,
+						nodes: [
+							{ message: message("u1"), parentId: null },
+							{ message: message("u1"), parentId: null },
+						],
+						version: 1,
+					},
+				}),
+		).toThrow("Duplicate message id u1 in snapshot");
 	});
 });

--- a/packages/thread/test/message-tree.test.ts
+++ b/packages/thread/test/message-tree.test.ts
@@ -27,18 +27,14 @@ describe("MessageTree", () => {
 		expect(tree.getMessage("a3")?.id).toBe("a3");
 	});
 
-	test("reconciles a selected path without deleting hidden descendants", () => {
+	test("merges a selected path without deleting hidden descendants", () => {
 		const tree = new MessageTree({
 			messages: [message("u1"), message("a1", "assistant")],
 		});
 		tree.upsertMessage(message("u2"), "a1");
 		tree.upsertMessage(message("a2", "assistant"), "u2");
 
-		tree.reconcilePath([
-			message("u1"),
-			message("a1", "assistant"),
-			message("u3"),
-		]);
+		tree.mergePath([message("u1"), message("a1", "assistant"), message("u3")]);
 
 		expect(tree.getPath().map(({ id }) => id)).toEqual(["u1", "a1", "u3"]);
 		expect(tree.getMessage("a2")?.id).toBe("a2");
@@ -50,7 +46,7 @@ describe("MessageTree", () => {
 		});
 		tree.upsertMessage(message("u2"), "a1");
 
-		expect(() => tree.reconcilePath([message("u1"), message("u2")])).toThrow(
+		expect(() => tree.mergePath([message("u1"), message("u2")])).toThrow(
 			"Cannot move message u2",
 		);
 		expect(tree.getParentId("u2")).toBe("a1");

--- a/packages/thread/test/message-tree.test.ts
+++ b/packages/thread/test/message-tree.test.ts
@@ -67,6 +67,15 @@ describe("MessageTree", () => {
 		);
 	});
 
+	test("allows message IDs that resemble internal root keys", () => {
+		const tree = new MessageTree({ messages: [message("__root__")] });
+		tree.upsertMessage(message("child"), "__root__");
+
+		expect(tree.getIndexes().rootIds).toEqual(["__root__"]);
+		expect(tree.getChildren("__root__").map(({ id }) => id)).toEqual(["child"]);
+		expect(tree.getLeaves().map(({ id }) => id)).toEqual(["child"]);
+	});
+
 	test("only removes leaves and moves the selected cursor to the parent", () => {
 		const tree = new MessageTree({
 			messages: [message("u1"), message("a1", "assistant")],
@@ -129,5 +138,19 @@ describe("MessageTree", () => {
 					},
 				}),
 		).toThrow("Duplicate message id u1 in snapshot");
+
+		expect(
+			() =>
+				new MessageTree({
+					snapshot: {
+						cursorId: null,
+						nodes: [
+							{ message: message("a"), parentId: "b" },
+							{ message: message("b"), parentId: "a" },
+						],
+						version: 1,
+					},
+				}),
+		).toThrow("Unknown parent message b");
 	});
 });


### PR DESCRIPTION
## Summary
- Implements canonical message, parent, child, root, and cursor storage.
- Derives active paths and sibling/leaf navigation without duplicating ancestors.
- Validates missing parents and cycles while preserving hidden branches.

## Behavior
Adds the headless topology layer; no network or React behavior.

## Verification
- Package message-tree tests pass at the stack tip.

## Review focus
Tree invariants, snapshot round trips, and path reconciliation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical, headless message tree with navigation, safe mutations, and v1 snapshot save/restore using ordered traversal. Separates path updates from selection and removes root-sentinel collisions; no network or React changes.

- **New Features**
  - Topology & navigation: parent/child links with real roots via `null` parent and `cursorId`; `getPath`/`getPathIds`, `getSiblings`/`getLeaves`, `getParent`/`getChildren`.
  - Mutations & paths: `upsertMessage` (optional sibling index, no cross-parent moves), `removeLeaf` (moves cursor), cursor setters, `setPath` (update + select), `updatePath` (update only).
  - Snapshots v1: ordered-node serialization via `getSnapshot()` using a single tree traversal and strict `restore` (rejects unordered/duplicate nodes).
  - Utilities: `getMessageText`, `getIndexes()`.

- **Refactors & Bug Fixes**
  - Removed root sentinel usage so IDs like `__root__` work; `getIndexes().rootIds` shows real roots.
  - Separated path updates from selection; tightened validation for cycles and cross-parent moves.
  - Reused a single ordered tree traversal for leaves and snapshot serialization for consistent ordering.
  - Scripts: include `test` in `format`/`lint`; exported `getMessageText`.

<sup>Written for commit 81c2cb567559210e977264bfb7ac8a526976f446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `getMessageText` to extract combined text from message parts, and re-exported it from the thread package.
  * Enhanced the threaded message tree API with `setPath` / `updatePath` for selected-path management.
* **Bug Fixes**
  * Strengthened tree validation to prevent cycles, reject invalid parent insertions, and restrict `removeLeaf` to leaf nodes.
  * Ensured removal and path operations update cursor/path state consistently.
* **Tests**
  * Added Bun test coverage for cursor/path behavior, snapshot round-trips, and validation errors.
* **Chores**
  * Expanded formatting and lint checks to include test files and additional docs/configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. **#235** 👈 current
5. #236
6. #237
7. #238
8. #239
9. #240
10. #241
11. #242
12. #243
13. #244
14. #245
15. #246
16. #247
17. #248
18. #249
19. #250
20. #251
21. #252
22. #253
23. #254
<!-- stack:links:end -->