### PR TITLE
Threads 3: Adapt isolated AI SDK runs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -239,6 +239,7 @@
       "name": "@chatjs/thread",
       "version": "0.0.0",
       "devDependencies": {
+        "@ai-sdk/react": "^3.0.152",
         "@types/bun": "^1.3.12",
         "ai": "^6.0.150",
         "typescript": "6.0.2",

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -51,6 +51,7 @@
 		"ai": "^6.0.0"
 	},
 	"devDependencies": {
+		"@ai-sdk/react": "^3.0.152",
 		"@types/bun": "^1.3.12",
 		"ai": "^6.0.150",
 		"typescript": "6.0.2"

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -1,0 +1,156 @@
+import {
+	AbstractChat,
+	type ChatState,
+	type ChatStatus,
+	type ChatTransport,
+	type UIMessage,
+} from "ai";
+import type { ThreadChatOptions, ThreadRunSpec } from "./types";
+
+export interface ThreadRunHost<TMessage extends UIMessage> {
+	readonly dataPartSchemas: ThreadChatOptions<TMessage>["dataPartSchemas"];
+	readonly id: string;
+	readonly messageMetadataSchema: ThreadChatOptions<TMessage>["messageMetadataSchema"];
+	onData: ThreadChatOptions<TMessage>["onData"];
+	onError: ThreadChatOptions<TMessage>["onError"];
+	onFinish: ThreadChatOptions<TMessage>["onFinish"];
+	onToolCall: ThreadChatOptions<TMessage>["onToolCall"];
+	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
+	transport: ChatTransport<TMessage>;
+	finishRequest: (runId: string, isAbort: boolean) => void;
+	getPath: (messageId: string) => TMessage[];
+	hasAssistantStarted: (messageId: string) => boolean;
+	indexMessageOwnership: (runId: string, message: TMessage) => void;
+	markAssistantStarted: (messageId: string) => void;
+	mergeRunPath: (messages: TMessage[]) => void;
+	registerToolCall: (runId: string, toolCallId: string) => void;
+	removeMessage: (messageId: string) => void;
+	setRunError: (runId: string, error: Error | undefined) => void;
+	setRunStatus: (runId: string, status: ChatStatus) => void;
+	upsertMessage: (
+		message: TMessage,
+		parentId: string | null,
+		options?: { silent?: boolean },
+	) => void;
+}
+
+class ThreadChatState<TMessage extends UIMessage>
+	implements ChatState<TMessage>
+{
+	#error: Error | undefined;
+	readonly #host: ThreadRunHost<TMessage>;
+	readonly #spec: ThreadRunSpec;
+	#status: ChatStatus = "ready";
+
+	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
+		this.#host = host;
+		this.#spec = spec;
+	}
+
+	get error() {
+		return this.#error;
+	}
+
+	set error(error: Error | undefined) {
+		this.#error = error;
+		this.#host.setRunError(this.#spec.runId, error);
+	}
+
+	get messages() {
+		const leafId = this.#host.hasAssistantStarted(this.#spec.assistantMessageId)
+			? this.#spec.assistantMessageId
+			: this.#spec.userMessageId;
+		return this.#host.getPath(leafId);
+	}
+
+	set messages(messages: TMessage[]) {
+		this.#host.mergeRunPath(messages);
+	}
+
+	get status() {
+		return this.#status;
+	}
+
+	set status(status: ChatStatus) {
+		this.#status = status;
+		this.#host.setRunStatus(this.#spec.runId, status);
+	}
+
+	popMessage = () => {
+		const lastMessage = this.messages.at(-1);
+		if (lastMessage) {
+			this.#host.removeMessage(lastMessage.id);
+		}
+	};
+
+	pushMessage = (message: TMessage) => {
+		this.writeMessage(message);
+	};
+
+	replaceMessage = (_index: number, message: TMessage) => {
+		this.writeMessage(message);
+	};
+
+	snapshot = <T>(thing: T): T => structuredClone(thing);
+
+	private writeMessage(message: TMessage) {
+		if (message.role === "assistant") {
+			const assistantMessage = {
+				...message,
+				id: this.#spec.assistantMessageId,
+			};
+			this.#host.markAssistantStarted(this.#spec.assistantMessageId);
+			this.#host.upsertMessage(assistantMessage, this.#spec.userMessageId);
+			this.#host.indexMessageOwnership(this.#spec.runId, assistantMessage);
+			return;
+		}
+
+		this.#host.upsertMessage(message, this.#spec.parentMessageId);
+	}
+}
+
+export class ThreadRunChat<
+	TMessage extends UIMessage,
+> extends AbstractChat<TMessage> {
+	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
+		const transport: ChatTransport<TMessage> = {
+			reconnectToStream: (options) => host.transport.reconnectToStream(options),
+			sendMessages: (options) => host.transport.sendMessages(options),
+		};
+		super({
+			dataPartSchemas: host.dataPartSchemas,
+			generateId: () => spec.assistantMessageId,
+			id: host.id,
+			messageMetadataSchema: host.messageMetadataSchema,
+			onData: (event) => host.onData?.(event),
+			onError: (error) => {
+				host.setRunError(spec.runId, error);
+				host.onError?.(error);
+			},
+			onFinish: (event) => {
+				const assistantMessage = {
+					...event.message,
+					id: spec.assistantMessageId,
+				};
+				host.upsertMessage(assistantMessage, spec.userMessageId, {
+					silent: true,
+				});
+				host.indexMessageOwnership(spec.runId, assistantMessage);
+				host.finishRequest(spec.runId, event.isAbort);
+				host.onFinish?.({
+					...event,
+					message: assistantMessage,
+					messages: host.getPath(spec.assistantMessageId),
+				});
+			},
+			onToolCall: async (event) => {
+				host.registerToolCall(spec.runId, event.toolCall.toolCallId);
+				await host.onToolCall?.(event);
+			},
+			sendAutomaticallyWhen: (event) =>
+				host.sendAutomaticallyWhen?.(event) ?? false,
+			state: new ThreadChatState(host, spec),
+			transport,
+		});
+	}
+}

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -5,7 +5,16 @@ import {
 	type ChatTransport,
 	type UIMessage,
 } from "ai";
