### PR TITLE
Threads 5: Prove AI SDK behavioral parity

### DIFF
--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -192,36 +192,6 @@ describe("ThreadRunChat", () => {
 		expect(spec.messageId).toBe("server-id");
 	});
 
-	test("creates a distinct response after an assistant parent", async () => {
-		const parent: UIMessage = {
-			id: "assistant-parent",
-			parts: [{ text: "first", type: "text" }],
-			role: "assistant",
-		};
-		const spec: ThreadRunSpec = {
-			id: "run-1",
-			parentMessageId: parent.id,
-			siblingOrder: 0,
-		};
-		const transport = new ControlledTransport();
-		const host = new TestRunHost(transport, parent, spec);
-		const chat = new ThreadRunChat(host, spec);
-
-		const request = chat.start();
-		await Bun.sleep(0);
-		transport.emit(
-			{ messageId: "assistant-child", type: "start" },
-			{ id: "text-1", type: "text-start" },
-			{ delta: "second", id: "text-1", type: "text-delta" },
-			{ id: "text-1", type: "text-end" },
-		);
-		transport.finish();
-		await request;
-
-		expect(host.tree.getMessage(parent.id)).toEqual(parent);
-		expect(host.tree.getParentId("assistant-child")).toBe(parent.id);
-	});
-
 	test("reports a failed stream exactly once without adding a response", async () => {
 		const error = new Error("stream failed");
 		const callbackErrors: Error[] = [];
@@ -242,7 +212,7 @@ describe("ThreadRunChat", () => {
 		expect(host.tree.getChildren(spec.parentMessageId)).toEqual([]);
 	});
 
-	test("continues one response across automatic follow-up requests", async () => {
+	test("continues one response after an automatic tool follow-up", async () => {
 		const spec = createSpec();
 		const transport = new ControlledTransport();
 		const host = new TestRunHost(transport, userMessage(), spec);
@@ -253,17 +223,31 @@ describe("ThreadRunChat", () => {
 		await waitFor(() => transport.requests.length === 1);
 		transport.emit(
 			{ messageId: "assistant-1", type: "start" },
-			{ id: "first", type: "text-start" },
-			{ delta: "one", id: "first", type: "text-delta" },
-			{ id: "first", type: "text-end" },
+			{
+				dynamic: true,
+				input: { city: "London" },
+				toolCallId: "tool-1",
+				toolName: "weather",
+				type: "tool-input-available",
+			},
+			{
+				dynamic: true,
+				output: { temperature: 22 },
+				toolCallId: "tool-1",
+				type: "tool-output-available",
+			},
+			{ finishReason: "tool-calls", type: "finish" },
 		);
 		transport.finish();
 
 		await waitFor(() => transport.requests.length === 2);
+		expect(transport.requests[1]?.options.messageId).toBe("assistant-1");
 		transport.emit(
+			{ messageId: "assistant-1", type: "start" },
 			{ id: "second", type: "text-start" },
-			{ delta: "two", id: "second", type: "text-delta" },
+			{ delta: "It is 22 degrees.", id: "second", type: "text-delta" },
 			{ id: "second", type: "text-end" },
+			{ finishReason: "stop", type: "finish" },
 		);
 		transport.finish();
 		await request;
@@ -273,8 +257,16 @@ describe("ThreadRunChat", () => {
 			host.tree.getChildren(spec.parentMessageId).map(({ id }) => id),
 		).toEqual(["assistant-1"]);
 		expect(host.tree.getMessage("assistant-1")?.parts).toEqual([
-			expect.objectContaining({ text: "one", type: "text" }),
-			expect.objectContaining({ text: "two", type: "text" }),
+			expect.objectContaining({
+				output: { temperature: 22 },
+				state: "output-available",
+				toolCallId: "tool-1",
+				type: "dynamic-tool",
+			}),
+			expect.objectContaining({
+				text: "It is 22 degrees.",
+				type: "text",
+			}),
 		]);
 		expect(host.status).toBe("ready");
 	});

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -72,6 +72,33 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 	}
 }
 
+class ResumeTransport extends ControlledTransport {
+	lastReconnectOptions:
+		| Parameters<ChatTransport<UIMessage>["reconnectToStream"]>[0]
+		| undefined;
+
+	override reconnectToStream(
+		options: Parameters<ChatTransport<UIMessage>["reconnectToStream"]>[0],
+	) {
+		this.lastReconnectOptions = options;
+		return Promise.resolve(
+			new ReadableStream<UIMessageChunk>({
+				start(controller) {
+					controller.enqueue({ id: "text", type: "text-start" });
+					controller.enqueue({
+						delta: "resumed",
+						id: "text",
+						type: "text-delta",
+					});
+					controller.enqueue({ id: "text", type: "text-end" });
+					controller.enqueue({ finishReason: "stop", type: "finish" });
+					controller.close();
+				},
+			}),
+		);
+	}
+}
+
 function user(id: string): UIMessage {
 	return { id, parts: [{ text: id, type: "text" }], role: "user" };
 }
@@ -387,5 +414,96 @@ describe("ThreadChat", () => {
 		transport.emitText(0, "assistant-1", "complete");
 
 		await expect(run.finished).rejects.toThrow("application callback failed");
+	});
+
+	test("regenerates an assistant as a sibling response", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const first = await chat.startRun({
+			message: user("user-1"),
+		});
+		await waitFor(() => transport.requests.length === 1);
+		transport.emitText(0, "assistant-1", "first");
+		await first.finished;
+
+		const regeneration = chat.regenerate({ messageId: "assistant-1" });
+		await waitFor(() => transport.requests.length === 2);
+		transport.emitText(1, "assistant-2", "second");
+		await regeneration;
+
+		expect(chat.getSiblings("assistant-1").map(({ id }) => id)).toEqual([
+			"assistant-1",
+			"assistant-2",
+		]);
+		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
+	});
+
+	test("routes tool output to the run that owns the tool call", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({ transport });
+		const runA = await chat.startRun({
+			message: user("user-a"),
+		});
+		const runB = await chat.startRun({
+			follow: false,
+			from: null,
+			message: user("user-b"),
+		});
+		await waitFor(() => transport.requests.length === 2);
+		for (const [requestIndex, assistantMessageId, toolCallId] of [
+			[0, "assistant-a", "tool-a"],
+			[1, "assistant-b", "tool-b"],
+		] as const) {
+			transport.emit(requestIndex, {
+				messageId: assistantMessageId,
+				type: "start",
+			});
+			transport.emit(requestIndex, {
+				dynamic: true,
+				input: { branch: assistantMessageId },
+				toolCallId,
+				toolName: "branch-tool",
+				type: "tool-input-available",
+			});
+		}
+		await waitFor(
+			() =>
+				chat.getMessage("assistant-a")?.parts.length === 1 &&
+				chat.getMessage("assistant-b")?.parts.length === 1,
+		);
+		transport.finish(0);
+		transport.finish(1);
+		await Promise.all([runA.finished, runB.finished]);
+
+		await chat.addToolOutput({
+			output: "A only",
+			tool: "branch-tool",
+			toolCallId: "tool-a",
+		});
+
+		expect(chat.getMessage("assistant-a")?.parts).toContainEqual(
+			expect.objectContaining({ output: "A only", toolCallId: "tool-a" }),
+		);
+		expect(chat.getMessage("assistant-b")?.parts).toContainEqual(
+			expect.not.objectContaining({ output: "A only" }),
+		);
+	});
+
+	test("resumes a restored assistant through its reconstructed run", async () => {
+		const transport = new ResumeTransport();
+		const chat = new ThreadChat({
+			messages: [
+				user("user-1"),
+				{ id: "assistant-1", parts: [], role: "assistant" },
+			],
+			transport,
+		});
+
+		await chat.resumeStream();
+
+		expect(getMessageText(requireMessage(chat.getMessage("assistant-1")))).toBe(
+			"resumed",
+		);
+		expect(transport.lastReconnectOptions?.body).toBeUndefined();
 	});
 });

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -438,6 +438,20 @@ describe("ThreadChat", () => {
 		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
 	});
 
+	test("rejects an unknown explicit regeneration target", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],
+			transport,
+		});
+
+		await expect(chat.regenerate({ messageId: "missing" })).rejects.toThrow(
+			"message missing not found",
+		);
+		expect(transport.requests).toHaveLength(0);
+		expect(chat.getSnapshot().cursorId).toBe("assistant-1");
+	});
+
 	test("rejects regeneration when the response parent is an assistant", async () => {
 		const transport = new ControlledTransport();
 		const chat = new ThreadChat({
@@ -484,7 +498,7 @@ describe("ThreadChat", () => {
 		]);
 	});
 
-	test("routes tool output to the run that owns the tool call", async () => {
+	test("routes tool output and approval to their owning runs", async () => {
 		const transport = new ControlledTransport();
 		const chat = new ThreadChat({ transport });
 		const runA = await chat.startRun({
@@ -496,9 +510,9 @@ describe("ThreadChat", () => {
 			message: user("user-b"),
 		});
 		await waitFor(() => transport.requests.length === 2);
-		for (const [requestIndex, assistantMessageId, toolCallId] of [
-			[0, "assistant-a", "tool-a"],
-			[1, "assistant-b", "tool-b"],
+		for (const [requestIndex, assistantMessageId, toolCallId, approvalId] of [
+			[0, "assistant-a", "tool-a", "approval-a"],
+			[1, "assistant-b", "tool-b", "approval-b"],
 		] as const) {
 			transport.emit(requestIndex, {
 				messageId: assistantMessageId,
@@ -510,6 +524,11 @@ describe("ThreadChat", () => {
 				toolCallId,
 				toolName: "branch-tool",
 				type: "tool-input-available",
+			});
+			transport.emit(requestIndex, {
+				approvalId,
+				toolCallId,
+				type: "tool-approval-request",
 			});
 		}
 		await waitFor(
@@ -526,13 +545,76 @@ describe("ThreadChat", () => {
 			tool: "branch-tool",
 			toolCallId: "tool-a",
 		});
+		await chat.addToolApprovalResponse({
+			approved: true,
+			id: "approval-b",
+		});
 
 		expect(chat.getMessage("assistant-a")?.parts).toContainEqual(
 			expect.objectContaining({ output: "A only", toolCallId: "tool-a" }),
 		);
-		expect(chat.getMessage("assistant-b")?.parts).toContainEqual(
-			expect.not.objectContaining({ output: "A only" }),
+		expect(chat.getMessage("assistant-b")?.parts).not.toContainEqual(
+			expect.objectContaining({ output: "A only" }),
 		);
+		expect(chat.getMessage("assistant-b")?.parts).toContainEqual(
+			expect.objectContaining({
+				approval: expect.objectContaining({
+					approved: true,
+					id: "approval-b",
+				}),
+				state: "approval-responded",
+				toolCallId: "tool-b",
+			}),
+		);
+	});
+
+	test("enforces the global concurrency limit before resuming", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			concurrency: { maxActiveRuns: 1 },
+			transport,
+		});
+		const completed = await chat.startRun({ message: user("user-a") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.emitText(0, "assistant-a", "complete");
+		await completed.finished;
+
+		const active = await chat.startRun({
+			follow: false,
+			from: null,
+			message: user("user-b"),
+		});
+		await waitFor(() => transport.requests.length === 2);
+
+		await expect(chat.resumeRun(completed.id)).rejects.toThrow(
+			"max active runs",
+		);
+		transport.finish(1);
+		await active.finished;
+	});
+
+	test("enforces the per-message concurrency limit before resuming", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			concurrency: { maxActiveRunsPerMessage: 1 },
+			transport,
+		});
+		const completed = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.emitText(0, "assistant-1", "complete");
+		await completed.finished;
+
+		const active = await chat.startRun({
+			follow: false,
+			from: "user-1",
+		});
+		await waitFor(() => transport.requests.length === 2);
+
+		await expect(chat.resumeRun(completed.id)).rejects.toThrow(
+			"Cannot start another run from user-1",
+		);
+		transport.finish(1);
+		await active.finished;
 	});
 
 	test("resumes a restored assistant through its reconstructed run", async () => {

--- a/packages/thread/test/thread-chat.test.ts
+++ b/packages/thread/test/thread-chat.test.ts
@@ -438,6 +438,52 @@ describe("ThreadChat", () => {
 		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
 	});
 
+	test("rejects regeneration when the response parent is an assistant", async () => {
+		const transport = new ControlledTransport();
+		const chat = new ThreadChat({
+			messages: [
+				{ ...user("assistant-parent"), role: "assistant" },
+				{ ...user("assistant-child"), role: "assistant" },
+			],
+			transport,
+		});
+
+		await expect(
+			chat.regenerate({ messageId: "assistant-child" }),
+		).rejects.toThrow(
+			"Cannot start a new run directly from assistant message assistant-parent; attach an input message first",
+		);
+		expect(transport.requests).toHaveLength(0);
+		expect(chat.getSnapshot().runs).toHaveLength(0);
+	});
+
+	test("restores assistant-to-assistant edges as tree data", () => {
+		const assistantParent = {
+			...user("assistant-parent"),
+			role: "assistant" as const,
+		};
+		const assistantChild = {
+			...user("assistant-child"),
+			role: "assistant" as const,
+		};
+		const chat = new ThreadChat({
+			initialTree: {
+				cursorId: assistantChild.id,
+				nodes: [
+					{ message: assistantParent, parentId: null },
+					{ message: assistantChild, parentId: assistantParent.id },
+				],
+				version: 1,
+			},
+		});
+
+		expect(chat.getParent(assistantChild.id)?.id).toBe(assistantParent.id);
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual([
+			assistantParent.id,
+			assistantChild.id,
+		]);
+	});
+
 	test("routes tool output to the run that owns the tool call", async () => {
 		const transport = new ControlledTransport();
 		const chat = new ThreadChat({ transport });


### PR DESCRIPTION
## Summary
- Adds integration coverage comparing `ThreadRunChat` with AI SDK React Chat reduction.
- Covers text, reasoning, tools, data parts, callbacks, and server ID replacement.

## Behavior
Tests only; production behavior is unchanged.

## Verification
- AI SDK parity tests pass at the stack tip.

## Review focus
Whether the chunk sequences cover the compatibility behavior we depend on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests to prove `ThreadChat` and `ThreadRunChat` match AI SDK React Chat behavior.

- Continues one response after an automatic tool follow-up using the same `messageId`, preserving dynamic tool parts and finish reasons.
- Regenerates as a sibling with cursor updates; rejects unknown targets and assistant-parent regenerations.
- Routes `addToolOutput` and approval responses by `toolCallId` to the owning run.
- Restores assistant-to-assistant links on load.
- Enforces global and per-message concurrency limits before resuming runs.
- `resumeStream` reconnects without a body and continues a restored assistant through its reconstructed run.

<sup>Written for commit 42b9edd5791ad3767602131abbc4ac159f8e4c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. #235
5. #236
6. #237
7. **#238** 👈 current
8. #239
9. #240
10. #241
11. #242
12. #243
13. #244
14. #245
15. #246
16. #247
17. #248
18. #249
19. #250
20. #251
21. #252
22. #253
23. #254
<!-- stack:links:end -->