### PR TITLE
Threads 4: Orchestrate concurrent tree runs

### DIFF
--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -209,10 +209,12 @@ type RunRecord<TMessage extends UIMessage> = {
 };
 ```
 
-Run IDs and message IDs are deliberately separate. A run exists before its
-assistant message and keeps the same ID if the server supplies a canonical
-message ID. Stop and resume operations address the stable run ID; message-based
-helpers resolve the run currently associated with that node.
+Run IDs and response message IDs are deliberately separate. Multiple runs can
+be submitted before any response message exists, so each run needs a stable
+identity immediately for status, cancellation, and ownership. Its response
+message ID remains unknown until AI SDK first publishes the response and may
+then come from the server. Message-based helpers resolve the run associated with
+that node after this binding occurs.
 
 `ThreadChat` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
 reconnection needs an AI SDK request lifecycle. Completed run records are

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -297,6 +297,13 @@ A normal `sendMessage` follows this sequence:
 `sendMessage` waits for the request and automatic follow-ups to finish, matching
 the AI SDK contract. `tree.startRun` returns a handle immediately for callers
 that need to start, inspect, or stop multiple responses independently.
+The handle's `finished` property always reads the run's current request promise,
+including a later request started by `resumeRun`.
+
+As in AI SDK, expected transport and stream failures resolve after publishing
+`error` status. Unexpected application or state-layer exceptions that escape
+`AbstractChat` reject `sendMessage`, `resumeRun`, and the corresponding
+`finished` promise.
 
 ## Status and Cancellation
 
@@ -311,16 +318,18 @@ Runs use the AI SDK `ChatStatus` values:
 with `chat.messages` and `chat.error`, it always describes the active path and
 never aggregates hidden branches.
 
-`chat.tree.status` aggregates all runs with active work taking precedence:
+`chat.tree.status` aggregates current activity across all runs:
 
 1. `streaming` when any run is streaming
 2. `submitted` when no run is streaming and any run is submitted
-3. `error` when no run is active and any run has failed
-4. `ready` otherwise
+3. `ready` otherwise
 
 A run is included in `tree.activeRuns` while it is `submitted` or `streaming`.
-Consumers that need to distinguish simultaneous states inspect `tree.runs`;
-the aggregate is intentionally only a whole-tree activity projection.
+Historical failures remain available on their entries in `tree.runs`, but do not
+affect the aggregate after activity finishes. Consumers that need to distinguish
+simultaneous or historical states inspect `tree.runs`; the aggregate is
+intentionally only a whole-tree activity projection and has no aggregate error
+object.
 
 Cancellation is scoped by run:
 

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -196,7 +196,7 @@ receiving stream updates even when their snapshots are not currently rendered.
 
 ## Run Model
 
-Every assistant response has one `RunRecord`:
+Every assistant response lifecycle has one `RunRecord`:
 
 ```ts
 type RunRecord<TMessage extends UIMessage> = {
@@ -222,6 +222,18 @@ addressable.
 Starting multiple runs from the same user message creates assistant siblings.
 Starting runs from separate leaves updates those branches concurrently. Each
 run has independent status, error, request serialization, and cancellation.
+Automatic tool continuations remain in the same run and update the same
+assistant response node.
+
+A new live run requires a non-assistant response parent. AI SDK interprets an
+assistant message at the end of a request as the response to continue, not as
+the parent of another response. Therefore, a bare `startRun` from an assistant
+message is rejected. Branching from an assistant remains supported by attaching
+a new input message with `sendMessage` and generating from that input.
+
+This is a `ThreadChat` live-run invariant, not a `MessageTree` invariant. The
+tree remains role-agnostic so persisted, restored, or server-created data may
+contain assistant-to-assistant edges.
 
 ## AI SDK Integration
 
@@ -240,6 +252,13 @@ behavior for:
 The internal `ThreadChatState` presents one linear branch path to
 `AbstractChat`. It writes accumulated assistant snapshots into `ThreadChat`
 when AI SDK publishes the streaming response.
+
+`ThreadRunChat` does not insert a synthetic response into that path. AI SDK
+creates the provisional assistant response using its normal last-message rules
+and a generated response ID reserved by the run. The first unbound request
+clears its transport `messageId`, matching `useChat.sendMessage(input)`; after
+the response is bound, automatic follow-up requests carry that assistant ID and
+continue the same node.
 
 The supplied AI SDK `ChatTransport` remains the request and stream boundary.
 The package does not define another transport protocol or manually parse
@@ -261,7 +280,8 @@ position so concurrent streams remain ordered by creation rather than arrival.
 A normal `sendMessage` follows this sequence:
 
 1. Resolve the origin from the active cursor or an explicit `tree.from` value.
-2. Check concurrency limits and reject without mutating the tree when exceeded.
+2. Validate that the response parent is not an assistant and check concurrency
+   limits, rejecting without mutating the tree when either condition fails.
 3. Create or update the user message under that origin.
 4. Create a stable run ID and reserve its sibling position without adding a
    placeholder message.

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,4 +1,5 @@
 export { getMessageText } from "./message-utils";
+export { createThreadChat, ThreadChat } from "./thread-chat";
 
 export type {
 	MessageTreeNode,

--- a/packages/thread/src/run-registry.ts
+++ b/packages/thread/src/run-registry.ts
@@ -121,12 +121,10 @@ export class RunRegistry<TMessage extends UIMessage> {
 			(run) => run.status === "submitted" || run.status === "streaming",
 		);
 		let status: ChatStatus = "ready";
-		if (runs.some((run) => run.status === "streaming")) {
+		if (activeRuns.some((run) => run.status === "streaming")) {
 			status = "streaming";
-		} else if (runs.some((run) => run.status === "submitted")) {
+		} else if (activeRuns.some((run) => run.status === "submitted")) {
 			status = "submitted";
-		} else if (runs.some((run) => run.status === "error")) {
-			status = "error";
 		}
 		return { activeRuns, runs, status };
 	}
@@ -249,7 +247,6 @@ export class RunRegistry<TMessage extends UIMessage> {
 		const run = this.#runsById.get(runId);
 		if (!run) return;
 		run.error = error;
-		run.status = error ? "error" : run.status;
 	}
 
 	setStatus(runId: string, status: ChatStatus) {

--- a/packages/thread/src/run-registry.ts
+++ b/packages/thread/src/run-registry.ts
@@ -1,0 +1,289 @@
+import type { ChatStatus, UIMessage } from "ai";
+import type { ThreadRunChat, ThreadRunSpec } from "./ai-sdk-run-chat";
+import type { ThreadConcurrency, ThreadRun } from "./types";
+
+export type RunRecord<TMessage extends UIMessage> = {
+	chat: ThreadRunChat<TMessage>;
+	error: Error | undefined;
+	finished: Promise<void>;
+	spec: ThreadRunSpec;
+	status: ChatStatus;
+};
+
+export class RunRegistry<TMessage extends UIMessage> {
+	readonly #concurrency: Required<ThreadConcurrency>;
+	readonly #runIdByApprovalId = new Map<string, string>();
+	readonly #runIdByToolCallId = new Map<string, string>();
+	readonly #runsById = new Map<string, RunRecord<TMessage>>();
+	#selectedRunId: string | null = null;
+
+	constructor(concurrency: ThreadConcurrency = {}) {
+		this.#concurrency = {
+			maxActiveRuns: concurrency.maxActiveRuns ?? Number.POSITIVE_INFINITY,
+			maxActiveRunsPerMessage:
+				concurrency.maxActiveRunsPerMessage ?? Number.POSITIVE_INFINITY,
+		};
+	}
+
+	add(record: RunRecord<TMessage>) {
+		if (this.#runsById.has(record.spec.id)) {
+			throw new Error(`Run ${record.spec.id} already exists`);
+		}
+		this.#runsById.set(record.spec.id, record);
+	}
+
+	assertCanStart(parentMessageId: string) {
+		const activeRuns = this.getActive();
+		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
+			throw new Error("Cannot start run: max active runs reached");
+		}
+		const activeFromMessage = activeRuns.filter(
+			(run) => run.spec.parentMessageId === parentMessageId,
+		).length;
+		if (activeFromMessage >= this.#concurrency.maxActiveRunsPerMessage) {
+			throw new Error(`Cannot start another run from ${parentMessageId}`);
+		}
+	}
+
+	clear() {
+		this.#selectedRunId = null;
+		this.#runIdByApprovalId.clear();
+		this.#runIdByToolCallId.clear();
+		this.#runsById.clear();
+	}
+
+	get(runId: string) {
+		return this.#runsById.get(runId);
+	}
+
+	getActive() {
+		return this.values().filter(
+			(run) => run.status === "submitted" || run.status === "streaming",
+		);
+	}
+
+	getForApproval(approvalId: string) {
+		const runId = this.#runIdByApprovalId.get(approvalId);
+		if (!runId) throw new Error(`No run owns tool approval ${approvalId}`);
+		return this.require(runId);
+	}
+
+	getForMessage(messageId: string) {
+		const runs = this.values().reverse();
+		return (
+			runs.find((candidate) => candidate.spec.messageId === messageId) ??
+			runs.find(
+				(candidate) =>
+					candidate.spec.parentMessageId === messageId &&
+					(candidate.status === "submitted" ||
+						candidate.status === "streaming"),
+			) ??
+			runs.find((candidate) => candidate.spec.parentMessageId === messageId)
+		);
+	}
+
+	getForToolCall(toolCallId: string) {
+		const runId = this.#runIdByToolCallId.get(toolCallId);
+		if (!runId) throw new Error(`No run owns tool call ${toolCallId}`);
+		return this.require(runId);
+	}
+
+	getInsertionIndex({
+		childIds,
+		parentMessageId,
+		siblingOrder,
+	}: {
+		childIds: string[];
+		parentMessageId: string | null;
+		siblingOrder: number;
+	}) {
+		const siblingOrderByMessageId = new Map<string, number>();
+		for (const candidate of this.#runsById.values()) {
+			if (
+				candidate.spec.parentMessageId === parentMessageId &&
+				candidate.spec.messageId
+			) {
+				siblingOrderByMessageId.set(
+					candidate.spec.messageId,
+					candidate.spec.siblingOrder,
+				);
+			}
+		}
+		return childIds.filter((childId) => {
+			const order = siblingOrderByMessageId.get(childId);
+			return order === undefined || order < siblingOrder;
+		}).length;
+	}
+
+	getSnapshot() {
+		const runs = this.snapshots();
+		const activeRuns = runs.filter(
+			(run) => run.status === "submitted" || run.status === "streaming",
+		);
+		let status: ChatStatus = "ready";
+		if (runs.some((run) => run.status === "streaming")) {
+			status = "streaming";
+		} else if (runs.some((run) => run.status === "submitted")) {
+			status = "submitted";
+		} else if (runs.some((run) => run.status === "error")) {
+			status = "error";
+		}
+		return { activeRuns, runs, status };
+	}
+
+	resolveSelected({
+		cursorId,
+		pathIds,
+	}: {
+		cursorId: string | null;
+		pathIds: ReadonlySet<string>;
+	}) {
+		if (this.#selectedRunId) {
+			const selectedRun = this.#runsById.get(this.#selectedRunId);
+			if (selectedRun) return selectedRun;
+		}
+
+		const runs = this.values().reverse();
+		const responseRun = runs.find(
+			(run) =>
+				run.spec.messageId !== undefined && pathIds.has(run.spec.messageId),
+		);
+		if (responseRun) return responseRun;
+		if (!cursorId) return undefined;
+
+		return (
+			runs.find(
+				(run) =>
+					run.spec.parentMessageId === cursorId &&
+					(run.status === "submitted" || run.status === "streaming"),
+			) ?? runs.find((run) => run.spec.parentMessageId === cursorId)
+		);
+	}
+
+	indexMessageOwnership(runId: string, message: TMessage) {
+		const toolCallIds: string[] = [];
+		const approvalIds: string[] = [];
+		for (const part of message.parts) {
+			if ("toolCallId" in part && typeof part.toolCallId === "string") {
+				toolCallIds.push(part.toolCallId);
+			}
+			if (
+				"approval" in part &&
+				part.approval &&
+				typeof part.approval === "object" &&
+				"id" in part.approval &&
+				typeof part.approval.id === "string"
+			) {
+				approvalIds.push(part.approval.id);
+			}
+		}
+
+		for (const toolCallId of toolCallIds) {
+			this.assertOwnershipAvailable(
+				this.#runIdByToolCallId,
+				toolCallId,
+				runId,
+				"tool call",
+			);
+		}
+		for (const approvalId of approvalIds) {
+			this.assertOwnershipAvailable(
+				this.#runIdByApprovalId,
+				approvalId,
+				runId,
+				"tool approval",
+			);
+		}
+		for (const toolCallId of toolCallIds) {
+			this.#runIdByToolCallId.set(toolCallId, runId);
+		}
+		for (const approvalId of approvalIds) {
+			this.#runIdByApprovalId.set(approvalId, runId);
+		}
+	}
+
+	isExplicitlySelected(runId: string) {
+		return this.#selectedRunId === runId;
+	}
+
+	registerToolCall(runId: string, toolCallId: string) {
+		this.assertOwnershipAvailable(
+			this.#runIdByToolCallId,
+			toolCallId,
+			runId,
+			"tool call",
+		);
+		this.#runIdByToolCallId.set(toolCallId, runId);
+	}
+
+	require(runId: string) {
+		const run = this.#runsById.get(runId);
+		if (!run) throw new Error(`Unknown run ${runId}`);
+		return run;
+	}
+
+	reserveId(generateId: () => string) {
+		const runId = generateId();
+		if (this.#runsById.has(runId)) {
+			throw new Error(`Run ${runId} already exists`);
+		}
+		return runId;
+	}
+
+	reserveSiblingOrder(
+		parentMessageId: string | null,
+		existingChildrenCount: number,
+	) {
+		const existingMessageOrder = existingChildrenCount - 1;
+		const runOrders = this.values()
+			.filter((run) => run.spec.parentMessageId === parentMessageId)
+			.map((run) => run.spec.siblingOrder);
+		return Math.max(existingMessageOrder, ...runOrders) + 1;
+	}
+
+	select(runId: string | null) {
+		this.#selectedRunId = runId;
+	}
+
+	setError(runId: string, error: Error | undefined) {
+		const run = this.#runsById.get(runId);
+		if (!run) return;
+		run.error = error;
+		run.status = error ? "error" : run.status;
+	}
+
+	setStatus(runId: string, status: ChatStatus) {
+		const run = this.#runsById.get(runId);
+		if (run) run.status = status;
+	}
+
+	snapshots() {
+		return this.values().map((run) => this.toSnapshot(run));
+	}
+
+	toSnapshot(run: RunRecord<TMessage>): ThreadRun {
+		return {
+			error: run.error,
+			id: run.spec.id,
+			status: run.status,
+		};
+	}
+
+	values() {
+		return Array.from(this.#runsById.values());
+	}
+
+	private assertOwnershipAvailable(
+		owners: Map<string, string>,
+		id: string,
+		runId: string,
+		label: string,
+	) {
+		const existingRunId = owners.get(id);
+		if (existingRunId && existingRunId !== runId) {
+			throw new Error(
+				`${label} ${id} is already owned by run ${existingRunId}`,
+			);
+		}
+	}
+}

--- a/packages/thread/src/run-registry.ts
+++ b/packages/thread/src/run-registry.ts
@@ -32,7 +32,7 @@ export class RunRegistry<TMessage extends UIMessage> {
 		this.#runsById.set(record.spec.id, record);
 	}
 
-	assertCanStart(parentMessageId: string) {
+	assertCanStart(parentMessageId: string | null) {
 		const activeRuns = this.getActive();
 		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
 			throw new Error("Cannot start run: max active runs reached");

--- a/packages/thread/src/run-registry.ts
+++ b/packages/thread/src/run-registry.ts
@@ -1,4 +1,4 @@
-import type { ChatStatus, UIMessage } from "ai";
+import { type ChatStatus, isToolUIPart, type UIMessage } from "ai";
 import type { ThreadRunChat, ThreadRunSpec } from "./ai-sdk-run-chat";
 import type { ThreadConcurrency, ThreadRun } from "./types";
 
@@ -162,18 +162,9 @@ export class RunRegistry<TMessage extends UIMessage> {
 		const toolCallIds: string[] = [];
 		const approvalIds: string[] = [];
 		for (const part of message.parts) {
-			if ("toolCallId" in part && typeof part.toolCallId === "string") {
-				toolCallIds.push(part.toolCallId);
-			}
-			if (
-				"approval" in part &&
-				part.approval &&
-				typeof part.approval === "object" &&
-				"id" in part.approval &&
-				typeof part.approval.id === "string"
-			) {
-				approvalIds.push(part.approval.id);
-			}
+			if (!isToolUIPart(part)) continue;
+			toolCallIds.push(part.toolCallId);
+			if (part.approval) approvalIds.push(part.approval.id);
 		}
 
 		for (const toolCallId of toolCallIds) {

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -1,0 +1,653 @@
+import {
+	type ChatRequestOptions,
+	type ChatStatus,
+	type ChatTransport,
+	type CreateUIMessage,
+	convertFileListToFileUIParts,
+	DefaultChatTransport,
+	generateId,
+	type UIMessage,
+} from "ai";
+import { ThreadRunChat, type ThreadRunHost } from "./ai-sdk-run-chat";
+import { MessageTree } from "./message-tree";
+import type {
+	MessageTreeSnapshot,
+	SendMessageInput,
+	ThreadChatOptions,
+	ThreadConcurrency,
+	ThreadRun,
+	ThreadRunHandle,
+	ThreadRunSpec,
+	ThreadStartRunOptions,
+	ThreadStateSnapshot,
+	TreeSendOptions,
+} from "./types";
+
+type RunRecord<TMessage extends UIMessage> = {
+	aborted: boolean;
+	chat: ThreadRunChat<TMessage>;
+	error: Error | undefined;
+	finished: Promise<void>;
+	spec: ThreadRunSpec;
+	status: ChatStatus;
+};
+
+function getAssistantMessageIdFromOptions(options?: TreeSendOptions) {
+	const assistantMessageId = (
+		options?.body as Record<string, unknown> | undefined
+	)?.assistantMessageId;
+	return typeof assistantMessageId === "string" ? assistantMessageId : null;
+}
+
+function getInputMessageId<TMessage extends UIMessage>(
+	input: NonNullable<SendMessageInput<TMessage>>,
+) {
+	if ("id" in input && typeof input.id === "string") {
+		return input.id;
+	}
+	return input.messageId;
+}
+
+function createEmptyAssistantMessage<TMessage extends UIMessage>(id: string) {
+	return { id, parts: [], role: "assistant" } as unknown as TMessage;
+}
+
+async function createUserMessageFromInput<TMessage extends UIMessage>({
+	fallbackId,
+	input,
+}: {
+	fallbackId: string;
+	input: NonNullable<SendMessageInput<TMessage>>;
+}): Promise<TMessage> {
+	const messageId = getInputMessageId(input) ?? fallbackId;
+	const metadata = "metadata" in input ? input.metadata : undefined;
+	if ("text" in input) {
+		const fileParts =
+			"files" in input && input.files
+				? Array.isArray(input.files)
+					? input.files
+					: await convertFileListToFileUIParts(input.files)
+				: [];
+		return {
+			id: messageId,
+			metadata,
+			parts: [...fileParts, { text: input.text, type: "text" }],
+			role: "user",
+		} as TMessage;
+	}
+	if ("files" in input && input.files) {
+		return {
+			id: messageId,
+			metadata,
+			parts: Array.isArray(input.files)
+				? input.files
+				: await convertFileListToFileUIParts(input.files),
+			role: "user",
+		} as TMessage;
+	}
+	return {
+		...input,
+		id: messageId,
+		metadata,
+		parts: "parts" in input ? input.parts : [],
+		role: "user",
+	} as TMessage;
+}
+
+export class ThreadChat<TMessage extends UIMessage = UIMessage>
+	implements ThreadRunHost<TMessage>
+{
+	readonly id: string;
+	readonly dataPartSchemas: ThreadChatOptions<TMessage>["dataPartSchemas"];
+	readonly generateMessageId: NonNullable<
+		ThreadChatOptions<TMessage>["generateId"]
+	>;
+	readonly messageMetadataSchema: ThreadChatOptions<TMessage>["messageMetadataSchema"];
+	onData: ThreadChatOptions<TMessage>["onData"];
+	onError: ThreadChatOptions<TMessage>["onError"];
+	onFinish: ThreadChatOptions<TMessage>["onFinish"];
+	onThreadEvent: ThreadChatOptions<TMessage>["onThreadEvent"];
+	onToolCall: ThreadChatOptions<TMessage>["onToolCall"];
+	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
+	transport: ChatTransport<TMessage>;
+
+	readonly #assistantStarted = new Set<string>();
+	readonly #concurrency: Required<ThreadConcurrency>;
+	readonly #listeners = new Set<() => void>();
+	readonly #runsById = new Map<string, RunRecord<TMessage>>();
+	readonly #tree: MessageTree<TMessage>;
+	#lastEvent = "Ready";
+	#snapshot: ThreadStateSnapshot<TMessage>;
+	#storeVersion = 0;
+
+	constructor(options: ThreadChatOptions<TMessage> = {}) {
+		this.id = options.id ?? generateId();
+		this.dataPartSchemas = options.dataPartSchemas;
+		this.generateMessageId = options.generateId ?? generateId;
+		this.messageMetadataSchema = options.messageMetadataSchema;
+		this.onData = options.onData;
+		this.onError = options.onError;
+		this.onFinish = options.onFinish;
+		this.onThreadEvent = options.onThreadEvent;
+		this.onToolCall = options.onToolCall;
+		this.sendAutomaticallyWhen = options.sendAutomaticallyWhen;
+		this.transport = options.transport ?? new DefaultChatTransport();
+		this.#concurrency = {
+			maxActiveRuns:
+				options.concurrency?.maxActiveRuns ?? Number.POSITIVE_INFINITY,
+			maxActiveRunsPerMessage:
+				options.concurrency?.maxActiveRunsPerMessage ??
+				Number.POSITIVE_INFINITY,
+		};
+		this.#tree = new MessageTree({
+			messages: options.messages,
+			snapshot: options.initialTree,
+		});
+		this.#snapshot = this.buildSnapshot();
+	}
+
+	getSnapshot = () => this.#snapshot;
+
+	updateOptions(options: ThreadChatOptions<TMessage>) {
+		if ("onData" in options) this.onData = options.onData;
+		if ("onError" in options) this.onError = options.onError;
+		if ("onFinish" in options) this.onFinish = options.onFinish;
+		if ("onThreadEvent" in options) {
+			this.onThreadEvent = options.onThreadEvent;
+		}
+		if ("onToolCall" in options) this.onToolCall = options.onToolCall;
+		if ("sendAutomaticallyWhen" in options) {
+			this.sendAutomaticallyWhen = options.sendAutomaticallyWhen;
+		}
+		if (options.transport) this.transport = options.transport;
+	}
+
+	subscribe = (listener: () => void) => {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	};
+
+	addMessage(message: TMessage, parentId: string | null) {
+		this.upsertMessage(message, parentId);
+	}
+
+	getTreeSnapshot() {
+		return this.#tree.getSnapshot();
+	}
+
+	getChildren(messageId: string | null) {
+		return this.#tree.getChildren(messageId);
+	}
+
+	getLeaves(messageId: string | null = null) {
+		return this.#tree.getLeaves(messageId);
+	}
+
+	getMessage(messageId: string) {
+		return this.#tree.getMessage(messageId);
+	}
+
+	getParent(messageId: string) {
+		return this.#tree.getParent(messageId);
+	}
+
+	getPath(messageId?: string | null) {
+		return this.#tree.getPath(messageId);
+	}
+
+	getSiblings(messageId: string) {
+		return this.#tree.getSiblings(messageId);
+	}
+
+	setCursor(messageId: string | null) {
+		this.#tree.setCursor(messageId);
+		this.emit(`Set cursor ${messageId ?? "root"}`);
+		this.onThreadEvent?.({ cursorId: messageId, type: "cursor-changed" });
+	}
+
+	setCursorToParentOf(messageId: string) {
+		this.#tree.setCursorToParentOf(messageId);
+		this.emit(`Set cursor ${this.#tree.cursorId ?? "root"}`);
+		this.onThreadEvent?.({
+			cursorId: this.#tree.cursorId,
+			type: "cursor-changed",
+		});
+	}
+
+	hasAssistantStarted(assistantMessageId: string) {
+		return this.#assistantStarted.has(assistantMessageId);
+	}
+
+	markAssistantStarted(assistantMessageId: string) {
+		this.#assistantStarted.add(assistantMessageId);
+	}
+
+	upsertMessage(
+		message: TMessage,
+		parentId: string | null,
+		options: { silent?: boolean } = {},
+	) {
+		this.#tree.upsertMessage(message, parentId);
+		if (!options.silent) this.emit(`Upserted ${message.id}`);
+	}
+
+	removeMessage(messageId: string) {
+		this.#tree.removeLeaf(messageId);
+		this.emit(`Removed ${messageId}`);
+	}
+
+	replacePath(messages: TMessage[], options: { silent?: boolean } = {}) {
+		this.assertCanResetTree();
+		this.clearRunState();
+		this.#tree.replacePath(messages);
+		if (!options.silent) this.emit("Replaced active path");
+	}
+
+	mergePath(messages: TMessage[], options: { silent?: boolean } = {}) {
+		this.#tree.reconcilePath(messages);
+		if (!options.silent) this.emit("Reconciled active path");
+	}
+
+	mergeRunPath(messages: TMessage[]) {
+		this.#tree.reconcilePath(messages, { moveCursor: false });
+	}
+
+	restore(
+		snapshot: MessageTreeSnapshot<TMessage>,
+		options: { silent?: boolean } = {},
+	) {
+		this.assertCanResetTree();
+		this.clearRunState();
+		this.#tree.restore(snapshot);
+		if (!options.silent) this.emit("Restored tree");
+	}
+
+	setMessages(messages: TMessage[] | ((messages: TMessage[]) => TMessage[])) {
+		const nextMessages =
+			typeof messages === "function"
+				? messages(this.#snapshot.messages)
+				: messages;
+		this.mergePath(nextMessages);
+	}
+
+	sendMessage = async (
+		input?: SendMessageInput<TMessage>,
+		options?: TreeSendOptions,
+	) => {
+		const run = await this.startRun({
+			follow: options?.tree?.follow,
+			from:
+				options?.tree && "from" in options.tree
+					? (options.tree.from ?? null)
+					: undefined,
+			message: input,
+			request: options,
+		});
+		await run.finished;
+	};
+
+	startRun = async ({
+		follow: requestedFollow,
+		from,
+		message: input,
+		request: options,
+	}: ThreadStartRunOptions<TMessage> = {}): Promise<ThreadRunHandle> => {
+		const originCursorId = from === undefined ? this.#tree.cursorId : from;
+		if (originCursorId && !this.#tree.has(originCursorId)) {
+			throw new Error(`Unknown message ${originCursorId}`);
+		}
+		const follow = requestedFollow ?? originCursorId === this.#tree.cursorId;
+
+		if (!input) {
+			const originMessage = originCursorId
+				? this.#tree.getMessage(originCursorId)
+				: undefined;
+			if (!originMessage || originMessage.role !== "user") {
+				throw new Error("Select a user message before starting a run");
+			}
+			this.assertCanStartRun(originMessage.id);
+			return this.startAssistantForUser({
+				assistantMessageId: this.reserveAssistantMessageId(
+					options,
+					originMessage.id,
+				),
+				follow,
+				options,
+				originCursorId,
+				parentMessageId: this.#tree.getParentId(originMessage.id) ?? null,
+				userMessageId: originMessage.id,
+			});
+		}
+
+		const userMessage = await createUserMessageFromInput({
+			fallbackId: getInputMessageId(input) ?? this.generateMessageId(),
+			input,
+		});
+		const existingMessage = this.#tree.getMessage(userMessage.id);
+		if (existingMessage && existingMessage.role !== "user") {
+			throw new Error(`Message ${userMessage.id} is not a user message`);
+		}
+		this.assertCanStartRun(userMessage.id);
+		const assistantMessageId = this.reserveAssistantMessageId(
+			options,
+			userMessage.id,
+		);
+		const attachmentId = existingMessage
+			? (this.#tree.getParentId(userMessage.id) ?? null)
+			: originCursorId;
+		this.#tree.upsertMessage(userMessage, attachmentId);
+		if (follow) this.#tree.setCursor(userMessage.id);
+
+		return this.startAssistantForUser({
+			assistantMessageId,
+			follow,
+			options,
+			originCursorId,
+			parentMessageId: attachmentId,
+			userMessageId: userMessage.id,
+		});
+	};
+
+	clearError = () => {
+		const run = this.getSelectedRunRecord();
+		if (run) {
+			run.error = undefined;
+			run.chat.clearError();
+			this.emit("Cleared error");
+		}
+	};
+
+	stop = () => this.getSelectedRunRecord()?.chat.stop() ?? Promise.resolve();
+
+	stopAll() {
+		return Promise.all(
+			this.getActiveRunRecords().map((run) => run.chat.stop()),
+		).then(() => undefined);
+	}
+
+	stopRun(runId: string) {
+		return this.#runsById.get(runId)?.chat.stop() ?? Promise.resolve();
+	}
+
+	stopRunForMessage(messageId: string) {
+		const run = this.getRunForMessage(messageId);
+		return run ? this.stopRun(run.id) : Promise.resolve();
+	}
+
+	getRun(runId: string) {
+		const run = this.#runsById.get(runId);
+		return run ? this.toRunSnapshot(run) : undefined;
+	}
+
+	getRunForMessage(messageId: string) {
+		const runs = Array.from(this.#runsById.values()).reverse();
+		const run =
+			runs.find(
+				(candidate) => candidate.spec.assistantMessageId === messageId,
+			) ??
+			runs.find(
+				(candidate) =>
+					candidate.spec.userMessageId === messageId &&
+					(candidate.status === "submitted" ||
+						candidate.status === "streaming"),
+			) ??
+			runs.find((candidate) => candidate.spec.userMessageId === messageId);
+		return run ? this.toRunSnapshot(run) : undefined;
+	}
+
+	setRunError(runId: string, error: Error | undefined) {
+		const run = this.#runsById.get(runId);
+		if (!run) return;
+		run.error = error;
+		run.status = error ? "error" : run.status;
+		this.emit(error ? `Error in ${runId}` : "Cleared error");
+		this.emitRunEvent(run, "run-updated");
+	}
+
+	setRunStatus(runId: string, status: ChatStatus) {
+		const run = this.#runsById.get(runId);
+		if (!run) return;
+		run.status = status;
+		this.emit(`${runId} is ${status}`);
+		this.emitRunEvent(run, "run-updated");
+	}
+
+	finishRequest(runId: string, isAbort: boolean) {
+		const run = this.#runsById.get(runId);
+		if (run) run.aborted ||= isAbort;
+		this.emit(isAbort ? `Stopping ${runId}` : `Received ${runId}`);
+	}
+
+	registerToolCall() {}
+
+	indexMessageOwnership() {}
+
+	private buildSnapshot(): ThreadStateSnapshot<TMessage> {
+		const tree = this.#tree.getSnapshot();
+		const runs = Array.from(this.#runsById.values()).map((run) =>
+			this.toRunSnapshot(run),
+		);
+		const activeRuns = runs.filter(
+			(run) => run.status === "submitted" || run.status === "streaming",
+		);
+		const selectedRun = this.getSelectedRunRecord();
+		return {
+			...tree,
+			activeRuns,
+			error: selectedRun?.error,
+			lastEvent: this.#lastEvent,
+			messages: this.#tree.getPath(),
+			runs,
+			status: selectedRun?.status ?? "ready",
+			storeVersion: this.#storeVersion,
+			treeStatus: this.resolveStatus(runs),
+		};
+	}
+
+	private emit(event: string) {
+		this.#lastEvent = event;
+		this.#storeVersion += 1;
+		this.#snapshot = this.buildSnapshot();
+		for (const listener of this.#listeners) listener();
+	}
+
+	private assertCanStartRun(userMessageId: string) {
+		const activeRuns = this.getActiveRunRecords();
+		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
+			throw new Error("Cannot start run: max active runs reached");
+		}
+		const activeFromMessage = activeRuns.filter(
+			(run) => run.spec.userMessageId === userMessageId,
+		).length;
+		if (activeFromMessage >= this.#concurrency.maxActiveRunsPerMessage) {
+			throw new Error(`Cannot start another run from ${userMessageId}`);
+		}
+	}
+
+	private getActiveRunRecords() {
+		return Array.from(this.#runsById.values()).filter(
+			(run) => run.status === "submitted" || run.status === "streaming",
+		);
+	}
+
+	private getSelectedRunRecord() {
+		const pathIds = new Set(this.#tree.getPathIds());
+		return Array.from(this.#runsById.values())
+			.reverse()
+			.find((run) => pathIds.has(run.spec.assistantMessageId));
+	}
+
+	private assertCanResetTree() {
+		if (this.getActiveRunRecords().length > 0) {
+			throw new Error("Cannot replace the tree while runs are active");
+		}
+	}
+
+	private clearRunState() {
+		this.#assistantStarted.clear();
+		this.#runsById.clear();
+	}
+
+	private reserveAssistantMessageId(
+		options: TreeSendOptions | undefined,
+		userMessageId: string,
+	) {
+		const assistantMessageId =
+			getAssistantMessageIdFromOptions(options) ?? this.generateMessageId();
+		const existingMessage = this.#tree.getMessage(assistantMessageId);
+		const isClaimablePlaceholder =
+			existingMessage?.role === "assistant" &&
+			existingMessage.parts.length === 0 &&
+			this.#tree.getParentId(assistantMessageId) === userMessageId;
+		if (
+			assistantMessageId === userMessageId ||
+			(existingMessage && !isClaimablePlaceholder) ||
+			this.#runsById.has(assistantMessageId)
+		) {
+			throw new Error(
+				`Assistant message id ${assistantMessageId} is unavailable`,
+			);
+		}
+		return assistantMessageId;
+	}
+
+	private startAssistantForUser({
+		assistantMessageId,
+		follow,
+		options,
+		originCursorId,
+		parentMessageId,
+		userMessageId,
+	}: Omit<ThreadRunSpec, "runId"> & { options?: TreeSendOptions }) {
+		const spec: ThreadRunSpec = {
+			assistantMessageId,
+			follow,
+			originCursorId,
+			parentMessageId,
+			runId: assistantMessageId,
+			userMessageId,
+		};
+		if (!this.#tree.has(assistantMessageId)) {
+			this.#tree.upsertMessage(
+				createEmptyAssistantMessage<TMessage>(assistantMessageId),
+				userMessageId,
+			);
+		}
+		if (follow) this.#tree.setCursor(assistantMessageId);
+		return this.startRunRequest(spec, options);
+	}
+
+	private startRunRequest(spec: ThreadRunSpec, options?: TreeSendOptions) {
+		const chat = new ThreadRunChat(this, spec);
+		const record: RunRecord<TMessage> = {
+			aborted: false,
+			chat,
+			error: undefined,
+			finished: Promise.resolve(),
+			spec,
+			status: "submitted",
+		};
+		this.#runsById.set(spec.runId, record);
+		this.emit(`Started ${spec.runId}`);
+		this.emitRunEvent(record, "run-started");
+		const userMessage = this.#tree.getMessage(spec.userMessageId);
+		const finished = chat
+			.sendMessage(userMessage as CreateUIMessage<TMessage>, {
+				...this.withRunRequestBody(spec, options),
+			})
+			.catch((error: unknown) => {
+				this.setRunError(
+					spec.runId,
+					error instanceof Error ? error : new Error(String(error)),
+				);
+			})
+			.finally(() => this.completeRun(spec.runId));
+		record.finished = finished;
+		return this.createRunHandle(record);
+	}
+
+	private completeRun(runId: string) {
+		const run = this.#runsById.get(runId);
+		if (!run) return;
+		this.emit(
+			run.aborted
+				? `Stopped ${runId}`
+				: run.error
+					? `Failed ${runId}`
+					: `Finished ${runId}`,
+		);
+		this.emitRunEvent(
+			run,
+			run.aborted ? "run-aborted" : run.error ? "run-failed" : "run-completed",
+		);
+	}
+
+	private createRunHandle(run: RunRecord<TMessage>): ThreadRunHandle {
+		return {
+			assistantMessageId: run.spec.assistantMessageId,
+			finished: run.finished,
+			getSnapshot: () => this.getRun(run.spec.runId),
+			id: run.spec.runId,
+			stop: () => this.stopRun(run.spec.runId),
+		};
+	}
+
+	private emitRunEvent(
+		run: RunRecord<TMessage>,
+		type:
+			| "run-aborted"
+			| "run-completed"
+			| "run-failed"
+			| "run-started"
+			| "run-updated",
+	) {
+		this.onThreadEvent?.({ run: this.toRunSnapshot(run), type });
+	}
+
+	private toRunSnapshot(run: RunRecord<TMessage>): ThreadRun {
+		return {
+			assistantMessageId: run.spec.assistantMessageId,
+			error: run.error,
+			follow: run.spec.follow,
+			id: run.spec.runId,
+			originCursorId: run.spec.originCursorId,
+			parentMessageId: run.spec.parentMessageId,
+			status: run.status,
+			userMessageId: run.spec.userMessageId,
+		};
+	}
+
+	private resolveStatus(runs: ThreadRun[]) {
+		if (runs.some((run) => run.status === "error")) return "error";
+		if (runs.some((run) => run.status === "streaming")) return "streaming";
+		if (runs.some((run) => run.status === "submitted")) return "submitted";
+		return "ready";
+	}
+
+	private withRunRequestBody(
+		spec: ThreadRunSpec,
+		options: ChatRequestOptions | undefined,
+	): ChatRequestOptions {
+		return {
+			...options,
+			body: {
+				...(options?.body ?? {}),
+				assistantMessageId: spec.assistantMessageId,
+				tree: {
+					assistantMessageId: spec.assistantMessageId,
+					cursorId: spec.assistantMessageId,
+					originCursorId: spec.originCursorId,
+					parentMessageId: spec.parentMessageId,
+					pathIds: this.#tree.getPathIds(spec.assistantMessageId),
+					userMessageId: spec.userMessageId,
+				},
+			},
+		};
+	}
+}
+
+export function createThreadChat<TMessage extends UIMessage = UIMessage>(
+	options: ThreadChatOptions<TMessage> = {},
+) {
+	return new ThreadChat(options);
+}

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -31,10 +31,7 @@ type SendMessageInput<TMessage extends UIMessage> = Parameters<
 function getInputMessageId<TMessage extends UIMessage>(
 	input: NonNullable<SendMessageInput<TMessage>>,
 ) {
-	if ("id" in input && typeof input.id === "string") {
-		return input.id;
-	}
-	return input.messageId;
+	return "id" in input ? (input.id ?? input.messageId) : input.messageId;
 }
 
 function specializeMessage<TMessage extends UIMessage>(message: UIMessage) {
@@ -51,28 +48,20 @@ async function createMessageFromInput<TMessage extends UIMessage>({
 	input: NonNullable<SendMessageInput<TMessage>>;
 }): Promise<TMessage> {
 	const messageId = getInputMessageId(input) ?? fallbackId;
-	const metadata = "metadata" in input ? input.metadata : undefined;
-	if ("text" in input && typeof input.text === "string") {
-		const fileParts =
-			"files" in input && input.files
-				? Array.isArray(input.files)
-					? input.files
-					: await convertFileListToFileUIParts(input.files)
-				: [];
+	const metadata = input.metadata;
+	if ("text" in input || "files" in input) {
+		const fileParts = Array.isArray(input.files)
+			? input.files
+			: await convertFileListToFileUIParts(input.files);
 		return specializeMessage<TMessage>({
 			id: messageId,
 			metadata,
-			parts: [...fileParts, { text: input.text, type: "text" }],
-			role: "user",
-		});
-	}
-	if ("files" in input && input.files) {
-		return specializeMessage<TMessage>({
-			id: messageId,
-			metadata,
-			parts: Array.isArray(input.files)
-				? input.files
-				: await convertFileListToFileUIParts(input.files),
+			parts: [
+				...fileParts,
+				...("text" in input && input.text != null
+					? [{ text: input.text, type: "text" as const }]
+					: []),
+			],
 			role: "user",
 		});
 	}
@@ -80,7 +69,6 @@ async function createMessageFromInput<TMessage extends UIMessage>({
 		...input,
 		id: messageId,
 		metadata,
-		parts: "parts" in input ? input.parts : [],
 		role: input.role ?? "user",
 	});
 }

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -52,7 +52,7 @@ function specializeMessage<TMessage extends UIMessage>(message: UIMessage) {
 	return message as TMessage;
 }
 
-async function createUserMessageFromInput<TMessage extends UIMessage>({
+async function createMessageFromInput<TMessage extends UIMessage>({
 	fallbackId,
 	input,
 }: {
@@ -90,7 +90,7 @@ async function createUserMessageFromInput<TMessage extends UIMessage>({
 		id: messageId,
 		metadata,
 		parts: "parts" in input ? input.parts : [],
-		role: "user",
+		role: input.role ?? "user",
 	});
 }
 
@@ -221,14 +221,12 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	getRunPath(runId: string) {
 		const run = this.getRunRecord(runId);
-		return this.#tree.getPath(
-			run.spec.assistantMessageId ?? run.spec.userMessageId,
-		);
+		return this.#tree.getPath(run.spec.messageId ?? run.spec.parentMessageId);
 	}
 
-	writeRunAssistantMessage(runId: string, message: TMessage) {
+	writeRunMessage(runId: string, message: TMessage) {
 		const run = this.getRunRecord(runId);
-		const currentMessageId = run.spec.assistantMessageId;
+		const currentMessageId = run.spec.messageId;
 		if (currentMessageId && currentMessageId !== message.id) {
 			throw new Error(
 				`Run ${runId} is already bound to message ${currentMessageId}`,
@@ -239,33 +237,33 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			if (existingMessage) {
 				throw new Error(`Message ${message.id} already exists`);
 			}
-			run.spec.assistantMessageId = message.id;
+			run.spec.messageId = message.id;
 		}
 
 		const siblingOrderByMessageId = new Map<string, number>();
 		for (const candidate of this.#runsById.values()) {
-			if (candidate.spec.assistantMessageId) {
+			if (candidate.spec.messageId) {
 				siblingOrderByMessageId.set(
-					candidate.spec.assistantMessageId,
+					candidate.spec.messageId,
 					candidate.spec.siblingOrder,
 				);
 			}
 		}
 		const insertionIndex = this.#tree
-			.getChildren(run.spec.userMessageId)
+			.getChildren(run.spec.parentMessageId)
 			.filter((child) => {
 				const siblingOrder = siblingOrderByMessageId.get(child.id);
 				return (
 					siblingOrder === undefined || siblingOrder < run.spec.siblingOrder
 				);
 			}).length;
-		this.#tree.upsertMessage(message, run.spec.userMessageId, {
+		this.#tree.upsertMessage(message, run.spec.parentMessageId, {
 			index: insertionIndex,
 		});
 		this.indexMessageOwnership(runId, message);
 		if (
 			this.#selectedRunId === runId &&
-			this.#tree.cursorId === run.spec.userMessageId
+			this.#tree.cursorId === run.spec.parentMessageId
 		) {
 			this.#tree.setCursor(message.id);
 		}
@@ -283,20 +281,18 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 				: undefined);
 		if (!target) return;
 
-		const userMessageId =
+		const parentMessageId =
 			target.role === "assistant"
 				? this.#tree.getParentId(target.id)
 				: target.id;
-		if (!userMessageId) return;
+		if (!parentMessageId) return;
 
-		this.assertCanStartRun(userMessageId);
-		const run = this.startAssistantForUser({
+		this.assertCanStartRun(parentMessageId);
+		const run = this.startRunFromParent({
 			follow: true,
 			id: this.reserveRunId(),
 			options,
-			originCursorId: target.id,
-			parentMessageId: this.#tree.getParentId(userMessageId) ?? null,
-			userMessageId,
+			parentMessageId,
 		});
 		await run.finished;
 	};
@@ -393,42 +389,35 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			const originMessage = originCursorId
 				? this.#tree.getMessage(originCursorId)
 				: undefined;
-			if (!originMessage || originMessage.role !== "user") {
-				throw new Error("Select a user message before starting a run");
+			if (!originMessage) {
+				throw new Error("Select a message before starting a run");
 			}
 			this.assertCanStartRun(originMessage.id);
-			return this.startAssistantForUser({
+			return this.startRunFromParent({
 				follow,
 				id: this.reserveRunId(),
 				options,
-				originCursorId,
-				parentMessageId: this.#tree.getParentId(originMessage.id) ?? null,
-				userMessageId: originMessage.id,
+				parentMessageId: originMessage.id,
 			});
 		}
 
-		const userMessage = await createUserMessageFromInput({
+		const message = await createMessageFromInput({
 			fallbackId: getInputMessageId(input) ?? this.generateMessageId(),
 			input,
 		});
-		const existingMessage = this.#tree.getMessage(userMessage.id);
-		if (existingMessage && existingMessage.role !== "user") {
-			throw new Error(`Message ${userMessage.id} is not a user message`);
-		}
-		this.assertCanStartRun(userMessage.id);
+		const existingMessage = this.#tree.getMessage(message.id);
+		this.assertCanStartRun(message.id);
 		const attachmentId = existingMessage
-			? (this.#tree.getParentId(userMessage.id) ?? null)
+			? (this.#tree.getParentId(message.id) ?? null)
 			: originCursorId;
-		this.#tree.upsertMessage(userMessage, attachmentId);
-		if (follow) this.#tree.setCursor(userMessage.id);
+		this.#tree.upsertMessage(message, attachmentId);
+		if (follow) this.#tree.setCursor(message.id);
 
-		return this.startAssistantForUser({
+		return this.startRunFromParent({
 			follow,
 			id: this.reserveRunId(),
 			options,
-			originCursorId,
-			parentMessageId: attachmentId,
-			userMessageId: userMessage.id,
+			parentMessageId: message.id,
 		});
 	};
 
@@ -466,16 +455,14 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	getRunForMessage(messageId: string) {
 		const runs = Array.from(this.#runsById.values()).reverse();
 		const run =
-			runs.find(
-				(candidate) => candidate.spec.assistantMessageId === messageId,
-			) ??
+			runs.find((candidate) => candidate.spec.messageId === messageId) ??
 			runs.find(
 				(candidate) =>
-					candidate.spec.userMessageId === messageId &&
+					candidate.spec.parentMessageId === messageId &&
 					(candidate.status === "submitted" ||
 						candidate.status === "streaming"),
 			) ??
-			runs.find((candidate) => candidate.spec.userMessageId === messageId);
+			runs.find((candidate) => candidate.spec.parentMessageId === messageId);
 		return run ? this.toRunSnapshot(run) : undefined;
 	}
 
@@ -573,16 +560,16 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		for (const listener of this.#listeners) listener();
 	}
 
-	private assertCanStartRun(userMessageId: string) {
+	private assertCanStartRun(parentMessageId: string) {
 		const activeRuns = this.getActiveRunRecords();
 		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
 			throw new Error("Cannot start run: max active runs reached");
 		}
 		const activeFromMessage = activeRuns.filter(
-			(run) => run.spec.userMessageId === userMessageId,
+			(run) => run.spec.parentMessageId === parentMessageId,
 		).length;
 		if (activeFromMessage >= this.#concurrency.maxActiveRunsPerMessage) {
-			throw new Error(`Cannot start another run from ${userMessageId}`);
+			throw new Error(`Cannot start another run from ${parentMessageId}`);
 		}
 	}
 
@@ -601,20 +588,18 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		const runs = Array.from(this.#runsById.values()).reverse();
 		const responseRun = runs.find(
 			(run) =>
-				run.spec.assistantMessageId !== undefined &&
-				pathIds.has(run.spec.assistantMessageId),
+				run.spec.messageId !== undefined && pathIds.has(run.spec.messageId),
 		);
 		if (responseRun) return responseRun;
 
 		const cursorId = this.#tree.cursorId;
-		const cursor = cursorId ? this.#tree.getMessage(cursorId) : undefined;
-		if (cursor?.role !== "user") return undefined;
+		if (!cursorId) return undefined;
 		return (
 			runs.find(
 				(run) =>
-					run.spec.userMessageId === cursor.id &&
+					run.spec.parentMessageId === cursorId &&
 					(run.status === "submitted" || run.status === "streaming"),
-			) ?? runs.find((run) => run.spec.userMessageId === cursor.id)
+			) ?? runs.find((run) => run.spec.parentMessageId === cursorId)
 		);
 	}
 
@@ -637,24 +622,22 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	private createRunForSelectedAssistant() {
-		const assistantMessageId = this.#tree.cursorId;
-		if (!assistantMessageId) return undefined;
-		const assistantMessage = this.#tree.getMessage(assistantMessageId);
-		if (!assistantMessage || assistantMessage.role !== "assistant") {
+		const messageId = this.#tree.cursorId;
+		if (!messageId) return undefined;
+		const message = this.#tree.getMessage(messageId);
+		if (!message || message.role !== "assistant") {
 			return undefined;
 		}
-		const userMessageId = this.#tree.getParentId(assistantMessageId);
-		if (!userMessageId) return undefined;
+		const parentMessageId = this.#tree.getParentId(messageId);
+		if (!parentMessageId) return undefined;
 
-		const spec: ThreadRunSpec = {
-			assistantMessageId,
+		const spec: ThreadRunSpec & { parentMessageId: string } = {
+			messageId,
+			parentMessageId,
 			siblingOrder: this.#tree
-				.getChildren(userMessageId)
-				.findIndex((message) => message.id === assistantMessageId),
+				.getChildren(parentMessageId)
+				.findIndex((child) => child.id === messageId),
 			id: this.reserveRunId(),
-			originCursorId: assistantMessageId,
-			parentMessageId: this.#tree.getParentId(userMessageId) ?? null,
-			userMessageId,
 		};
 		const record: RunRecord<TMessage> = {
 			chat: new ThreadRunChat(this, spec),
@@ -665,7 +648,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		};
 		this.#runsById.set(spec.id, record);
 		this.#selectedRunId = spec.id;
-		this.indexMessageOwnership(spec.id, assistantMessage);
+		this.indexMessageOwnership(spec.id, message);
 		this.emit();
 		return record;
 	}
@@ -705,41 +688,45 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		return runId;
 	}
 
-	private startAssistantForUser({
+	private startRunFromParent({
 		follow,
 		id,
 		options,
-		originCursorId,
 		parentMessageId,
-		userMessageId,
-	}: Omit<ThreadRunSpec, "assistantMessageId" | "siblingOrder"> & {
+	}: Omit<ThreadRunSpec, "messageId" | "parentMessageId" | "siblingOrder"> & {
 		follow: boolean;
 		options?: ChatRequestOptions;
+		parentMessageId: string;
 	}) {
-		const spec: ThreadRunSpec = {
+		const spec: ThreadRunSpec & { parentMessageId: string } = {
 			id,
-			originCursorId,
 			parentMessageId,
-			siblingOrder: this.reserveSiblingOrder(userMessageId),
-			userMessageId,
+			siblingOrder: this.reserveSiblingOrder(parentMessageId),
 		};
 		if (follow) {
 			this.#selectedRunId = id;
-			this.#tree.setCursor(userMessageId);
+			this.#tree.setCursor(parentMessageId);
 		}
 		return this.startRunRequest(spec, options);
 	}
 
-	private reserveSiblingOrder(userMessageId: string) {
+	private reserveSiblingOrder(parentMessageId: string | null) {
 		const existingMessageOrder =
-			this.#tree.getChildren(userMessageId).length - 1;
+			this.#tree.getChildren(parentMessageId).length - 1;
 		const runOrders = Array.from(this.#runsById.values())
-			.filter((run) => run.spec.userMessageId === userMessageId)
+			.filter((run) => run.spec.parentMessageId === parentMessageId)
 			.map((run) => run.spec.siblingOrder);
 		return Math.max(existingMessageOrder, ...runOrders) + 1;
 	}
 
-	private startRunRequest(spec: ThreadRunSpec, options?: ChatRequestOptions) {
+	private startRunRequest(
+		spec: ThreadRunSpec & { parentMessageId: string },
+		options?: ChatRequestOptions,
+	) {
+		const parentMessage = this.#tree.getMessage(spec.parentMessageId);
+		if (!parentMessage) {
+			throw new Error(`Unknown message ${spec.parentMessageId}`);
+		}
 		const chat = new ThreadRunChat(this, spec);
 		const record: RunRecord<TMessage> = {
 			chat,
@@ -750,9 +737,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		};
 		this.#runsById.set(spec.id, record);
 		this.emit();
-		const userMessage = this.#tree.getMessage(spec.userMessageId);
 		const finished = chat
-			.sendMessage(userMessage, options)
+			.start(options)
 			.catch((error: unknown) => {
 				this.setRunError(
 					spec.id,

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -234,11 +234,14 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		...options
 	} = {}) => {
 		const target =
-			(messageId ? this.#tree.getMessage(messageId) : undefined) ??
-			(this.#tree.cursorId
-				? this.#tree.getMessage(this.#tree.cursorId)
-				: undefined);
-		if (!target) return;
+			messageId == null
+				? this.#tree.cursorId
+					? this.#tree.getMessage(this.#tree.cursorId)
+					: undefined
+				: this.#tree.getMessage(messageId);
+		if (!target) {
+			throw new Error(`message ${messageId} not found`);
+		}
 
 		const parentMessageId =
 			target.role === "assistant"
@@ -442,8 +445,11 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		for (const listener of this.#listeners) listener();
 	}
 
-	private assertCanStartRun(parentMessageId: string) {
-		const parentMessage = this.#tree.getMessage(parentMessageId);
+	private assertCanStartRun(parentMessageId: string | null) {
+		const parentMessage =
+			parentMessageId == null
+				? undefined
+				: this.#tree.getMessage(parentMessageId);
 		if (parentMessage) this.assertValidRunParent(parentMessage);
 		this.#runs.assertCanStart(parentMessageId);
 	}
@@ -564,6 +570,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		run: RunRecord<TMessage>,
 		options: ChatRequestOptions,
 	) {
+		this.assertCanStartRun(run.spec.parentMessageId);
 		const finished = run.chat.resumeStream(options).finally(() => this.emit());
 		run.finished = finished;
 		this.emit();

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -405,6 +405,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			fallbackId: getInputMessageId(input) ?? this.generateMessageId(),
 			input,
 		});
+		this.assertValidRunParent(message);
 		const existingMessage = this.#tree.getMessage(message.id);
 		this.assertCanStartRun(message.id);
 		const attachmentId = existingMessage
@@ -561,6 +562,9 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	private assertCanStartRun(parentMessageId: string) {
+		const parentMessage = this.#tree.getMessage(parentMessageId);
+		if (parentMessage) this.assertValidRunParent(parentMessage);
+
 		const activeRuns = this.getActiveRunRecords();
 		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
 			throw new Error("Cannot start run: max active runs reached");
@@ -570,6 +574,14 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		).length;
 		if (activeFromMessage >= this.#concurrency.maxActiveRunsPerMessage) {
 			throw new Error(`Cannot start another run from ${parentMessageId}`);
+		}
+	}
+
+	private assertValidRunParent(message: TMessage) {
+		if (message.role === "assistant") {
+			throw new Error(
+				`Cannot start a new run directly from assistant message ${message.id}; attach an input message first`,
+			);
 		}
 	}
 

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -384,11 +384,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	clearError = () => {
 		const run = this.getSelectedRunRecord();
-		if (run) {
-			run.error = undefined;
-			run.chat.clearError();
-			this.emit();
-		}
+		if (run) run.chat.clearError();
 	};
 
 	stop = () => this.getSelectedRunRecord()?.chat.stop() ?? Promise.resolve();
@@ -560,22 +556,16 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		};
 		this.#runs.add(record);
 		this.emit();
-		const finished = chat
-			.start(options)
-			.catch((error: unknown) => {
-				this.setRunError(
-					spec.id,
-					error instanceof Error ? error : new Error(String(error)),
-				);
-			})
-			.finally(() => this.emit());
+		const finished = chat.start(options).finally(() => this.emit());
 		record.finished = finished;
 		return this.createRunHandle(record);
 	}
 
 	private createRunHandle(run: RunRecord<TMessage>): ThreadRunHandle {
 		return {
-			finished: run.finished,
+			get finished() {
+				return run.finished;
+			},
 			id: run.spec.id,
 			getSnapshot: () => this.getRun(run.spec.id),
 			stop: () => run.chat.stop(),
@@ -586,7 +576,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		run: RunRecord<TMessage>,
 		options: ChatRequestOptions,
 	) {
-		run.error = undefined;
 		const finished = run.chat.resumeStream(options).finally(() => this.emit());
 		run.finished = finished;
 		this.emit();

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -1,8 +1,8 @@
 import {
+	type AbstractChat,
 	type ChatRequestOptions,
 	type ChatStatus,
 	type ChatTransport,
-	type CreateUIMessage,
 	convertFileListToFileUIParts,
 	DefaultChatTransport,
 	generateId,
@@ -16,7 +16,6 @@ import {
 import { MessageTree } from "./message-tree";
 import type {
 	MessageTreeSnapshot,
-	SendMessageInput,
 	ThreadChatOptions,
 	ThreadConcurrency,
 	ThreadRun,
@@ -26,21 +25,17 @@ import type {
 	TreeSendOptions,
 } from "./types";
 
+type SendMessageInput<TMessage extends UIMessage> = Parameters<
+	AbstractChat<TMessage>["sendMessage"]
+>[0];
+
 type RunRecord<TMessage extends UIMessage> = {
-	aborted: boolean;
 	chat: ThreadRunChat<TMessage>;
 	error: Error | undefined;
 	finished: Promise<void>;
 	spec: ThreadRunSpec;
 	status: ChatStatus;
 };
-
-function getAssistantMessageIdFromOptions(options?: TreeSendOptions) {
-	const assistantMessageId = (
-		options?.body as Record<string, unknown> | undefined
-	)?.assistantMessageId;
-	return typeof assistantMessageId === "string" ? assistantMessageId : null;
-}
 
 function getInputMessageId<TMessage extends UIMessage>(
 	input: NonNullable<SendMessageInput<TMessage>>,
@@ -51,8 +46,10 @@ function getInputMessageId<TMessage extends UIMessage>(
 	return input.messageId;
 }
 
-function createEmptyAssistantMessage<TMessage extends UIMessage>(id: string) {
-	return { id, parts: [], role: "assistant" } as unknown as TMessage;
+function specializeMessage<TMessage extends UIMessage>(message: UIMessage) {
+	// Like AI SDK's AbstractChat, construction crosses a generic boundary here:
+	// TMessage may narrow metadata or parts beyond the base UIMessage shape.
+	return message as TMessage;
 }
 
 async function createUserMessageFromInput<TMessage extends UIMessage>({
@@ -64,37 +61,37 @@ async function createUserMessageFromInput<TMessage extends UIMessage>({
 }): Promise<TMessage> {
 	const messageId = getInputMessageId(input) ?? fallbackId;
 	const metadata = "metadata" in input ? input.metadata : undefined;
-	if ("text" in input) {
+	if ("text" in input && typeof input.text === "string") {
 		const fileParts =
 			"files" in input && input.files
 				? Array.isArray(input.files)
 					? input.files
 					: await convertFileListToFileUIParts(input.files)
 				: [];
-		return {
+		return specializeMessage<TMessage>({
 			id: messageId,
 			metadata,
 			parts: [...fileParts, { text: input.text, type: "text" }],
 			role: "user",
-		} as TMessage;
+		});
 	}
 	if ("files" in input && input.files) {
-		return {
+		return specializeMessage<TMessage>({
 			id: messageId,
 			metadata,
 			parts: Array.isArray(input.files)
 				? input.files
 				: await convertFileListToFileUIParts(input.files),
 			role: "user",
-		} as TMessage;
+		});
 	}
-	return {
+	return specializeMessage<TMessage>({
 		...input,
 		id: messageId,
 		metadata,
 		parts: "parts" in input ? input.parts : [],
 		role: "user",
-	} as TMessage;
+	});
 }
 
 export class ThreadChat<TMessage extends UIMessage = UIMessage>
@@ -109,19 +106,18 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	onData: ThreadChatOptions<TMessage>["onData"];
 	onError: ThreadChatOptions<TMessage>["onError"];
 	onFinish: ThreadChatOptions<TMessage>["onFinish"];
-	onThreadEvent: ThreadChatOptions<TMessage>["onThreadEvent"];
 	onToolCall: ThreadChatOptions<TMessage>["onToolCall"];
 	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
 
-	readonly #assistantStarted = new Set<string>();
 	readonly #concurrency: Required<ThreadConcurrency>;
 	readonly #listeners = new Set<() => void>();
+	readonly #runIdByApprovalId = new Map<string, string>();
+	readonly #runIdByToolCallId = new Map<string, string>();
 	readonly #runsById = new Map<string, RunRecord<TMessage>>();
 	readonly #tree: MessageTree<TMessage>;
-	#lastEvent = "Ready";
+	#selectedRunId: string | null = null;
 	#snapshot: ThreadStateSnapshot<TMessage>;
-	#storeVersion = 0;
 
 	constructor(options: ThreadChatOptions<TMessage> = {}) {
 		this.id = options.id ?? generateId();
@@ -131,7 +127,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		this.onData = options.onData;
 		this.onError = options.onError;
 		this.onFinish = options.onFinish;
-		this.onThreadEvent = options.onThreadEvent;
 		this.onToolCall = options.onToolCall;
 		this.sendAutomaticallyWhen = options.sendAutomaticallyWhen;
 		this.transport = options.transport ?? new DefaultChatTransport();
@@ -155,9 +150,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		if ("onData" in options) this.onData = options.onData;
 		if ("onError" in options) this.onError = options.onError;
 		if ("onFinish" in options) this.onFinish = options.onFinish;
-		if ("onThreadEvent" in options) {
-			this.onThreadEvent = options.onThreadEvent;
-		}
 		if ("onToolCall" in options) this.onToolCall = options.onToolCall;
 		if ("sendAutomaticallyWhen" in options) {
 			this.sendAutomaticallyWhen = options.sendAutomaticallyWhen;
@@ -173,6 +165,19 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	addMessage(message: TMessage, parentId: string | null) {
 		this.upsertMessage(message, parentId);
 	}
+
+	addToolApprovalResponse: AbstractChat<TMessage>["addToolApprovalResponse"] =
+		async (response) => {
+			const run = this.getRunForApproval(response.id);
+			await run.chat.addToolApprovalResponse(response);
+		};
+
+	addToolOutput: AbstractChat<TMessage>["addToolOutput"] = async (output) => {
+		const run = this.getRunForToolCall(output.toolCallId);
+		await run.chat.addToolOutput(output);
+	};
+
+	addToolResult: AbstractChat<TMessage>["addToolResult"] = this.addToolOutput;
 
 	getTreeSnapshot() {
 		return this.#tree.getSnapshot();
@@ -203,27 +208,98 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	setCursor(messageId: string | null) {
+		this.#selectedRunId = null;
 		this.#tree.setCursor(messageId);
-		this.emit(`Set cursor ${messageId ?? "root"}`);
-		this.onThreadEvent?.({ cursorId: messageId, type: "cursor-changed" });
+		this.emit();
 	}
 
 	setCursorToParentOf(messageId: string) {
+		this.#selectedRunId = null;
 		this.#tree.setCursorToParentOf(messageId);
-		this.emit(`Set cursor ${this.#tree.cursorId ?? "root"}`);
-		this.onThreadEvent?.({
-			cursorId: this.#tree.cursorId,
-			type: "cursor-changed",
+		this.emit();
+	}
+
+	getRunPath(runId: string) {
+		const run = this.getRunRecord(runId);
+		return this.#tree.getPath(
+			run.spec.assistantMessageId ?? run.spec.userMessageId,
+		);
+	}
+
+	writeRunAssistantMessage(runId: string, message: TMessage) {
+		const run = this.getRunRecord(runId);
+		const currentMessageId = run.spec.assistantMessageId;
+		if (currentMessageId && currentMessageId !== message.id) {
+			throw new Error(
+				`Run ${runId} is already bound to message ${currentMessageId}`,
+			);
+		}
+		if (!currentMessageId) {
+			const existingMessage = this.#tree.getMessage(message.id);
+			if (existingMessage) {
+				throw new Error(`Message ${message.id} already exists`);
+			}
+			run.spec.assistantMessageId = message.id;
+		}
+
+		const siblingOrderByMessageId = new Map<string, number>();
+		for (const candidate of this.#runsById.values()) {
+			if (candidate.spec.assistantMessageId) {
+				siblingOrderByMessageId.set(
+					candidate.spec.assistantMessageId,
+					candidate.spec.siblingOrder,
+				);
+			}
+		}
+		const insertionIndex = this.#tree
+			.getChildren(run.spec.userMessageId)
+			.filter((child) => {
+				const siblingOrder = siblingOrderByMessageId.get(child.id);
+				return (
+					siblingOrder === undefined || siblingOrder < run.spec.siblingOrder
+				);
+			}).length;
+		this.#tree.upsertMessage(message, run.spec.userMessageId, {
+			index: insertionIndex,
 		});
+		this.indexMessageOwnership(runId, message);
+		if (
+			this.#selectedRunId === runId &&
+			this.#tree.cursorId === run.spec.userMessageId
+		) {
+			this.#tree.setCursor(message.id);
+		}
+		this.emit();
 	}
 
-	hasAssistantStarted(assistantMessageId: string) {
-		return this.#assistantStarted.has(assistantMessageId);
-	}
+	regenerate: AbstractChat<TMessage>["regenerate"] = async ({
+		messageId,
+		...options
+	} = {}) => {
+		const target =
+			(messageId ? this.#tree.getMessage(messageId) : undefined) ??
+			(this.#tree.cursorId
+				? this.#tree.getMessage(this.#tree.cursorId)
+				: undefined);
+		if (!target) return;
 
-	markAssistantStarted(assistantMessageId: string) {
-		this.#assistantStarted.add(assistantMessageId);
-	}
+		const userMessageId =
+			target.role === "assistant"
+				? this.#tree.getParentId(target.id)
+				: target.id;
+		if (!userMessageId) return;
+
+		this.assertCanStartRun(userMessageId);
+		const run = this.startAssistantForUser({
+			follow: true,
+			id: this.reserveRunId(),
+			options,
+			originCursorId: target.id,
+			parentMessageId: this.#tree.getParentId(userMessageId) ?? null,
+			userMessageId,
+		});
+		await run.finished;
+	};
 
 	upsertMessage(
 		message: TMessage,
@@ -231,29 +307,42 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		options: { silent?: boolean } = {},
 	) {
 		this.#tree.upsertMessage(message, parentId);
-		if (!options.silent) this.emit(`Upserted ${message.id}`);
+		if (!options.silent) this.emit();
 	}
 
 	removeMessage(messageId: string) {
 		this.#tree.removeLeaf(messageId);
-		this.emit(`Removed ${messageId}`);
+		this.emit();
 	}
 
 	replacePath(messages: TMessage[], options: { silent?: boolean } = {}) {
 		this.assertCanResetTree();
 		this.clearRunState();
 		this.#tree.replacePath(messages);
-		if (!options.silent) this.emit("Replaced active path");
+		if (!options.silent) this.emit();
 	}
 
 	mergePath(messages: TMessage[], options: { silent?: boolean } = {}) {
 		this.#tree.reconcilePath(messages);
-		if (!options.silent) this.emit("Reconciled active path");
+		if (!options.silent) this.emit();
 	}
 
 	mergeRunPath(messages: TMessage[]) {
 		this.#tree.reconcilePath(messages, { moveCursor: false });
 	}
+
+	resumeStream: AbstractChat<TMessage>["resumeStream"] = async (
+		options = {},
+	) => {
+		const run =
+			this.getSelectedRunRecord() ?? this.createRunForSelectedAssistant();
+		if (!run) return;
+		await this.resumeRunRequest(run, options);
+	};
+
+	resumeRun = async (runId: string, options: ChatRequestOptions = {}) => {
+		await this.resumeRunRequest(this.getRunRecord(runId), options);
+	};
 
 	restore(
 		snapshot: MessageTreeSnapshot<TMessage>,
@@ -262,7 +351,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		this.assertCanResetTree();
 		this.clearRunState();
 		this.#tree.restore(snapshot);
-		if (!options.silent) this.emit("Restored tree");
+		if (!options.silent) this.emit();
 	}
 
 	setMessages(messages: TMessage[] | ((messages: TMessage[]) => TMessage[])) {
@@ -270,6 +359,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			typeof messages === "function"
 				? messages(this.#snapshot.messages)
 				: messages;
+		this.#selectedRunId = null;
 		this.mergePath(nextMessages);
 	}
 
@@ -277,14 +367,12 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		input?: SendMessageInput<TMessage>,
 		options?: TreeSendOptions,
 	) => {
+		const { tree, ...request } = options ?? {};
 		const run = await this.startRun({
-			follow: options?.tree?.follow,
-			from:
-				options?.tree && "from" in options.tree
-					? (options.tree.from ?? null)
-					: undefined,
+			follow: tree?.follow,
+			from: tree && "from" in tree ? (tree.from ?? null) : undefined,
 			message: input,
-			request: options,
+			request,
 		});
 		await run.finished;
 	};
@@ -310,11 +398,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			}
 			this.assertCanStartRun(originMessage.id);
 			return this.startAssistantForUser({
-				assistantMessageId: this.reserveAssistantMessageId(
-					options,
-					originMessage.id,
-				),
 				follow,
+				id: this.reserveRunId(),
 				options,
 				originCursorId,
 				parentMessageId: this.#tree.getParentId(originMessage.id) ?? null,
@@ -331,10 +416,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			throw new Error(`Message ${userMessage.id} is not a user message`);
 		}
 		this.assertCanStartRun(userMessage.id);
-		const assistantMessageId = this.reserveAssistantMessageId(
-			options,
-			userMessage.id,
-		);
 		const attachmentId = existingMessage
 			? (this.#tree.getParentId(userMessage.id) ?? null)
 			: originCursorId;
@@ -342,8 +423,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		if (follow) this.#tree.setCursor(userMessage.id);
 
 		return this.startAssistantForUser({
-			assistantMessageId,
 			follow,
+			id: this.reserveRunId(),
 			options,
 			originCursorId,
 			parentMessageId: attachmentId,
@@ -356,7 +437,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		if (run) {
 			run.error = undefined;
 			run.chat.clearError();
-			this.emit("Cleared error");
+			this.emit();
 		}
 	};
 
@@ -403,27 +484,67 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		if (!run) return;
 		run.error = error;
 		run.status = error ? "error" : run.status;
-		this.emit(error ? `Error in ${runId}` : "Cleared error");
-		this.emitRunEvent(run, "run-updated");
+		this.emit();
 	}
 
 	setRunStatus(runId: string, status: ChatStatus) {
 		const run = this.#runsById.get(runId);
 		if (!run) return;
 		run.status = status;
-		this.emit(`${runId} is ${status}`);
-		this.emitRunEvent(run, "run-updated");
+		this.emit();
 	}
 
-	finishRequest(runId: string, isAbort: boolean) {
-		const run = this.#runsById.get(runId);
-		if (run) run.aborted ||= isAbort;
-		this.emit(isAbort ? `Stopping ${runId}` : `Received ${runId}`);
+	registerToolCall(runId: string, toolCallId: string) {
+		this.assertOwnershipAvailable(
+			this.#runIdByToolCallId,
+			toolCallId,
+			runId,
+			"tool call",
+		);
+		this.#runIdByToolCallId.set(toolCallId, runId);
 	}
 
-	registerToolCall() {}
+	indexMessageOwnership(runId: string, message: TMessage) {
+		const toolCallIds: string[] = [];
+		const approvalIds: string[] = [];
+		for (const part of message.parts) {
+			if ("toolCallId" in part && typeof part.toolCallId === "string") {
+				toolCallIds.push(part.toolCallId);
+			}
+			if (
+				"approval" in part &&
+				part.approval &&
+				typeof part.approval === "object" &&
+				"id" in part.approval &&
+				typeof part.approval.id === "string"
+			) {
+				approvalIds.push(part.approval.id);
+			}
+		}
 
-	indexMessageOwnership() {}
+		for (const toolCallId of toolCallIds) {
+			this.assertOwnershipAvailable(
+				this.#runIdByToolCallId,
+				toolCallId,
+				runId,
+				"tool call",
+			);
+		}
+		for (const approvalId of approvalIds) {
+			this.assertOwnershipAvailable(
+				this.#runIdByApprovalId,
+				approvalId,
+				runId,
+				"tool approval",
+			);
+		}
+		for (const toolCallId of toolCallIds) {
+			this.#runIdByToolCallId.set(toolCallId, runId);
+		}
+		for (const approvalId of approvalIds) {
+			this.#runIdByApprovalId.set(approvalId, runId);
+		}
+	}
 
 	private buildSnapshot(): ThreadStateSnapshot<TMessage> {
 		const tree = this.#tree.getSnapshot();
@@ -440,18 +561,14 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			...indexes,
 			activeRuns,
 			error: selectedRun?.error,
-			lastEvent: this.#lastEvent,
 			messages: this.#tree.getPath(),
 			runs,
 			status: selectedRun?.status ?? "ready",
-			storeVersion: this.#storeVersion,
 			treeStatus: this.resolveStatus(runs),
 		};
 	}
 
-	private emit(event: string) {
-		this.#lastEvent = event;
-		this.#storeVersion += 1;
+	private emit() {
 		this.#snapshot = this.buildSnapshot();
 		for (const listener of this.#listeners) listener();
 	}
@@ -476,10 +593,81 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	private getSelectedRunRecord() {
+		if (this.#selectedRunId) {
+			const selectedRun = this.#runsById.get(this.#selectedRunId);
+			if (selectedRun) return selectedRun;
+		}
 		const pathIds = new Set(this.#tree.getPathIds());
-		return Array.from(this.#runsById.values())
-			.reverse()
-			.find((run) => pathIds.has(run.spec.assistantMessageId));
+		const runs = Array.from(this.#runsById.values()).reverse();
+		const responseRun = runs.find(
+			(run) =>
+				run.spec.assistantMessageId !== undefined &&
+				pathIds.has(run.spec.assistantMessageId),
+		);
+		if (responseRun) return responseRun;
+
+		const cursorId = this.#tree.cursorId;
+		const cursor = cursorId ? this.#tree.getMessage(cursorId) : undefined;
+		if (cursor?.role !== "user") return undefined;
+		return (
+			runs.find(
+				(run) =>
+					run.spec.userMessageId === cursor.id &&
+					(run.status === "submitted" || run.status === "streaming"),
+			) ?? runs.find((run) => run.spec.userMessageId === cursor.id)
+		);
+	}
+
+	private getRunRecord(runId: string) {
+		const run = this.#runsById.get(runId);
+		if (!run) throw new Error(`Unknown run ${runId}`);
+		return run;
+	}
+
+	private getRunForToolCall(toolCallId: string) {
+		const runId = this.#runIdByToolCallId.get(toolCallId);
+		if (!runId) throw new Error(`No run owns tool call ${toolCallId}`);
+		return this.getRunRecord(runId);
+	}
+
+	private getRunForApproval(approvalId: string) {
+		const runId = this.#runIdByApprovalId.get(approvalId);
+		if (!runId) throw new Error(`No run owns tool approval ${approvalId}`);
+		return this.getRunRecord(runId);
+	}
+
+	private createRunForSelectedAssistant() {
+		const assistantMessageId = this.#tree.cursorId;
+		if (!assistantMessageId) return undefined;
+		const assistantMessage = this.#tree.getMessage(assistantMessageId);
+		if (!assistantMessage || assistantMessage.role !== "assistant") {
+			return undefined;
+		}
+		const userMessageId = this.#tree.getParentId(assistantMessageId);
+		if (!userMessageId) return undefined;
+
+		const spec: ThreadRunSpec = {
+			assistantMessageId,
+			siblingOrder: this.#tree
+				.getChildren(userMessageId)
+				.findIndex((message) => message.id === assistantMessageId),
+			id: this.reserveRunId(),
+			originCursorId: assistantMessageId,
+			parentMessageId: this.#tree.getParentId(userMessageId) ?? null,
+			userMessageId,
+		};
+		const record: RunRecord<TMessage> = {
+			chat: new ThreadRunChat(this, spec),
+			error: undefined,
+			finished: Promise.resolve(),
+			spec,
+			status: "ready",
+		};
+		this.#runsById.set(spec.id, record);
+		this.#selectedRunId = spec.id;
+		this.indexMessageOwnership(spec.id, assistantMessage);
+		this.emit();
+		return record;
 	}
 
 	private assertCanResetTree() {
@@ -489,130 +677,118 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	private clearRunState() {
-		this.#assistantStarted.clear();
+		this.#selectedRunId = null;
+		this.#runIdByApprovalId.clear();
+		this.#runIdByToolCallId.clear();
 		this.#runsById.clear();
 	}
 
-	private reserveAssistantMessageId(
-		options: TreeSendOptions | undefined,
-		userMessageId: string,
+	private assertOwnershipAvailable(
+		owners: Map<string, string>,
+		id: string,
+		runId: string,
+		label: string,
 	) {
-		const assistantMessageId =
-			getAssistantMessageIdFromOptions(options) ?? this.generateMessageId();
-		const existingMessage = this.#tree.getMessage(assistantMessageId);
-		const isClaimablePlaceholder =
-			existingMessage?.role === "assistant" &&
-			existingMessage.parts.length === 0 &&
-			this.#tree.getParentId(assistantMessageId) === userMessageId;
-		if (
-			assistantMessageId === userMessageId ||
-			(existingMessage && !isClaimablePlaceholder) ||
-			this.#runsById.has(assistantMessageId)
-		) {
+		const existingRunId = owners.get(id);
+		if (existingRunId && existingRunId !== runId) {
 			throw new Error(
-				`Assistant message id ${assistantMessageId} is unavailable`,
+				`${label} ${id} is already owned by run ${existingRunId}`,
 			);
 		}
-		return assistantMessageId;
+	}
+
+	private reserveRunId() {
+		const runId = this.generateMessageId();
+		if (this.#runsById.has(runId)) {
+			throw new Error(`Run ${runId} already exists`);
+		}
+		return runId;
 	}
 
 	private startAssistantForUser({
-		assistantMessageId,
 		follow,
+		id,
 		options,
 		originCursorId,
 		parentMessageId,
 		userMessageId,
-	}: ThreadRunSpec & { follow: boolean; options?: TreeSendOptions }) {
+	}: Omit<ThreadRunSpec, "assistantMessageId" | "siblingOrder"> & {
+		follow: boolean;
+		options?: ChatRequestOptions;
+	}) {
 		const spec: ThreadRunSpec = {
-			assistantMessageId,
+			id,
 			originCursorId,
 			parentMessageId,
+			siblingOrder: this.reserveSiblingOrder(userMessageId),
 			userMessageId,
 		};
-		if (!this.#tree.has(assistantMessageId)) {
-			this.#tree.upsertMessage(
-				createEmptyAssistantMessage<TMessage>(assistantMessageId),
-				userMessageId,
-			);
+		if (follow) {
+			this.#selectedRunId = id;
+			this.#tree.setCursor(userMessageId);
 		}
-		if (follow) this.#tree.setCursor(assistantMessageId);
 		return this.startRunRequest(spec, options);
 	}
 
-	private startRunRequest(spec: ThreadRunSpec, options?: TreeSendOptions) {
+	private reserveSiblingOrder(userMessageId: string) {
+		const existingMessageOrder =
+			this.#tree.getChildren(userMessageId).length - 1;
+		const runOrders = Array.from(this.#runsById.values())
+			.filter((run) => run.spec.userMessageId === userMessageId)
+			.map((run) => run.spec.siblingOrder);
+		return Math.max(existingMessageOrder, ...runOrders) + 1;
+	}
+
+	private startRunRequest(spec: ThreadRunSpec, options?: ChatRequestOptions) {
 		const chat = new ThreadRunChat(this, spec);
 		const record: RunRecord<TMessage> = {
-			aborted: false,
 			chat,
 			error: undefined,
 			finished: Promise.resolve(),
 			spec,
 			status: "submitted",
 		};
-		this.#runsById.set(spec.assistantMessageId, record);
-		this.emit(`Started ${spec.assistantMessageId}`);
-		this.emitRunEvent(record, "run-started");
+		this.#runsById.set(spec.id, record);
+		this.emit();
 		const userMessage = this.#tree.getMessage(spec.userMessageId);
 		const finished = chat
-			.sendMessage(userMessage as CreateUIMessage<TMessage>, {
-				...this.withRunRequestBody(spec, options),
-			})
+			.sendMessage(userMessage, options)
 			.catch((error: unknown) => {
 				this.setRunError(
-					spec.assistantMessageId,
+					spec.id,
 					error instanceof Error ? error : new Error(String(error)),
 				);
 			})
-			.finally(() => this.completeRun(spec.assistantMessageId));
+			.finally(() => this.emit());
 		record.finished = finished;
 		return this.createRunHandle(record);
 	}
 
-	private completeRun(runId: string) {
-		const run = this.#runsById.get(runId);
-		if (!run) return;
-		this.emit(
-			run.aborted
-				? `Stopped ${runId}`
-				: run.error
-					? `Failed ${runId}`
-					: `Finished ${runId}`,
-		);
-		this.emitRunEvent(
-			run,
-			run.aborted ? "run-aborted" : run.error ? "run-failed" : "run-completed",
-		);
-	}
-
 	private createRunHandle(run: RunRecord<TMessage>): ThreadRunHandle {
-		const id = run.spec.assistantMessageId;
 		return {
 			finished: run.finished,
-			getSnapshot: () => this.getRun(id),
-			id,
-			stop: () => this.stopRun(id),
+			id: run.spec.id,
+			getSnapshot: () => this.getRun(run.spec.id),
+			stop: () => run.chat.stop(),
 		};
 	}
 
-	private emitRunEvent(
+	private async resumeRunRequest(
 		run: RunRecord<TMessage>,
-		type:
-			| "run-aborted"
-			| "run-completed"
-			| "run-failed"
-			| "run-started"
-			| "run-updated",
+		options: ChatRequestOptions,
 	) {
-		this.onThreadEvent?.({ run: this.toRunSnapshot(run), type });
+		run.error = undefined;
+		const finished = run.chat.resumeStream(options).finally(() => this.emit());
+		run.finished = finished;
+		this.emit();
+		await finished;
 	}
 
 	private toRunSnapshot(run: RunRecord<TMessage>): ThreadRun {
 		return {
 			error: run.error,
-			id: run.spec.assistantMessageId,
+			id: run.spec.id,
 			status: run.status,
-			userMessageId: run.spec.userMessageId,
 		};
 	}
 
@@ -621,27 +797,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		if (runs.some((run) => run.status === "submitted")) return "submitted";
 		if (runs.some((run) => run.status === "error")) return "error";
 		return "ready";
-	}
-
-	private withRunRequestBody(
-		spec: ThreadRunSpec,
-		options: ChatRequestOptions | undefined,
-	): ChatRequestOptions {
-		return {
-			...options,
-			body: {
-				...(options?.body ?? {}),
-				assistantMessageId: spec.assistantMessageId,
-				tree: {
-					assistantMessageId: spec.assistantMessageId,
-					cursorId: spec.assistantMessageId,
-					originCursorId: spec.originCursorId,
-					parentMessageId: spec.parentMessageId,
-					pathIds: this.#tree.getPathIds(spec.assistantMessageId),
-					userMessageId: spec.userMessageId,
-				},
-			},
-		};
 	}
 }
 

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -8,7 +8,11 @@ import {
 	generateId,
 	type UIMessage,
 } from "ai";
-import { ThreadRunChat, type ThreadRunHost } from "./ai-sdk-run-chat";
+import {
+	ThreadRunChat,
+	type ThreadRunHost,
+	type ThreadRunSpec,
+} from "./ai-sdk-run-chat";
 import { MessageTree } from "./message-tree";
 import type {
 	MessageTreeSnapshot,
@@ -17,7 +21,6 @@ import type {
 	ThreadConcurrency,
 	ThreadRun,
 	ThreadRunHandle,
-	ThreadRunSpec,
 	ThreadStartRunOptions,
 	ThreadStateSnapshot,
 	TreeSendOptions,
@@ -424,6 +427,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	private buildSnapshot(): ThreadStateSnapshot<TMessage> {
 		const tree = this.#tree.getSnapshot();
+		const indexes = this.#tree.getIndexes();
 		const runs = Array.from(this.#runsById.values()).map((run) =>
 			this.toRunSnapshot(run),
 		);
@@ -433,6 +437,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		const selectedRun = this.getSelectedRunRecord();
 		return {
 			...tree,
+			...indexes,
 			activeRuns,
 			error: selectedRun?.error,
 			lastEvent: this.#lastEvent,
@@ -518,13 +523,11 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		originCursorId,
 		parentMessageId,
 		userMessageId,
-	}: Omit<ThreadRunSpec, "runId"> & { options?: TreeSendOptions }) {
+	}: ThreadRunSpec & { follow: boolean; options?: TreeSendOptions }) {
 		const spec: ThreadRunSpec = {
 			assistantMessageId,
-			follow,
 			originCursorId,
 			parentMessageId,
-			runId: assistantMessageId,
 			userMessageId,
 		};
 		if (!this.#tree.has(assistantMessageId)) {
@@ -547,8 +550,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			spec,
 			status: "submitted",
 		};
-		this.#runsById.set(spec.runId, record);
-		this.emit(`Started ${spec.runId}`);
+		this.#runsById.set(spec.assistantMessageId, record);
+		this.emit(`Started ${spec.assistantMessageId}`);
 		this.emitRunEvent(record, "run-started");
 		const userMessage = this.#tree.getMessage(spec.userMessageId);
 		const finished = chat
@@ -557,11 +560,11 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			})
 			.catch((error: unknown) => {
 				this.setRunError(
-					spec.runId,
+					spec.assistantMessageId,
 					error instanceof Error ? error : new Error(String(error)),
 				);
 			})
-			.finally(() => this.completeRun(spec.runId));
+			.finally(() => this.completeRun(spec.assistantMessageId));
 		record.finished = finished;
 		return this.createRunHandle(record);
 	}
@@ -583,12 +586,12 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	private createRunHandle(run: RunRecord<TMessage>): ThreadRunHandle {
+		const id = run.spec.assistantMessageId;
 		return {
-			assistantMessageId: run.spec.assistantMessageId,
 			finished: run.finished,
-			getSnapshot: () => this.getRun(run.spec.runId),
-			id: run.spec.runId,
-			stop: () => this.stopRun(run.spec.runId),
+			getSnapshot: () => this.getRun(id),
+			id,
+			stop: () => this.stopRun(id),
 		};
 	}
 
@@ -606,21 +609,17 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	private toRunSnapshot(run: RunRecord<TMessage>): ThreadRun {
 		return {
-			assistantMessageId: run.spec.assistantMessageId,
 			error: run.error,
-			follow: run.spec.follow,
-			id: run.spec.runId,
-			originCursorId: run.spec.originCursorId,
-			parentMessageId: run.spec.parentMessageId,
+			id: run.spec.assistantMessageId,
 			status: run.status,
 			userMessageId: run.spec.userMessageId,
 		};
 	}
 
 	private resolveStatus(runs: ThreadRun[]) {
-		if (runs.some((run) => run.status === "error")) return "error";
 		if (runs.some((run) => run.status === "streaming")) return "streaming";
 		if (runs.some((run) => run.status === "submitted")) return "submitted";
+		if (runs.some((run) => run.status === "error")) return "error";
 		return "ready";
 	}
 

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -115,17 +115,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	getSnapshot = () => this.#snapshot;
 
-	updateOptions(options: ThreadChatOptions<TMessage>) {
-		if ("onData" in options) this.onData = options.onData;
-		if ("onError" in options) this.onError = options.onError;
-		if ("onFinish" in options) this.onFinish = options.onFinish;
-		if ("onToolCall" in options) this.onToolCall = options.onToolCall;
-		if ("sendAutomaticallyWhen" in options) {
-			this.sendAutomaticallyWhen = options.sendAutomaticallyWhen;
-		}
-		if (options.transport) this.transport = options.transport;
-	}
-
 	subscribe = (listener: () => void) => {
 		this.#listeners.add(listener);
 		return () => this.#listeners.delete(listener);

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -14,11 +14,10 @@ import {
 	type ThreadRunSpec,
 } from "./ai-sdk-run-chat";
 import { MessageTree } from "./message-tree";
+import { type RunRecord, RunRegistry } from "./run-registry";
 import type {
 	MessageTreeSnapshot,
 	ThreadChatOptions,
-	ThreadConcurrency,
-	ThreadRun,
 	ThreadRunHandle,
 	ThreadStartRunOptions,
 	ThreadStateSnapshot,
@@ -28,14 +27,6 @@ import type {
 type SendMessageInput<TMessage extends UIMessage> = Parameters<
 	AbstractChat<TMessage>["sendMessage"]
 >[0];
-
-type RunRecord<TMessage extends UIMessage> = {
-	chat: ThreadRunChat<TMessage>;
-	error: Error | undefined;
-	finished: Promise<void>;
-	spec: ThreadRunSpec;
-	status: ChatStatus;
-};
 
 function getInputMessageId<TMessage extends UIMessage>(
 	input: NonNullable<SendMessageInput<TMessage>>,
@@ -110,13 +101,9 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
 
-	readonly #concurrency: Required<ThreadConcurrency>;
 	readonly #listeners = new Set<() => void>();
-	readonly #runIdByApprovalId = new Map<string, string>();
-	readonly #runIdByToolCallId = new Map<string, string>();
-	readonly #runsById = new Map<string, RunRecord<TMessage>>();
+	readonly #runs: RunRegistry<TMessage>;
 	readonly #tree: MessageTree<TMessage>;
-	#selectedRunId: string | null = null;
 	#snapshot: ThreadStateSnapshot<TMessage>;
 
 	constructor(options: ThreadChatOptions<TMessage> = {}) {
@@ -130,13 +117,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		this.onToolCall = options.onToolCall;
 		this.sendAutomaticallyWhen = options.sendAutomaticallyWhen;
 		this.transport = options.transport ?? new DefaultChatTransport();
-		this.#concurrency = {
-			maxActiveRuns:
-				options.concurrency?.maxActiveRuns ?? Number.POSITIVE_INFINITY,
-			maxActiveRunsPerMessage:
-				options.concurrency?.maxActiveRunsPerMessage ??
-				Number.POSITIVE_INFINITY,
-		};
+		this.#runs = new RunRegistry(options.concurrency);
 		this.#tree = new MessageTree({
 			messages: options.messages,
 			snapshot: options.initialTree,
@@ -168,12 +149,12 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	addToolApprovalResponse: AbstractChat<TMessage>["addToolApprovalResponse"] =
 		async (response) => {
-			const run = this.getRunForApproval(response.id);
+			const run = this.#runs.getForApproval(response.id);
 			await run.chat.addToolApprovalResponse(response);
 		};
 
 	addToolOutput: AbstractChat<TMessage>["addToolOutput"] = async (output) => {
-		const run = this.getRunForToolCall(output.toolCallId);
+		const run = this.#runs.getForToolCall(output.toolCallId);
 		await run.chat.addToolOutput(output);
 	};
 
@@ -208,24 +189,24 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	setCursor(messageId: string | null) {
-		this.#selectedRunId = null;
+		this.#runs.select(null);
 		this.#tree.setCursor(messageId);
 		this.emit();
 	}
 
 	setCursorToParentOf(messageId: string) {
-		this.#selectedRunId = null;
+		this.#runs.select(null);
 		this.#tree.setCursorToParentOf(messageId);
 		this.emit();
 	}
 
 	getRunPath(runId: string) {
-		const run = this.getRunRecord(runId);
+		const run = this.#runs.require(runId);
 		return this.#tree.getPath(run.spec.messageId ?? run.spec.parentMessageId);
 	}
 
 	writeRunMessage(runId: string, message: TMessage) {
-		const run = this.getRunRecord(runId);
+		const run = this.#runs.require(runId);
 		const currentMessageId = run.spec.messageId;
 		if (currentMessageId && currentMessageId !== message.id) {
 			throw new Error(
@@ -240,29 +221,19 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			run.spec.messageId = message.id;
 		}
 
-		const siblingOrderByMessageId = new Map<string, number>();
-		for (const candidate of this.#runsById.values()) {
-			if (candidate.spec.messageId) {
-				siblingOrderByMessageId.set(
-					candidate.spec.messageId,
-					candidate.spec.siblingOrder,
-				);
-			}
-		}
-		const insertionIndex = this.#tree
-			.getChildren(run.spec.parentMessageId)
-			.filter((child) => {
-				const siblingOrder = siblingOrderByMessageId.get(child.id);
-				return (
-					siblingOrder === undefined || siblingOrder < run.spec.siblingOrder
-				);
-			}).length;
+		const insertionIndex = this.#runs.getInsertionIndex({
+			childIds: this.#tree
+				.getChildren(run.spec.parentMessageId)
+				.map((child) => child.id),
+			parentMessageId: run.spec.parentMessageId,
+			siblingOrder: run.spec.siblingOrder,
+		});
 		this.#tree.upsertMessage(message, run.spec.parentMessageId, {
 			index: insertionIndex,
 		});
 		this.indexMessageOwnership(runId, message);
 		if (
-			this.#selectedRunId === runId &&
+			this.#runs.isExplicitlySelected(runId) &&
 			this.#tree.cursorId === run.spec.parentMessageId
 		) {
 			this.#tree.setCursor(message.id);
@@ -290,7 +261,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		this.assertCanStartRun(parentMessageId);
 		const run = this.startRunFromParent({
 			follow: true,
-			id: this.reserveRunId(),
+			id: this.#runs.reserveId(this.generateMessageId),
 			options,
 			parentMessageId,
 		});
@@ -311,20 +282,13 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		this.emit();
 	}
 
-	replacePath(messages: TMessage[], options: { silent?: boolean } = {}) {
-		this.assertCanResetTree();
-		this.clearRunState();
-		this.#tree.replacePath(messages);
-		if (!options.silent) this.emit();
-	}
-
 	mergePath(messages: TMessage[], options: { silent?: boolean } = {}) {
-		this.#tree.reconcilePath(messages);
+		this.#tree.mergePath(messages);
 		if (!options.silent) this.emit();
 	}
 
 	mergeRunPath(messages: TMessage[]) {
-		this.#tree.reconcilePath(messages, { moveCursor: false });
+		this.#tree.mergePath(messages, { moveCursor: false });
 	}
 
 	resumeStream: AbstractChat<TMessage>["resumeStream"] = async (
@@ -337,7 +301,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	};
 
 	resumeRun = async (runId: string, options: ChatRequestOptions = {}) => {
-		await this.resumeRunRequest(this.getRunRecord(runId), options);
+		await this.resumeRunRequest(this.#runs.require(runId), options);
 	};
 
 	restore(
@@ -345,7 +309,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		options: { silent?: boolean } = {},
 	) {
 		this.assertCanResetTree();
-		this.clearRunState();
+		this.#runs.clear();
 		this.#tree.restore(snapshot);
 		if (!options.silent) this.emit();
 	}
@@ -355,7 +319,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			typeof messages === "function"
 				? messages(this.#snapshot.messages)
 				: messages;
-		this.#selectedRunId = null;
+		this.#runs.select(null);
 		this.mergePath(nextMessages);
 	}
 
@@ -395,7 +359,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			this.assertCanStartRun(originMessage.id);
 			return this.startRunFromParent({
 				follow,
-				id: this.reserveRunId(),
+				id: this.#runs.reserveId(this.generateMessageId),
 				options,
 				parentMessageId: originMessage.id,
 			});
@@ -416,7 +380,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 		return this.startRunFromParent({
 			follow,
-			id: this.reserveRunId(),
+			id: this.#runs.reserveId(this.generateMessageId),
 			options,
 			parentMessageId: message.id,
 		});
@@ -435,12 +399,12 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 
 	stopAll() {
 		return Promise.all(
-			this.getActiveRunRecords().map((run) => run.chat.stop()),
+			this.#runs.getActive().map((run) => run.chat.stop()),
 		).then(() => undefined);
 	}
 
 	stopRun(runId: string) {
-		return this.#runsById.get(runId)?.chat.stop() ?? Promise.resolve();
+		return this.#runs.get(runId)?.chat.stop() ?? Promise.resolve();
 	}
 
 	stopRunForMessage(messageId: string) {
@@ -449,110 +413,47 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 
 	getRun(runId: string) {
-		const run = this.#runsById.get(runId);
-		return run ? this.toRunSnapshot(run) : undefined;
+		const run = this.#runs.get(runId);
+		return run ? this.#runs.toSnapshot(run) : undefined;
 	}
 
 	getRunForMessage(messageId: string) {
-		const runs = Array.from(this.#runsById.values()).reverse();
-		const run =
-			runs.find((candidate) => candidate.spec.messageId === messageId) ??
-			runs.find(
-				(candidate) =>
-					candidate.spec.parentMessageId === messageId &&
-					(candidate.status === "submitted" ||
-						candidate.status === "streaming"),
-			) ??
-			runs.find((candidate) => candidate.spec.parentMessageId === messageId);
-		return run ? this.toRunSnapshot(run) : undefined;
+		const run = this.#runs.getForMessage(messageId);
+		return run ? this.#runs.toSnapshot(run) : undefined;
 	}
 
 	setRunError(runId: string, error: Error | undefined) {
-		const run = this.#runsById.get(runId);
-		if (!run) return;
-		run.error = error;
-		run.status = error ? "error" : run.status;
+		this.#runs.setError(runId, error);
 		this.emit();
 	}
 
 	setRunStatus(runId: string, status: ChatStatus) {
-		const run = this.#runsById.get(runId);
-		if (!run) return;
-		run.status = status;
+		this.#runs.setStatus(runId, status);
 		this.emit();
 	}
 
 	registerToolCall(runId: string, toolCallId: string) {
-		this.assertOwnershipAvailable(
-			this.#runIdByToolCallId,
-			toolCallId,
-			runId,
-			"tool call",
-		);
-		this.#runIdByToolCallId.set(toolCallId, runId);
+		this.#runs.registerToolCall(runId, toolCallId);
 	}
 
 	indexMessageOwnership(runId: string, message: TMessage) {
-		const toolCallIds: string[] = [];
-		const approvalIds: string[] = [];
-		for (const part of message.parts) {
-			if ("toolCallId" in part && typeof part.toolCallId === "string") {
-				toolCallIds.push(part.toolCallId);
-			}
-			if (
-				"approval" in part &&
-				part.approval &&
-				typeof part.approval === "object" &&
-				"id" in part.approval &&
-				typeof part.approval.id === "string"
-			) {
-				approvalIds.push(part.approval.id);
-			}
-		}
-
-		for (const toolCallId of toolCallIds) {
-			this.assertOwnershipAvailable(
-				this.#runIdByToolCallId,
-				toolCallId,
-				runId,
-				"tool call",
-			);
-		}
-		for (const approvalId of approvalIds) {
-			this.assertOwnershipAvailable(
-				this.#runIdByApprovalId,
-				approvalId,
-				runId,
-				"tool approval",
-			);
-		}
-		for (const toolCallId of toolCallIds) {
-			this.#runIdByToolCallId.set(toolCallId, runId);
-		}
-		for (const approvalId of approvalIds) {
-			this.#runIdByApprovalId.set(approvalId, runId);
-		}
+		this.#runs.indexMessageOwnership(runId, message);
 	}
 
 	private buildSnapshot(): ThreadStateSnapshot<TMessage> {
 		const tree = this.#tree.getSnapshot();
 		const indexes = this.#tree.getIndexes();
-		const runs = Array.from(this.#runsById.values()).map((run) =>
-			this.toRunSnapshot(run),
-		);
-		const activeRuns = runs.filter(
-			(run) => run.status === "submitted" || run.status === "streaming",
-		);
+		const runSnapshot = this.#runs.getSnapshot();
 		const selectedRun = this.getSelectedRunRecord();
 		return {
 			...tree,
 			...indexes,
-			activeRuns,
+			activeRuns: runSnapshot.activeRuns,
 			error: selectedRun?.error,
 			messages: this.#tree.getPath(),
-			runs,
+			runs: runSnapshot.runs,
 			status: selectedRun?.status ?? "ready",
-			treeStatus: this.resolveStatus(runs),
+			treeStatus: runSnapshot.status,
 		};
 	}
 
@@ -564,17 +465,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	private assertCanStartRun(parentMessageId: string) {
 		const parentMessage = this.#tree.getMessage(parentMessageId);
 		if (parentMessage) this.assertValidRunParent(parentMessage);
-
-		const activeRuns = this.getActiveRunRecords();
-		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
-			throw new Error("Cannot start run: max active runs reached");
-		}
-		const activeFromMessage = activeRuns.filter(
-			(run) => run.spec.parentMessageId === parentMessageId,
-		).length;
-		if (activeFromMessage >= this.#concurrency.maxActiveRunsPerMessage) {
-			throw new Error(`Cannot start another run from ${parentMessageId}`);
-		}
+		this.#runs.assertCanStart(parentMessageId);
 	}
 
 	private assertValidRunParent(message: TMessage) {
@@ -585,52 +476,11 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		}
 	}
 
-	private getActiveRunRecords() {
-		return Array.from(this.#runsById.values()).filter(
-			(run) => run.status === "submitted" || run.status === "streaming",
-		);
-	}
-
 	private getSelectedRunRecord() {
-		if (this.#selectedRunId) {
-			const selectedRun = this.#runsById.get(this.#selectedRunId);
-			if (selectedRun) return selectedRun;
-		}
-		const pathIds = new Set(this.#tree.getPathIds());
-		const runs = Array.from(this.#runsById.values()).reverse();
-		const responseRun = runs.find(
-			(run) =>
-				run.spec.messageId !== undefined && pathIds.has(run.spec.messageId),
-		);
-		if (responseRun) return responseRun;
-
-		const cursorId = this.#tree.cursorId;
-		if (!cursorId) return undefined;
-		return (
-			runs.find(
-				(run) =>
-					run.spec.parentMessageId === cursorId &&
-					(run.status === "submitted" || run.status === "streaming"),
-			) ?? runs.find((run) => run.spec.parentMessageId === cursorId)
-		);
-	}
-
-	private getRunRecord(runId: string) {
-		const run = this.#runsById.get(runId);
-		if (!run) throw new Error(`Unknown run ${runId}`);
-		return run;
-	}
-
-	private getRunForToolCall(toolCallId: string) {
-		const runId = this.#runIdByToolCallId.get(toolCallId);
-		if (!runId) throw new Error(`No run owns tool call ${toolCallId}`);
-		return this.getRunRecord(runId);
-	}
-
-	private getRunForApproval(approvalId: string) {
-		const runId = this.#runIdByApprovalId.get(approvalId);
-		if (!runId) throw new Error(`No run owns tool approval ${approvalId}`);
-		return this.getRunRecord(runId);
+		return this.#runs.resolveSelected({
+			cursorId: this.#tree.cursorId,
+			pathIds: new Set(this.#tree.getPathIds()),
+		});
 	}
 
 	private createRunForSelectedAssistant() {
@@ -649,7 +499,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			siblingOrder: this.#tree
 				.getChildren(parentMessageId)
 				.findIndex((child) => child.id === messageId),
-			id: this.reserveRunId(),
+			id: this.#runs.reserveId(this.generateMessageId),
 		};
 		const record: RunRecord<TMessage> = {
 			chat: new ThreadRunChat(this, spec),
@@ -658,46 +508,17 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			spec,
 			status: "ready",
 		};
-		this.#runsById.set(spec.id, record);
-		this.#selectedRunId = spec.id;
+		this.#runs.add(record);
+		this.#runs.select(spec.id);
 		this.indexMessageOwnership(spec.id, message);
 		this.emit();
 		return record;
 	}
 
 	private assertCanResetTree() {
-		if (this.getActiveRunRecords().length > 0) {
+		if (this.#runs.getActive().length > 0) {
 			throw new Error("Cannot replace the tree while runs are active");
 		}
-	}
-
-	private clearRunState() {
-		this.#selectedRunId = null;
-		this.#runIdByApprovalId.clear();
-		this.#runIdByToolCallId.clear();
-		this.#runsById.clear();
-	}
-
-	private assertOwnershipAvailable(
-		owners: Map<string, string>,
-		id: string,
-		runId: string,
-		label: string,
-	) {
-		const existingRunId = owners.get(id);
-		if (existingRunId && existingRunId !== runId) {
-			throw new Error(
-				`${label} ${id} is already owned by run ${existingRunId}`,
-			);
-		}
-	}
-
-	private reserveRunId() {
-		const runId = this.generateMessageId();
-		if (this.#runsById.has(runId)) {
-			throw new Error(`Run ${runId} already exists`);
-		}
-		return runId;
 	}
 
 	private startRunFromParent({
@@ -713,22 +534,16 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		const spec: ThreadRunSpec & { parentMessageId: string } = {
 			id,
 			parentMessageId,
-			siblingOrder: this.reserveSiblingOrder(parentMessageId),
+			siblingOrder: this.#runs.reserveSiblingOrder(
+				parentMessageId,
+				this.#tree.getChildren(parentMessageId).length,
+			),
 		};
 		if (follow) {
-			this.#selectedRunId = id;
+			this.#runs.select(id);
 			this.#tree.setCursor(parentMessageId);
 		}
 		return this.startRunRequest(spec, options);
-	}
-
-	private reserveSiblingOrder(parentMessageId: string | null) {
-		const existingMessageOrder =
-			this.#tree.getChildren(parentMessageId).length - 1;
-		const runOrders = Array.from(this.#runsById.values())
-			.filter((run) => run.spec.parentMessageId === parentMessageId)
-			.map((run) => run.spec.siblingOrder);
-		return Math.max(existingMessageOrder, ...runOrders) + 1;
 	}
 
 	private startRunRequest(
@@ -747,7 +562,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 			spec,
 			status: "submitted",
 		};
-		this.#runsById.set(spec.id, record);
+		this.#runs.add(record);
 		this.emit();
 		const finished = chat
 			.start(options)
@@ -780,21 +595,6 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		run.finished = finished;
 		this.emit();
 		await finished;
-	}
-
-	private toRunSnapshot(run: RunRecord<TMessage>): ThreadRun {
-		return {
-			error: run.error,
-			id: run.spec.id,
-			status: run.status,
-		};
-	}
-
-	private resolveStatus(runs: ThreadRun[]) {
-		if (runs.some((run) => run.status === "streaming")) return "streaming";
-		if (runs.some((run) => run.status === "submitted")) return "submitted";
-		if (runs.some((run) => run.status === "error")) return "error";
-		return "ready";
 	}
 }
 

--- a/packages/thread/src/thread-chat.ts
+++ b/packages/thread/src/thread-chat.ts
@@ -282,13 +282,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 		this.emit();
 	}
 
-	mergePath(messages: TMessage[], options: { silent?: boolean } = {}) {
-		this.#tree.mergePath(messages);
-		if (!options.silent) this.emit();
-	}
-
-	mergeRunPath(messages: TMessage[]) {
-		this.#tree.mergePath(messages, { moveCursor: false });
+	updateRunPath(messages: TMessage[]) {
+		this.#tree.updatePath(messages);
 	}
 
 	resumeStream: AbstractChat<TMessage>["resumeStream"] = async (
@@ -320,7 +315,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 				? messages(this.#snapshot.messages)
 				: messages;
 		this.#runs.select(null);
-		this.mergePath(nextMessages);
+		this.#tree.setPath(nextMessages);
+		this.emit();
 	}
 
 	sendMessage = async (

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { ThreadChat } from "../src/thread-chat";
+
+class ControlledTransport implements ChatTransport<UIMessage> {
+	readonly requests = new Map<
+		string,
+		{
+			abortSignal: AbortSignal | undefined;
+			controller: ReadableStreamDefaultController<UIMessageChunk>;
+		}
+	>();
+
+	sendMessages: ChatTransport<UIMessage>["sendMessages"] = (options) => {
+		const assistantMessageId = (options.body as { assistantMessageId: string })
+			.assistantMessageId;
+		return Promise.resolve(
+			new ReadableStream({
+				start: (controller) => {
+					this.requests.set(assistantMessageId, {
+						abortSignal: options.abortSignal,
+						controller,
+					});
+					options.abortSignal?.addEventListener(
+						"abort",
+						() => {
+							controller.enqueue({ type: "abort" });
+							controller.close();
+						},
+						{ once: true },
+					);
+				},
+			}),
+		);
+	};
+
+	reconnectToStream() {
+		return Promise.resolve(null);
+	}
+
+	emitText(assistantMessageId: string, text: string) {
+		const controller = this.requests.get(assistantMessageId)?.controller;
+		controller?.enqueue({ messageId: assistantMessageId, type: "start" });
+		controller?.enqueue({ id: "text", type: "text-start" });
+		controller?.enqueue({ delta: text, id: "text", type: "text-delta" });
+		controller?.enqueue({ id: "text", type: "text-end" });
+		controller?.close();
+	}
+}
+
+function user(id: string): UIMessage {
+	return { id, parts: [{ text: id, type: "text" }], role: "user" };
+}
+
+async function waitFor(predicate: () => boolean) {
+	for (let attempt = 0; attempt < 500; attempt += 1) {
+		if (predicate()) return;
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for request");
+}
+
+describe("ThreadChat", () => {
+	test("streams concurrent responses into separate assistant siblings", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const primary = await chat.startRun({
+			follow: true,
+			message: user("user-1"),
+			request: { body: { assistantMessageId: "assistant-1" } },
+		});
+		const alternative = await chat.startRun({
+			follow: false,
+			from: "user-1",
+			request: { body: { assistantMessageId: "assistant-2" } },
+		});
+		await waitFor(() => transport.requests.size === 2);
+
+		transport.emitText("assistant-2", "second");
+		transport.emitText("assistant-1", "first");
+		await Promise.all([primary.finished, alternative.finished]);
+
+		expect(chat.getSiblings("assistant-1").map(({ id }) => id)).toEqual([
+			"assistant-1",
+			"assistant-2",
+		]);
+		expect(chat.getSnapshot().cursorId).toBe("assistant-1");
+	});
+
+	test("claims an optimistic assistant placeholder for its reserved run", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		chat.addMessage(user("user-1"), null);
+		chat.addMessage(
+			{
+				id: "assistant-1",
+				metadata: { lifecycle: "pending" },
+				parts: [],
+				role: "assistant",
+			},
+			"user-1",
+		);
+
+		const run = await chat.startRun({
+			from: "user-1",
+			request: { body: { assistantMessageId: "assistant-1" } },
+		});
+		await waitFor(() => transport.requests.has("assistant-1"));
+
+		expect(chat.getMessage("assistant-1")?.metadata).toEqual({
+			lifecycle: "pending",
+		});
+		transport.emitText("assistant-1", "claimed");
+		await run.finished;
+		expect(getMessageText(chat.getMessage("assistant-1") as UIMessage)).toBe(
+			"claimed",
+		);
+	});
+
+	test("does not claim a populated assistant as a new run", async () => {
+		const chat = new ThreadChat();
+		chat.addMessage(user("user-1"), null);
+		chat.addMessage(
+			{
+				id: "assistant-1",
+				parts: [{ text: "complete", type: "text" }],
+				role: "assistant",
+			},
+			"user-1",
+		);
+
+		await expect(
+			chat.startRun({
+				from: "user-1",
+				request: { body: { assistantMessageId: "assistant-1" } },
+			}),
+		).rejects.toThrow("unavailable");
+	});
+
+	test("keeps hidden branches when reconciling the selected path", () => {
+		const chat = new ThreadChat({
+			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],
+		});
+		chat.addMessage(user("user-2"), "assistant-1");
+		chat.addMessage({ ...user("assistant-2"), role: "assistant" }, "user-2");
+
+		chat.setMessages([
+			user("user-1"),
+			{ ...user("assistant-1"), role: "assistant" },
+			user("user-3"),
+		]);
+
+		expect(chat.getMessage("assistant-2")?.id).toBe("assistant-2");
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual([
+			"user-1",
+			"assistant-1",
+			"user-3",
+		]);
+	});
+
+	test("rejects concurrency before adding optimistic nodes", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			concurrency: { maxActiveRuns: 1 },
+			transport,
+		});
+		await chat.startRun({
+			message: user("user-1"),
+			request: { body: { assistantMessageId: "assistant-1" } },
+		});
+
+		await expect(
+			chat.startRun({
+				message: user("user-2"),
+				request: { body: { assistantMessageId: "assistant-2" } },
+			}),
+		).rejects.toThrow("max active runs");
+		expect(chat.getMessage("user-2")).toBeUndefined();
+	});
+
+	test("stopping one run does not abort another", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const first = await chat.startRun({
+			message: user("user-1"),
+			request: { body: { assistantMessageId: "assistant-1" } },
+		});
+		const second = await chat.startRun({
+			from: "user-1",
+			request: { body: { assistantMessageId: "assistant-2" } },
+		});
+		await waitFor(() => transport.requests.size === 2);
+
+		await first.stop();
+		expect(
+			transport.requests.get("assistant-1")?.abortSignal?.aborted,
+		).toBeTrue();
+		expect(
+			transport.requests.get("assistant-2")?.abortSignal?.aborted,
+		).toBeFalse();
+		transport.emitText("assistant-2", "complete");
+		await second.finished;
+	});
+});

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
-import { getMessageText } from "../src/message-tree";
+import { getMessageText } from "../src/message-utils";
 import { ThreadChat } from "../src/thread-chat";
 
 class ControlledTransport implements ChatTransport<UIMessage> {

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -168,7 +168,7 @@ describe("ThreadChat", () => {
 		expect(chat.getParent("response-1")?.id).toBe("context-1");
 	});
 
-	test("creates a child response after an assistant message", async () => {
+	test("rejects a bare run from an assistant before transport", async () => {
 		const transport = new ControlledTransport();
 		const parent: UIMessage = {
 			id: "assistant-parent",
@@ -176,14 +176,32 @@ describe("ThreadChat", () => {
 			role: "assistant",
 		};
 		const chat = new ThreadChat({ messages: [parent], transport });
-		const run = await chat.startRun({ from: parent.id });
-		await waitFor(() => transport.requests.length === 1);
 
-		transport.emitText(0, "assistant-child", "second");
-		await run.finished;
+		await expect(chat.startRun({ from: parent.id })).rejects.toThrow(
+			"Cannot start a new run directly from assistant message assistant-parent; attach an input message first",
+		);
+		expect(transport.requests).toHaveLength(0);
+		expect(chat.getTreeSnapshot().nodes).toHaveLength(1);
+		expect(chat.getSnapshot().runs).toHaveLength(0);
+	});
 
-		expect(chat.getMessage(parent.id)).toEqual(parent);
-		expect(chat.getParent("assistant-child")?.id).toBe(parent.id);
+	test("rejects an assistant input without mutating the tree", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ messages: [user("user-1")], transport });
+
+		await expect(
+			chat.sendMessage({
+				id: "assistant-input",
+				parts: [{ text: "prebuilt response", type: "text" }],
+				role: "assistant",
+			}),
+		).rejects.toThrow(
+			"Cannot start a new run directly from assistant message assistant-input; attach an input message first",
+		);
+		expect(transport.requests).toHaveLength(0);
+		expect(chat.getMessage("assistant-input")).toBeUndefined();
+		expect(chat.getSnapshot().cursorId).toBe("user-1");
+		expect(chat.getSnapshot().runs).toHaveLength(0);
 	});
 
 	test("keeps hidden branches when reconciling the selected path", () => {

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -149,6 +149,43 @@ describe("ThreadChat", () => {
 		expect(chat.getMessage("client-response")?.id).toBe("client-response");
 	});
 
+	test("attaches streamed output without requiring a user parent", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const run = await chat.startRun({
+			message: {
+				id: "context-1",
+				parts: [{ text: "System context", type: "text" }],
+				role: "system",
+			},
+		});
+		await waitFor(() => transport.requests.length === 1);
+
+		transport.emitText(0, "response-1", "complete");
+		await run.finished;
+
+		expect(chat.getMessage("context-1")?.role).toBe("system");
+		expect(chat.getParent("response-1")?.id).toBe("context-1");
+	});
+
+	test("creates a child response after an assistant message", async () => {
+		const transport = new ControlledTransport();
+		const parent: UIMessage = {
+			id: "assistant-parent",
+			parts: [{ text: "first", type: "text" }],
+			role: "assistant",
+		};
+		const chat = new ThreadChat({ messages: [parent], transport });
+		const run = await chat.startRun({ from: parent.id });
+		await waitFor(() => transport.requests.length === 1);
+
+		transport.emitText(0, "assistant-child", "second");
+		await run.finished;
+
+		expect(chat.getMessage(parent.id)).toEqual(parent);
+		expect(chat.getParent("assistant-child")?.id).toBe(parent.id);
+	});
+
 	test("keeps hidden branches when reconciling the selected path", () => {
 		const chat = new ThreadChat({
 			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -8,6 +8,7 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 		abortSignal: AbortSignal | undefined;
 		controller: ReadableStreamDefaultController<UIMessageChunk>;
 	}> = [];
+	#reconnectStream: ReadableStream<UIMessageChunk> | null = null;
 
 	sendMessages: ChatTransport<UIMessage>["sendMessages"] = (options) => {
 		return Promise.resolve(
@@ -33,7 +34,20 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 	reconnectToStream(
 		_options: Parameters<ChatTransport<UIMessage>["reconnectToStream"]>[0],
 	): Promise<ReadableStream<UIMessageChunk> | null> {
-		return Promise.resolve(null);
+		const stream = this.#reconnectStream;
+		this.#reconnectStream = null;
+		return Promise.resolve(stream);
+	}
+
+	prepareReconnect() {
+		let controller: ReadableStreamDefaultController<UIMessageChunk> | undefined;
+		this.#reconnectStream = new ReadableStream({
+			start(value) {
+				controller = value;
+			},
+		});
+		if (!controller) throw new Error("Expected reconnect controller");
+		return controller;
 	}
 
 	emit(requestIndex: number, chunk: UIMessageChunk) {
@@ -295,5 +309,83 @@ describe("ThreadChat", () => {
 			"assistant-2",
 			"assistant-3",
 		]);
+	});
+
+	test("preserves an error when resume finds no stream", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const run = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.fail(0, new Error("failed"));
+		await run.finished;
+		const error = run.getSnapshot()?.error;
+
+		await chat.resumeRun(run.id);
+
+		expect(run.getSnapshot()).toMatchObject({ error, status: "error" });
+		chat.clearError();
+		expect(run.getSnapshot()).toMatchObject({
+			error: undefined,
+			status: "ready",
+		});
+	});
+
+	test("run handles expose the current resumed request", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const run = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.emitText(0, "assistant-1", "first");
+		await run.finished;
+		const initialFinished = run.finished;
+		const reconnect = transport.prepareReconnect();
+
+		const resumed = chat.resumeRun(run.id);
+
+		expect(run.finished).not.toBe(initialFinished);
+		let finished = false;
+		void run.finished.then(() => {
+			finished = true;
+		});
+		await Bun.sleep(0);
+		expect(finished).toBeFalse();
+		reconnect.close();
+		await Promise.all([resumed, run.finished]);
+	});
+
+	test("aggregate status ignores historical run errors", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const failed = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.fail(0, new Error("failed"));
+		await failed.finished;
+		expect(chat.getSnapshot().treeStatus).toBe("ready");
+		expect(failed.getSnapshot()?.status).toBe("error");
+
+		const successful = await chat.startRun({ from: "user-1" });
+		await waitFor(() => transport.requests.length === 2);
+		expect(chat.getSnapshot().treeStatus).toBe("submitted");
+		transport.emitText(1, "assistant-1", "recovered");
+		await successful.finished;
+
+		expect(chat.getSnapshot().status).toBe("ready");
+		expect(chat.getSnapshot().treeStatus).toBe("ready");
+		expect(failed.getSnapshot()?.status).toBe("error");
+	});
+
+	test("unexpected application errors reject the run promise", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			sendAutomaticallyWhen: () => {
+				throw new Error("application callback failed");
+			},
+			transport,
+		});
+		const run = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.emitText(0, "assistant-1", "complete");
+
+		await expect(run.finished).rejects.toThrow("application callback failed");
 	});
 });

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -4,21 +4,16 @@ import { getMessageText } from "../src/message-tree";
 import { ThreadChat } from "../src/thread-chat";
 
 class ControlledTransport implements ChatTransport<UIMessage> {
-	readonly requests = new Map<
-		string,
-		{
-			abortSignal: AbortSignal | undefined;
-			controller: ReadableStreamDefaultController<UIMessageChunk>;
-		}
-	>();
+	readonly requests: Array<{
+		abortSignal: AbortSignal | undefined;
+		controller: ReadableStreamDefaultController<UIMessageChunk>;
+	}> = [];
 
 	sendMessages: ChatTransport<UIMessage>["sendMessages"] = (options) => {
-		const assistantMessageId = (options.body as { assistantMessageId: string })
-			.assistantMessageId;
 		return Promise.resolve(
 			new ReadableStream({
 				start: (controller) => {
-					this.requests.set(assistantMessageId, {
+					this.requests.push({
 						abortSignal: options.abortSignal,
 						controller,
 					});
@@ -35,13 +30,27 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 		);
 	};
 
-	reconnectToStream() {
+	reconnectToStream(
+		_options: Parameters<ChatTransport<UIMessage>["reconnectToStream"]>[0],
+	): Promise<ReadableStream<UIMessageChunk> | null> {
 		return Promise.resolve(null);
 	}
 
-	emitText(assistantMessageId: string, text: string) {
-		const controller = this.requests.get(assistantMessageId)?.controller;
-		controller?.enqueue({ messageId: assistantMessageId, type: "start" });
+	emit(requestIndex: number, chunk: UIMessageChunk) {
+		this.requests[requestIndex]?.controller.enqueue(chunk);
+	}
+
+	finish(requestIndex: number) {
+		this.requests[requestIndex]?.controller.close();
+	}
+
+	fail(requestIndex: number, error: Error) {
+		this.requests[requestIndex]?.controller.error(error);
+	}
+
+	emitText(requestIndex: number, messageId: string, text: string) {
+		const controller = this.requests[requestIndex]?.controller;
+		controller?.enqueue({ messageId, type: "start" });
 		controller?.enqueue({ id: "text", type: "text-start" });
 		controller?.enqueue({ delta: text, id: "text", type: "text-delta" });
 		controller?.enqueue({ id: "text", type: "text-end" });
@@ -51,6 +60,11 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 
 function user(id: string): UIMessage {
 	return { id, parts: [{ text: id, type: "text" }], role: "user" };
+}
+
+function requireMessage(message: UIMessage | undefined) {
+	if (!message) throw new Error("Expected message to exist");
+	return message;
 }
 
 async function waitFor(predicate: () => boolean) {
@@ -68,17 +82,15 @@ describe("ThreadChat", () => {
 		const primary = await chat.startRun({
 			follow: true,
 			message: user("user-1"),
-			request: { body: { assistantMessageId: "assistant-1" } },
 		});
 		const alternative = await chat.startRun({
 			follow: false,
 			from: "user-1",
-			request: { body: { assistantMessageId: "assistant-2" } },
 		});
-		await waitFor(() => transport.requests.size === 2);
+		await waitFor(() => transport.requests.length === 2);
 
-		transport.emitText("assistant-2", "second");
-		transport.emitText("assistant-1", "first");
+		transport.emitText(1, "assistant-2", "second");
+		transport.emitText(0, "assistant-1", "first");
 		await Promise.all([primary.finished, alternative.finished]);
 
 		expect(chat.getSiblings("assistant-1").map(({ id }) => id)).toEqual([
@@ -88,54 +100,53 @@ describe("ThreadChat", () => {
 		expect(chat.getSnapshot().cursorId).toBe("assistant-1");
 	});
 
-	test("claims an optimistic assistant placeholder for its reserved run", async () => {
+	test("keeps a submitted response out of the tree until streaming starts", async () => {
 		const transport = new ControlledTransport();
 		const chat = new ThreadChat({ transport });
-		chat.addMessage(user("user-1"), null);
-		chat.addMessage(
-			{
-				id: "assistant-1",
-				metadata: { lifecycle: "pending" },
-				parts: [],
-				role: "assistant",
-			},
-			"user-1",
-		);
-
 		const run = await chat.startRun({
-			from: "user-1",
-			request: { body: { assistantMessageId: "assistant-1" } },
+			message: user("user-1"),
 		});
-		await waitFor(() => transport.requests.has("assistant-1"));
+		await waitFor(() => transport.requests.length === 1);
 
-		expect(chat.getMessage("assistant-1")?.metadata).toEqual({
-			lifecycle: "pending",
-		});
-		transport.emitText("assistant-1", "claimed");
+		const runId = run.id;
+		expect(chat.getChildren("user-1")).toEqual([]);
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual(["user-1"]);
+		expect(run.getSnapshot()?.status).toBe("submitted");
+		transport.emitText(0, "server-assistant", "claimed");
 		await run.finished;
-		expect(getMessageText(chat.getMessage("assistant-1") as UIMessage)).toBe(
-			"claimed",
-		);
+		expect(run.id).toBe(runId);
+		expect(
+			getMessageText(requireMessage(chat.getMessage("server-assistant"))),
+		).toBe("claimed");
+		const snapshotMessage = chat
+			.getSnapshot()
+			.nodes.find(({ message }) => message.id === "server-assistant")?.message;
+		expect(getMessageText(requireMessage(snapshotMessage))).toBe("claimed");
 	});
 
-	test("does not claim a populated assistant as a new run", async () => {
-		const chat = new ThreadChat();
-		chat.addMessage(user("user-1"), null);
-		chat.addMessage(
-			{
-				id: "assistant-1",
-				parts: [{ text: "complete", type: "text" }],
-				role: "assistant",
-			},
-			"user-1",
-		);
+	test("uses AI SDK's client response ID when the stream omits one", async () => {
+		const generatedIds = ["run-1", "client-response"];
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			generateId: () => generatedIds.shift() ?? "unexpected-id",
+			id: "thread-1",
+			transport,
+		});
+		const run = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
 
-		await expect(
-			chat.startRun({
-				from: "user-1",
-				request: { body: { assistantMessageId: "assistant-1" } },
-			}),
-		).rejects.toThrow("unavailable");
+		transport.emit(0, { id: "text", type: "text-start" });
+		transport.emit(0, {
+			delta: "client identity",
+			id: "text",
+			type: "text-delta",
+		});
+		transport.emit(0, { id: "text", type: "text-end" });
+		transport.finish(0);
+		await run.finished;
+
+		expect(run.id).toBe("run-1");
+		expect(chat.getMessage("client-response")?.id).toBe("client-response");
 	});
 
 	test("keeps hidden branches when reconciling the selected path", () => {
@@ -159,7 +170,21 @@ describe("ThreadChat", () => {
 		]);
 	});
 
-	test("rejects concurrency before adding optimistic nodes", async () => {
+	test("does not follow a delayed run after the active path changes", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const primary = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+
+		chat.setMessages([user("user-1")]);
+		transport.emitText(0, "assistant-1", "primary");
+		await primary.finished;
+
+		expect(chat.getMessage("assistant-1")?.id).toBe("assistant-1");
+		expect(chat.getSnapshot().cursorId).toBe("user-1");
+	});
+
+	test("rejects concurrency before adding another user message", async () => {
 		const transport = new ControlledTransport();
 		const chat = new ThreadChat({
 			concurrency: { maxActiveRuns: 1 },
@@ -167,13 +192,11 @@ describe("ThreadChat", () => {
 		});
 		await chat.startRun({
 			message: user("user-1"),
-			request: { body: { assistantMessageId: "assistant-1" } },
 		});
 
 		await expect(
 			chat.startRun({
 				message: user("user-2"),
-				request: { body: { assistantMessageId: "assistant-2" } },
 			}),
 		).rejects.toThrow("max active runs");
 		expect(chat.getMessage("user-2")).toBeUndefined();
@@ -184,22 +207,38 @@ describe("ThreadChat", () => {
 		const chat = new ThreadChat({ transport });
 		const first = await chat.startRun({
 			message: user("user-1"),
-			request: { body: { assistantMessageId: "assistant-1" } },
 		});
 		const second = await chat.startRun({
 			from: "user-1",
-			request: { body: { assistantMessageId: "assistant-2" } },
 		});
-		await waitFor(() => transport.requests.size === 2);
+		await waitFor(() => transport.requests.length === 2);
 
 		await first.stop();
-		expect(
-			transport.requests.get("assistant-1")?.abortSignal?.aborted,
-		).toBeTrue();
-		expect(
-			transport.requests.get("assistant-2")?.abortSignal?.aborted,
-		).toBeFalse();
-		transport.emitText("assistant-2", "complete");
+		expect(transport.requests[0]?.abortSignal?.aborted).toBeTrue();
+		expect(transport.requests[1]?.abortSignal?.aborted).toBeFalse();
+		expect(chat.getChildren("user-1")).toEqual([]);
+		transport.emitText(1, "assistant-2", "complete");
 		await second.finished;
+	});
+
+	test("keeps creation order after an earlier run fails without a message", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const failed = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.fail(0, new Error("failed before start"));
+		await failed.finished;
+
+		const second = await chat.startRun({ from: "user-1" });
+		const third = await chat.startRun({ follow: false, from: "user-1" });
+		await waitFor(() => transport.requests.length === 3);
+		transport.emitText(2, "assistant-3", "third");
+		transport.emitText(1, "assistant-2", "second");
+		await Promise.all([second.finished, third.finished]);
+
+		expect(chat.getChildren("user-1").map(({ id }) => id)).toEqual([
+			"assistant-2",
+			"assistant-3",
+		]);
 	});
 });

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { getMessageText } from "../src/message-tree";
 import { ThreadChat } from "../src/thread-chat";
 
 class ControlledTransport implements ChatTransport<UIMessage> {


### PR DESCRIPTION
## Summary
- Adds `ThreadChat`, the imperative owner of the canonical tree and run registry.
- Supports concurrent responses, branch-local stopping, regeneration, resume, and tool ownership.
- Allows an empty optimistic assistant placeholder to be claimed exactly once by its reserved run.

## Behavior
Multiple responses can stream into distinct leaves without cursor changes aborting hidden work.

## Verification
- 17 package tests pass at the stack tip.
- Includes optimistic placeholder identity and populated-node rejection coverage.

## Review focus
Run admission, reserved identity claims, and isolation between concurrent responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a thread chat API for managing message trees, conversation branches, streaming responses, and run control.
  - Added support for concurrent runs, resuming responses, regeneration, tool-call tracking, and path navigation.
  - Exposed new thread chat creation and management exports.

- **Bug Fixes**
  - Improved handling of invalid assistant branching, response identifiers, interrupted runs, and resumed requests.
  - Aggregate thread status now reflects active activity without surfacing historical run failures.

- **Documentation**
  - Clarified run lifecycle, branching behavior, response binding, continuation rules, and status semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. #235
5. #236
6. **#237** 👈 current
7. #238
8. #239
9. #240
10. #241
11. #242
12. #243
13. #244
14. #245
15. #246
16. #247
17. #248
18. #249
19. #250
20. #251
21. #252
22. #253
23. #254
<!-- stack:links:end -->