-import type { ThreadChatOptions, ThreadRunSpec } from "./types";
+import type { ThreadChatOptions } from "./types";
+
+export type ThreadRunSpec = {
+	assistantMessageId?: string;
+	id: string;
+	originCursorId: string | null;
+	parentMessageId: string | null;
+	siblingOrder: number;
+	userMessageId: string;
+};
 
 export interface ThreadRunHost<TMessage extends UIMessage> {
 	readonly dataPartSchemas: ThreadChatOptions<TMessage>["dataPartSchemas"];
@@ -17,16 +26,14 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	onToolCall: ThreadChatOptions<TMessage>["onToolCall"];
 	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
-	finishRequest: (runId: string, isAbort: boolean) => void;
-	getPath: (messageId: string) => TMessage[];
-	hasAssistantStarted: (messageId: string) => boolean;
-	indexMessageOwnership: (runId: string, message: TMessage) => void;
-	markAssistantStarted: (messageId: string) => void;
+	generateMessageId: () => string;
+	getRunPath: (runId: string) => TMessage[];
 	mergeRunPath: (messages: TMessage[]) => void;
 	registerToolCall: (runId: string, toolCallId: string) => void;
 	removeMessage: (messageId: string) => void;
 	setRunError: (runId: string, error: Error | undefined) => void;
 	setRunStatus: (runId: string, status: ChatStatus) => void;
+	writeRunAssistantMessage: (runId: string, message: TMessage) => void;
 	upsertMessage: (
 		message: TMessage,
 		parentId: string | null,
@@ -53,14 +60,11 @@ class ThreadChatState<TMessage extends UIMessage>
 
 	set error(error: Error | undefined) {
 		this.#error = error;
-		this.#host.setRunError(this.#spec.runId, error);
+		this.#host.setRunError(this.#spec.id, error);
 	}
 
 	get messages() {
-		const leafId = this.#host.hasAssistantStarted(this.#spec.assistantMessageId)
-			? this.#spec.assistantMessageId
-			: this.#spec.userMessageId;
-		return this.#host.getPath(leafId);
+		return this.#host.getRunPath(this.#spec.id);
 	}
 
 	set messages(messages: TMessage[]) {
@@ -73,7 +77,7 @@ class ThreadChatState<TMessage extends UIMessage>
 
 	set status(status: ChatStatus) {
 		this.#status = status;
-		this.#host.setRunStatus(this.#spec.runId, status);
+		this.#host.setRunStatus(this.#spec.id, status);
 	}
 
 	popMessage = () => {
@@ -95,13 +99,7 @@ class ThreadChatState<TMessage extends UIMessage>
 
 	private writeMessage(message: TMessage) {
 		if (message.role === "assistant") {
-			const assistantMessage = {
-				...message,
-				id: this.#spec.assistantMessageId,
-			};
-			this.#host.markAssistantStarted(this.#spec.assistantMessageId);
-			this.#host.upsertMessage(assistantMessage, this.#spec.userMessageId);
-			this.#host.indexMessageOwnership(this.#spec.runId, assistantMessage);
+			this.#host.writeRunAssistantMessage(this.#spec.id, message);
 			return;
 		}
 
@@ -119,32 +117,24 @@ export class ThreadRunChat<
 		};
 		super({
 			dataPartSchemas: host.dataPartSchemas,
-			generateId: () => spec.assistantMessageId,
+			generateId: host.generateMessageId,
 			id: host.id,
 			messageMetadataSchema: host.messageMetadataSchema,
 			onData: (event) => host.onData?.(event),
 			onError: (error) => {
-				host.setRunError(spec.runId, error);
+				host.setRunError(spec.id, error);
 				host.onError?.(error);
 			},
 			onFinish: (event) => {
-				const assistantMessage = {
-					...event.message,
-					id: spec.assistantMessageId,
-				};
-				host.upsertMessage(assistantMessage, spec.userMessageId, {
-					silent: true,
-				});
-				host.indexMessageOwnership(spec.runId, assistantMessage);
-				host.finishRequest(spec.runId, event.isAbort);
+				const assistantMessage = event.message;
 				host.onFinish?.({
 					...event,
 					message: assistantMessage,
-					messages: host.getPath(spec.assistantMessageId),
+					messages: host.getRunPath(spec.id),
 				});
 			},
 			onToolCall: async (event) => {
-				host.registerToolCall(spec.runId, event.toolCall.toolCallId);
+				host.registerToolCall(spec.id, event.toolCall.toolCallId);
 				await host.onToolCall?.(event);
 			},
 			sendAutomaticallyWhen: (event) =>

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -1,5 +1,6 @@
 import {
 	AbstractChat,
+	type ChatRequestOptions,
 	type ChatState,
 	type ChatStatus,
 	type ChatTransport,
@@ -8,12 +9,10 @@ import {
 import type { ThreadChatOptions } from "./types";
 
 export type ThreadRunSpec = {
-	assistantMessageId?: string;
 	id: string;
-	originCursorId: string | null;
+	messageId?: string;
 	parentMessageId: string | null;
 	siblingOrder: number;
-	userMessageId: string;
 };
 
 export interface ThreadRunHost<TMessage extends UIMessage> {
@@ -33,12 +32,14 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	removeMessage: (messageId: string) => void;
 	setRunError: (runId: string, error: Error | undefined) => void;
 	setRunStatus: (runId: string, status: ChatStatus) => void;
-	writeRunAssistantMessage: (runId: string, message: TMessage) => void;
-	upsertMessage: (
-		message: TMessage,
-		parentId: string | null,
-		options?: { silent?: boolean },
-	) => void;
+	writeRunMessage: (runId: string, message: TMessage) => void;
+}
+
+function createPendingMessage<TMessage extends UIMessage>(id: string) {
+	// AbstractChat crosses the same generic boundary when it creates a response:
+	// TMessage may narrow metadata or parts beyond the base UIMessage shape.
+	const message: UIMessage = { id, parts: [], role: "assistant" };
+	return message as TMessage;
 }
 
 class ThreadChatState<TMessage extends UIMessage>
@@ -46,11 +47,17 @@ class ThreadChatState<TMessage extends UIMessage>
 {
 	#error: Error | undefined;
 	readonly #host: ThreadRunHost<TMessage>;
+	readonly #pendingMessage: TMessage;
 	readonly #spec: ThreadRunSpec;
 	#status: ChatStatus = "ready";
 
-	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
+	constructor(
+		host: ThreadRunHost<TMessage>,
+		spec: ThreadRunSpec,
+		pendingMessage: TMessage,
+	) {
 		this.#host = host;
+		this.#pendingMessage = pendingMessage;
 		this.#spec = spec;
 	}
 
@@ -64,11 +71,19 @@ class ThreadChatState<TMessage extends UIMessage>
 	}
 
 	get messages() {
-		return this.#host.getRunPath(this.#spec.id);
+		const path = this.#host.getRunPath(this.#spec.id);
+		return this.#spec.messageId === undefined
+			? [...path, this.#pendingMessage]
+			: path;
 	}
 
 	set messages(messages: TMessage[]) {
-		this.#host.mergeRunPath(messages);
+		const pendingIndex = messages.findIndex(
+			(message) => message.id === this.#pendingMessage.id,
+		);
+		this.#host.mergeRunPath(
+			pendingIndex === -1 ? messages : messages.slice(0, pendingIndex),
+		);
 	}
 
 	get status() {
@@ -82,7 +97,7 @@ class ThreadChatState<TMessage extends UIMessage>
 
 	popMessage = () => {
 		const lastMessage = this.messages.at(-1);
-		if (lastMessage) {
+		if (lastMessage && lastMessage.id !== this.#pendingMessage.id) {
 			this.#host.removeMessage(lastMessage.id);
 		}
 	};
@@ -91,19 +106,17 @@ class ThreadChatState<TMessage extends UIMessage>
 		this.writeMessage(message);
 	};
 
-	replaceMessage = (_index: number, message: TMessage) => {
+	replaceMessage = (index: number, message: TMessage) => {
+		if (index !== this.messages.length - 1) {
+			throw new Error("A thread run can only replace its current response");
+		}
 		this.writeMessage(message);
 	};
 
 	snapshot = <T>(thing: T): T => structuredClone(thing);
 
 	private writeMessage(message: TMessage) {
-		if (message.role === "assistant") {
-			this.#host.writeRunAssistantMessage(this.#spec.id, message);
-			return;
-		}
-
-		this.#host.upsertMessage(message, this.#spec.parentMessageId);
+		this.#host.writeRunMessage(this.#spec.id, message);
 	}
 }
 
@@ -111,25 +124,35 @@ export class ThreadRunChat<
 	TMessage extends UIMessage,
 > extends AbstractChat<TMessage> {
 	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
+		const pendingMessageId = host.generateMessageId();
+		const pendingMessage = createPendingMessage<TMessage>(pendingMessageId);
 		const transport: ChatTransport<TMessage> = {
 			reconnectToStream: (options) => host.transport.reconnectToStream(options),
-			sendMessages: (options) => host.transport.sendMessages(options),
+			sendMessages: (options) => {
+				const hasPendingMessage =
+					spec.messageId === undefined &&
+					options.messages.at(-1)?.id === pendingMessageId;
+				return host.transport.sendMessages({
+					...options,
+					messageId: hasPendingMessage ? undefined : options.messageId,
+					messages: hasPendingMessage
+						? options.messages.slice(0, -1)
+						: options.messages,
+				});
+			},
 		};
 		super({
 			dataPartSchemas: host.dataPartSchemas,
-			generateId: host.generateMessageId,
+			generateId: () => pendingMessageId,
 			id: host.id,
 			messageMetadataSchema: host.messageMetadataSchema,
 			onData: (event) => host.onData?.(event),
 			onError: (error) => {
-				host.setRunError(spec.id, error);
 				host.onError?.(error);
 			},
 			onFinish: (event) => {
-				const assistantMessage = event.message;
 				host.onFinish?.({
 					...event,
-					message: assistantMessage,
 					messages: host.getRunPath(spec.id),
 				});
 			},
@@ -139,8 +162,12 @@ export class ThreadRunChat<
 			},
 			sendAutomaticallyWhen: (event) =>
 				host.sendAutomaticallyWhen?.(event) ?? false,
-			state: new ThreadChatState(host, spec),
+			state: new ThreadChatState(host, spec, pendingMessage),
 			transport,
 		});
+	}
+
+	start(options?: ChatRequestOptions) {
+		return this.sendMessage(undefined, options);
 	}
 }

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -35,29 +35,16 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	writeRunMessage: (runId: string, message: TMessage) => void;
 }
 
-function createPendingMessage<TMessage extends UIMessage>(id: string) {
-	// AbstractChat crosses the same generic boundary when it creates a response:
-	// TMessage may narrow metadata or parts beyond the base UIMessage shape.
-	const message: UIMessage = { id, parts: [], role: "assistant" };
-	return message as TMessage;
-}
-
 class ThreadChatState<TMessage extends UIMessage>
 	implements ChatState<TMessage>
 {
 	#error: Error | undefined;
 	readonly #host: ThreadRunHost<TMessage>;
-	readonly #pendingMessage: TMessage;
 	readonly #spec: ThreadRunSpec;
 	#status: ChatStatus = "ready";
 
-	constructor(
-		host: ThreadRunHost<TMessage>,
-		spec: ThreadRunSpec,
-		pendingMessage: TMessage,
-	) {
+	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
 		this.#host = host;
-		this.#pendingMessage = pendingMessage;
 		this.#spec = spec;
 	}
 
@@ -71,19 +58,11 @@ class ThreadChatState<TMessage extends UIMessage>
 	}
 
 	get messages() {
-		const path = this.#host.getRunPath(this.#spec.id);
-		return this.#spec.messageId === undefined
-			? [...path, this.#pendingMessage]
-			: path;
+		return this.#host.getRunPath(this.#spec.id);
 	}
 
 	set messages(messages: TMessage[]) {
-		const pendingIndex = messages.findIndex(
-			(message) => message.id === this.#pendingMessage.id,
-		);
-		this.#host.mergeRunPath(
-			pendingIndex === -1 ? messages : messages.slice(0, pendingIndex),
-		);
+		this.#host.mergeRunPath(messages);
 	}
 
 	get status() {
@@ -97,9 +76,7 @@ class ThreadChatState<TMessage extends UIMessage>
 
 	popMessage = () => {
 		const lastMessage = this.messages.at(-1);
-		if (lastMessage && lastMessage.id !== this.#pendingMessage.id) {
-			this.#host.removeMessage(lastMessage.id);
-		}
+		if (lastMessage) this.#host.removeMessage(lastMessage.id);
 	};
 
 	pushMessage = (message: TMessage) => {
@@ -124,26 +101,20 @@ export class ThreadRunChat<
 	TMessage extends UIMessage,
 > extends AbstractChat<TMessage> {
 	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
-		const pendingMessageId = host.generateMessageId();
-		const pendingMessage = createPendingMessage<TMessage>(pendingMessageId);
+		const responseMessageId = host.generateMessageId();
 		const transport: ChatTransport<TMessage> = {
 			reconnectToStream: (options) => host.transport.reconnectToStream(options),
 			sendMessages: (options) => {
-				const hasPendingMessage =
-					spec.messageId === undefined &&
-					options.messages.at(-1)?.id === pendingMessageId;
 				return host.transport.sendMessages({
 					...options,
-					messageId: hasPendingMessage ? undefined : options.messageId,
-					messages: hasPendingMessage
-						? options.messages.slice(0, -1)
-						: options.messages,
+					messageId:
+						spec.messageId === undefined ? undefined : options.messageId,
 				});
 			},
 		};
 		super({
 			dataPartSchemas: host.dataPartSchemas,
-			generateId: () => pendingMessageId,
+			generateId: () => responseMessageId,
 			id: host.id,
 			messageMetadataSchema: host.messageMetadataSchema,
 			onData: (event) => host.onData?.(event),
@@ -162,7 +133,7 @@ export class ThreadRunChat<
 			},
 			sendAutomaticallyWhen: (event) =>
 				host.sendAutomaticallyWhen?.(event) ?? false,
-			state: new ThreadChatState(host, spec, pendingMessage),
+			state: new ThreadChatState(host, spec),
 			transport,
 		});
 	}

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -27,7 +27,7 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	transport: ChatTransport<TMessage>;
 	generateMessageId: () => string;
 	getRunPath: (runId: string) => TMessage[];
-	mergeRunPath: (messages: TMessage[]) => void;
+	updateRunPath: (messages: TMessage[]) => void;
 	registerToolCall: (runId: string, toolCallId: string) => void;
 	removeMessage: (messageId: string) => void;
 	setRunError: (runId: string, error: Error | undefined) => void;
@@ -62,7 +62,7 @@ class ThreadChatState<TMessage extends UIMessage>
 	}
 
 	set messages(messages: TMessage[]) {
-		this.#host.mergeRunPath(messages);
+		this.#host.updateRunPath(messages);
 	}
 
 	get status() {

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { Chat } from "@ai-sdk/react";
+import type { ChatStatus, ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { ThreadRunChat, type ThreadRunHost } from "../src/ai-sdk-run-chat";
+import { MessageTree } from "../src/message-tree";
+import type { ThreadRunSpec } from "../src/types";
+
+class ControlledTransport implements ChatTransport<UIMessage> {
+	controller: ReadableStreamDefaultController<UIMessageChunk> | undefined;
+
+	sendMessages: ChatTransport<UIMessage>["sendMessages"] = () =>
+		Promise.resolve(
+			new ReadableStream({
+				start: (controller) => {
+					this.controller = controller;
+				},
+			}),
+		);
+
+	reconnectToStream() {
+		return Promise.resolve(null);
+	}
+
+	emit(...chunks: UIMessageChunk[]) {
+		for (const chunk of chunks) {
+			this.controller?.enqueue(chunk);
+		}
+	}
+
+	finish() {
+		this.controller?.close();
+	}
+}
+
+class TestRunHost implements ThreadRunHost<UIMessage> {
+	readonly dataPartSchemas = undefined;
+	readonly id = "thread-chat";
+	readonly messageMetadataSchema = undefined;
+	readonly tree: MessageTree<UIMessage>;
+	onData: ThreadRunHost<UIMessage>["onData"];
+	onError: ThreadRunHost<UIMessage>["onError"];
+	onFinish: ThreadRunHost<UIMessage>["onFinish"];
+	onToolCall: ThreadRunHost<UIMessage>["onToolCall"];
+	sendAutomaticallyWhen: ThreadRunHost<UIMessage>["sendAutomaticallyWhen"];
+	transport: ChatTransport<UIMessage>;
+	readonly started = new Set<string>();
+	status: ChatStatus = "ready";
+
+	constructor(transport: ChatTransport<UIMessage>, userMessage: UIMessage) {
+		this.transport = transport;
+		this.tree = new MessageTree({ messages: [userMessage] });
+	}
+
+	finishRequest() {}
+	getPath = (messageId: string) => this.tree.getPath(messageId);
+	hasAssistantStarted = (messageId: string) => this.started.has(messageId);
+	indexMessageOwnership() {}
+	markAssistantStarted = (messageId: string) => {
+		this.started.add(messageId);
+	};
+	mergeRunPath = (messages: UIMessage[]) => {
+		this.tree.reconcilePath(messages, { moveCursor: false });
+	};
+	registerToolCall() {}
+	removeMessage = (messageId: string) => this.tree.removeLeaf(messageId);
+	setRunError = (_runId: string, error: Error | undefined) => {
+		this.onError?.(error as Error);
+	};
+	setRunStatus = (_runId: string, status: ChatStatus) => {
+		this.status = status;
+	};
+	upsertMessage = (message: UIMessage, parentId: string | null) => {
+		this.tree.upsertMessage(message, parentId);
+	};
+}
+
+function userMessage(): UIMessage {
+	return {
+		id: "user-1",
+		parts: [{ text: "Compare me", type: "text" }],
+		role: "user",
+	};
+}
+
+const spec: ThreadRunSpec = {
+	assistantMessageId: "assistant-1",
+	follow: true,
+	originCursorId: null,
+	parentMessageId: null,
+	runId: "assistant-1",
+	userMessageId: "user-1",
+};
+
+function emitRichResponse(transport: ControlledTransport) {
+	transport.emit(
+		{ messageId: "assistant-1", type: "start" },
+		{ id: "reasoning-1", type: "reasoning-start" },
+		{ delta: "thinking", id: "reasoning-1", type: "reasoning-delta" },
+		{ id: "reasoning-1", type: "reasoning-end" },
+		{ id: "text-1", type: "text-start" },
+		{ delta: "answer", id: "text-1", type: "text-delta" },
+		{ id: "text-1", type: "text-end" },
+		{ finishReason: "stop", type: "finish" },
+	);
+	transport.finish();
+}
+
+describe("ThreadRunChat", () => {
+	test("matches the AI SDK React Chat reducer for one response", async () => {
+		const standardTransport = new ControlledTransport();
+		const threadTransport = new ControlledTransport();
+		const input = userMessage();
+		const standardChat = new Chat<UIMessage>({
+			generateId: () => spec.assistantMessageId,
+			id: "standard-chat",
+			transport: standardTransport,
+		});
+		const host = new TestRunHost(threadTransport, input);
+		const threadRunChat = new ThreadRunChat(host, spec);
+
+		const standardRequest = standardChat.sendMessage(input);
+		const threadRequest = threadRunChat.sendMessage(input);
+		await Bun.sleep(0);
+		emitRichResponse(standardTransport);
+		emitRichResponse(threadTransport);
+		await Promise.all([standardRequest, threadRequest]);
+
+		expect(host.tree.getMessage(spec.assistantMessageId)).toEqual(
+			standardChat.messages.at(-1),
+		);
+		expect(host.status).toBe("ready");
+	});
+
+	test("keeps the reserved assistant identity when the stream sends another ID", async () => {
+		const transport = new ControlledTransport();
+		const input = userMessage();
+		const host = new TestRunHost(transport, input);
+		const chat = new ThreadRunChat(host, spec);
+
+		const request = chat.sendMessage(input);
+		await Bun.sleep(0);
+		transport.emit(
+			{ messageId: "server-id", type: "start" },
+			{ id: "text-1", type: "text-start" },
+			{ delta: "answer", id: "text-1", type: "text-delta" },
+			{ id: "text-1", type: "text-end" },
+		);
+		transport.finish();
+		await request;
+
+		expect(host.tree.getMessage("server-id")).toBeUndefined();
+		expect(host.tree.getMessage(spec.assistantMessageId)?.id).toBe(
+			spec.assistantMessageId,
+		);
+	});
+});

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -76,7 +76,7 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 	getRunPath = () =>
 		this.tree.getPath(this.spec.messageId ?? this.spec.parentMessageId);
 	mergeRunPath = (messages: UIMessage[]) => {
-		this.tree.reconcilePath(messages, { moveCursor: false });
+		this.tree.mergePath(messages, { moveCursor: false });
 	};
 	registerToolCall() {}
 	removeMessage = (messageId: string) => this.tree.removeLeaf(messageId);

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -75,8 +75,8 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 
 	getRunPath = () =>
 		this.tree.getPath(this.spec.messageId ?? this.spec.parentMessageId);
-	mergeRunPath = (messages: UIMessage[]) => {
-		this.tree.mergePath(messages, { moveCursor: false });
+	updateRunPath = (messages: UIMessage[]) => {
+		this.tree.updatePath(messages);
 	};
 	registerToolCall() {}
 	removeMessage = (messageId: string) => this.tree.removeLeaf(messageId);

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -9,16 +9,24 @@ import {
 import { MessageTree } from "../src/message-tree";
 
 class ControlledTransport implements ChatTransport<UIMessage> {
-	controller: ReadableStreamDefaultController<UIMessageChunk> | undefined;
+	readonly requests: Array<{
+		controller: ReadableStreamDefaultController<UIMessageChunk>;
+		options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0];
+	}> = [];
 
-	sendMessages: ChatTransport<UIMessage>["sendMessages"] = () =>
-		Promise.resolve(
+	get request() {
+		return this.requests.at(-1)?.options;
+	}
+
+	sendMessages: ChatTransport<UIMessage>["sendMessages"] = (options) => {
+		return Promise.resolve(
 			new ReadableStream({
 				start: (controller) => {
-					this.controller = controller;
+					this.requests.push({ controller, options });
 				},
 			}),
 		);
+	};
 
 	reconnectToStream() {
 		return Promise.resolve(null);
@@ -26,12 +34,16 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 
 	emit(...chunks: UIMessageChunk[]) {
 		for (const chunk of chunks) {
-			this.controller?.enqueue(chunk);
+			this.requests.at(-1)?.controller.enqueue(chunk);
 		}
 	}
 
 	finish() {
-		this.controller?.close();
+		this.requests.at(-1)?.controller.close();
+	}
+
+	fail(error: Error) {
+		this.requests.at(-1)?.controller.error(error);
 	}
 }
 
@@ -49,6 +61,7 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 	sendAutomaticallyWhen: ThreadRunHost<UIMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<UIMessage>;
 	status: ChatStatus = "ready";
+	readonly errors: Error[] = [];
 
 	constructor(
 		transport: ChatTransport<UIMessage>,
@@ -61,24 +74,27 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 	}
 
 	getRunPath = () =>
-		this.tree.getPath(this.spec.assistantMessageId ?? this.spec.userMessageId);
+		this.tree.getPath(this.spec.messageId ?? this.spec.parentMessageId);
 	mergeRunPath = (messages: UIMessage[]) => {
 		this.tree.reconcilePath(messages, { moveCursor: false });
 	};
 	registerToolCall() {}
 	removeMessage = (messageId: string) => this.tree.removeLeaf(messageId);
 	setRunError = (_runId: string, error: Error | undefined) => {
-		if (error) this.onError?.(error);
+		if (error) this.errors.push(error);
 	};
 	setRunStatus = (_runId: string, status: ChatStatus) => {
 		this.status = status;
 	};
-	upsertMessage = (message: UIMessage, parentId: string | null) => {
-		this.tree.upsertMessage(message, parentId);
-	};
-	writeRunAssistantMessage = (_runId: string, message: UIMessage) => {
-		this.spec.assistantMessageId = message.id;
-		this.tree.upsertMessage(message, this.spec.userMessageId);
+	writeRunMessage = (_runId: string, message: UIMessage) => {
+		if (this.spec.messageId && this.spec.messageId !== message.id) {
+			throw new Error("Run message identity changed");
+		}
+		if (!this.spec.messageId && this.tree.has(message.id)) {
+			throw new Error("Run message identity already exists");
+		}
+		this.spec.messageId = message.id;
+		this.tree.upsertMessage(message, this.spec.parentMessageId);
 	};
 }
 
@@ -93,10 +109,8 @@ function userMessage(): UIMessage {
 function createSpec(): ThreadRunSpec {
 	return {
 		id: "run-1",
-		originCursorId: null,
-		parentMessageId: null,
+		parentMessageId: "user-1",
 		siblingOrder: 0,
-		userMessageId: "user-1",
 	};
 }
 
@@ -114,6 +128,14 @@ function emitRichResponse(transport: ControlledTransport) {
 	transport.finish();
 }
 
+async function waitFor(predicate: () => boolean) {
+	for (let attempt = 0; attempt < 500; attempt += 1) {
+		if (predicate()) return;
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for request");
+}
+
 describe("ThreadRunChat", () => {
 	test("matches the AI SDK React Chat reducer for one response", async () => {
 		const spec = createSpec();
@@ -129,8 +151,14 @@ describe("ThreadRunChat", () => {
 		const threadRunChat = new ThreadRunChat(host, spec);
 
 		const standardRequest = standardChat.sendMessage(input);
-		const threadRequest = threadRunChat.sendMessage(input);
+		const threadRequest = threadRunChat.start();
 		await Bun.sleep(0);
+		expect(threadTransport.request?.messages).toEqual(
+			standardTransport.request?.messages,
+		);
+		expect(threadTransport.request?.messageId).toBe(
+			standardTransport.request?.messageId,
+		);
 		emitRichResponse(standardTransport);
 		emitRichResponse(threadTransport);
 		await Promise.all([standardRequest, threadRequest]);
@@ -148,7 +176,7 @@ describe("ThreadRunChat", () => {
 		const host = new TestRunHost(transport, input, spec);
 		const chat = new ThreadRunChat(host, spec);
 
-		const request = chat.sendMessage(input);
+		const request = chat.start();
 		await Bun.sleep(0);
 		transport.emit(
 			{ messageId: "server-id", type: "start" },
@@ -161,6 +189,93 @@ describe("ThreadRunChat", () => {
 
 		expect(host.tree.getMessage("client-response")).toBeUndefined();
 		expect(host.tree.getMessage("server-id")?.id).toBe("server-id");
-		expect(spec.assistantMessageId).toBe("server-id");
+		expect(spec.messageId).toBe("server-id");
+	});
+
+	test("creates a distinct response after an assistant parent", async () => {
+		const parent: UIMessage = {
+			id: "assistant-parent",
+			parts: [{ text: "first", type: "text" }],
+			role: "assistant",
+		};
+		const spec: ThreadRunSpec = {
+			id: "run-1",
+			parentMessageId: parent.id,
+			siblingOrder: 0,
+		};
+		const transport = new ControlledTransport();
+		const host = new TestRunHost(transport, parent, spec);
+		const chat = new ThreadRunChat(host, spec);
+
+		const request = chat.start();
+		await Bun.sleep(0);
+		transport.emit(
+			{ messageId: "assistant-child", type: "start" },
+			{ id: "text-1", type: "text-start" },
+			{ delta: "second", id: "text-1", type: "text-delta" },
+			{ id: "text-1", type: "text-end" },
+		);
+		transport.finish();
+		await request;
+
+		expect(host.tree.getMessage(parent.id)).toEqual(parent);
+		expect(host.tree.getParentId("assistant-child")).toBe(parent.id);
+	});
+
+	test("reports a failed stream exactly once without adding a response", async () => {
+		const error = new Error("stream failed");
+		const callbackErrors: Error[] = [];
+		const spec = createSpec();
+		const transport = new ControlledTransport();
+		const host = new TestRunHost(transport, userMessage(), spec);
+		host.onError = (callbackError) => callbackErrors.push(callbackError);
+		const chat = new ThreadRunChat(host, spec);
+
+		const request = chat.start();
+		await waitFor(() => transport.requests.length === 1);
+		transport.fail(error);
+		await request;
+
+		expect(host.errors).toEqual([error]);
+		expect(callbackErrors).toEqual([error]);
+		expect(host.status).toBe("error");
+		expect(host.tree.getChildren(spec.parentMessageId)).toEqual([]);
+	});
+
+	test("continues one response across automatic follow-up requests", async () => {
+		const spec = createSpec();
+		const transport = new ControlledTransport();
+		const host = new TestRunHost(transport, userMessage(), spec);
+		host.sendAutomaticallyWhen = () => transport.requests.length < 2;
+		const chat = new ThreadRunChat(host, spec);
+
+		const request = chat.start();
+		await waitFor(() => transport.requests.length === 1);
+		transport.emit(
+			{ messageId: "assistant-1", type: "start" },
+			{ id: "first", type: "text-start" },
+			{ delta: "one", id: "first", type: "text-delta" },
+			{ id: "first", type: "text-end" },
+		);
+		transport.finish();
+
+		await waitFor(() => transport.requests.length === 2);
+		transport.emit(
+			{ id: "second", type: "text-start" },
+			{ delta: "two", id: "second", type: "text-delta" },
+			{ id: "second", type: "text-end" },
+		);
+		transport.finish();
+		await request;
+
+		expect(transport.requests).toHaveLength(2);
+		expect(
+			host.tree.getChildren(spec.parentMessageId).map(({ id }) => id),
+		).toEqual(["assistant-1"]);
+		expect(host.tree.getMessage("assistant-1")?.parts).toEqual([
+			expect.objectContaining({ text: "one", type: "text" }),
+			expect.objectContaining({ text: "two", type: "text" }),
+		]);
+		expect(host.status).toBe("ready");
 	});
 });

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { Chat } from "@ai-sdk/react";
 import type { ChatStatus, ChatTransport, UIMessage, UIMessageChunk } from "ai";
-import { ThreadRunChat, type ThreadRunHost } from "../src/ai-sdk-run-chat";
+import {
+	ThreadRunChat,
+	type ThreadRunHost,
+	type ThreadRunSpec,
+} from "../src/ai-sdk-run-chat";
 import { MessageTree } from "../src/message-tree";
-import type { ThreadRunSpec } from "../src/types";
 
 class ControlledTransport implements ChatTransport<UIMessage> {
 	controller: ReadableStreamDefaultController<UIMessageChunk> | undefined;
@@ -36,6 +39,8 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 	readonly dataPartSchemas = undefined;
 	readonly id = "thread-chat";
 	readonly messageMetadataSchema = undefined;
+	readonly generateMessageId = () => "client-response";
+	readonly spec: ThreadRunSpec;
 	readonly tree: MessageTree<UIMessage>;
 	onData: ThreadRunHost<UIMessage>["onData"];
 	onError: ThreadRunHost<UIMessage>["onError"];
@@ -43,34 +48,37 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 	onToolCall: ThreadRunHost<UIMessage>["onToolCall"];
 	sendAutomaticallyWhen: ThreadRunHost<UIMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<UIMessage>;
-	readonly started = new Set<string>();
 	status: ChatStatus = "ready";
 
-	constructor(transport: ChatTransport<UIMessage>, userMessage: UIMessage) {
+	constructor(
+		transport: ChatTransport<UIMessage>,
+		userMessage: UIMessage,
+		spec: ThreadRunSpec,
+	) {
 		this.transport = transport;
+		this.spec = spec;
 		this.tree = new MessageTree({ messages: [userMessage] });
 	}
 
-	finishRequest() {}
-	getPath = (messageId: string) => this.tree.getPath(messageId);
-	hasAssistantStarted = (messageId: string) => this.started.has(messageId);
-	indexMessageOwnership() {}
-	markAssistantStarted = (messageId: string) => {
-		this.started.add(messageId);
-	};
+	getRunPath = () =>
+		this.tree.getPath(this.spec.assistantMessageId ?? this.spec.userMessageId);
 	mergeRunPath = (messages: UIMessage[]) => {
 		this.tree.reconcilePath(messages, { moveCursor: false });
 	};
 	registerToolCall() {}
 	removeMessage = (messageId: string) => this.tree.removeLeaf(messageId);
 	setRunError = (_runId: string, error: Error | undefined) => {
-		this.onError?.(error as Error);
+		if (error) this.onError?.(error);
 	};
 	setRunStatus = (_runId: string, status: ChatStatus) => {
 		this.status = status;
 	};
 	upsertMessage = (message: UIMessage, parentId: string | null) => {
 		this.tree.upsertMessage(message, parentId);
+	};
+	writeRunAssistantMessage = (_runId: string, message: UIMessage) => {
+		this.spec.assistantMessageId = message.id;
+		this.tree.upsertMessage(message, this.spec.userMessageId);
 	};
 }
 
@@ -82,14 +90,15 @@ function userMessage(): UIMessage {
 	};
 }
 
-const spec: ThreadRunSpec = {
-	assistantMessageId: "assistant-1",
-	follow: true,
-	originCursorId: null,
-	parentMessageId: null,
-	runId: "assistant-1",
-	userMessageId: "user-1",
-};
+function createSpec(): ThreadRunSpec {
+	return {
+		id: "run-1",
+		originCursorId: null,
+		parentMessageId: null,
+		siblingOrder: 0,
+		userMessageId: "user-1",
+	};
+}
 
 function emitRichResponse(transport: ControlledTransport) {
 	transport.emit(
@@ -107,15 +116,16 @@ function emitRichResponse(transport: ControlledTransport) {
 
 describe("ThreadRunChat", () => {
 	test("matches the AI SDK React Chat reducer for one response", async () => {
+		const spec = createSpec();
 		const standardTransport = new ControlledTransport();
 		const threadTransport = new ControlledTransport();
 		const input = userMessage();
 		const standardChat = new Chat<UIMessage>({
-			generateId: () => spec.assistantMessageId,
+			generateId: () => "client-response",
 			id: "standard-chat",
 			transport: standardTransport,
 		});
-		const host = new TestRunHost(threadTransport, input);
+		const host = new TestRunHost(threadTransport, input, spec);
 		const threadRunChat = new ThreadRunChat(host, spec);
 
 		const standardRequest = standardChat.sendMessage(input);
@@ -125,16 +135,17 @@ describe("ThreadRunChat", () => {
 		emitRichResponse(threadTransport);
 		await Promise.all([standardRequest, threadRequest]);
 
-		expect(host.tree.getMessage(spec.assistantMessageId)).toEqual(
+		expect(host.tree.getMessage("assistant-1")).toEqual(
 			standardChat.messages.at(-1),
 		);
 		expect(host.status).toBe("ready");
 	});
 
-	test("keeps the reserved assistant identity when the stream sends another ID", async () => {
+	test("adopts the server response identity from the start chunk", async () => {
+		const spec = createSpec();
 		const transport = new ControlledTransport();
 		const input = userMessage();
-		const host = new TestRunHost(transport, input);
+		const host = new TestRunHost(transport, input, spec);
 		const chat = new ThreadRunChat(host, spec);
 
 		const request = chat.sendMessage(input);
@@ -148,9 +159,8 @@ describe("ThreadRunChat", () => {
 		transport.finish();
 		await request;
 
-		expect(host.tree.getMessage("server-id")).toBeUndefined();
-		expect(host.tree.getMessage(spec.assistantMessageId)?.id).toBe(
-			spec.assistantMessageId,
-		);
+		expect(host.tree.getMessage("client-response")).toBeUndefined();
+		expect(host.tree.getMessage("server-id")?.id).toBe("server-id");
+		expect(spec.assistantMessageId).toBe("server-id");
 	});
 });


### PR DESCRIPTION
## Summary
- Adds one `AbstractChat` adapter per assistant response.
- Presents a linear branch path to AI SDK while writing updates into the shared tree.
- Binds server output to the reserved assistant identity.

## Behavior
Introduces the per-response AI SDK lifecycle adapter.

## Verification
- Package adapter tests pass at the stack tip.

## Review focus
The adapter boundary and how AI SDK callbacks are forwarded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates each `ai` SDK run and streams updates into the shared message tree. Adds a run-scoped `ThreadRunChat` adapter with colocated spec/host, aligned with SDK semantics and server-driven message IDs.

- **New Features**
  - Added `ThreadRunChat` (single-run `AbstractChat`): proxies transport and `reconnectToStream`; omits `messageId` until server `start`, then adopts it; uses `getRunPath`/`updateRunPath`; forwards run-path `messages` to `onFinish`; merges automatic follow-ups into one response; role-neutral `start()`; forwards `onData`/`onError`/`onToolCall`.
  - Added colocated `ThreadRunSpec` and `ThreadRunHost`: forward lifecycle callbacks; track run `status`/`error`; register tool calls; enforce identity in `writeRunMessage`/`removeMessage`. Tests cover reducer parity with `@ai-sdk/react` `Chat`, server ID adoption, assistant-parent runs, follow-ups, and single error reporting.

- **Dependencies**
  - Added dev dependency `@ai-sdk/react` for test parity.

<sup>Written for commit 786a325736981e141749be2d2eeae6a314b18860. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. #235
5. **#236** 👈 current
6. #237
7. #238
8. #239
9. #240
10. #241
11. #242
12. #243
13. #244
14. #245
15. #246
16. #247
17. #248
18. #249
19. #250
20. #251
21. #252
22. #253
23. #254
<!-- stack:links:end -->