### PR TITLE
Threads 6: Expose the useChat-compatible useThread hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -241,11 +241,15 @@
       "devDependencies": {
         "@ai-sdk/react": "^3.0.152",
         "@types/bun": "^1.3.12",
+        "@types/react": "19.2.7",
         "ai": "^6.0.150",
+        "react": "19.2.3",
         "typescript": "6.0.2",
       },
       "peerDependencies": {
+        "@ai-sdk/react": "^3.0.0",
         "ai": "^6.0.0",
+        "react": ">=18",
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -242,8 +242,10 @@
         "@ai-sdk/react": "^3.0.152",
         "@types/bun": "^1.3.12",
         "@types/react": "19.2.7",
+        "@types/react-test-renderer": "19.1.0",
         "ai": "^6.0.150",
         "react": "19.2.3",
+        "react-test-renderer": "19.2.3",
         "typescript": "6.0.2",
       },
       "peerDependencies": {
@@ -1371,6 +1373,8 @@
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
@@ -3020,7 +3024,7 @@
 
     "react-hook-form": ["react-hook-form@7.72.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+    "react-is": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -3033,6 +3037,8 @@
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.3", "", { "dependencies": { "react-is": "^19.2.3", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw=="],
 
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
@@ -4163,6 +4169,8 @@
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/packages/thread/build.ts
+++ b/packages/thread/build.ts
@@ -1,0 +1,20 @@
+const result = await Bun.build({
+	entrypoints: [
+		`${import.meta.dir}/src/index.ts`,
+		`${import.meta.dir}/src/react.ts`,
+	],
+	format: "esm",
+	outdir: `${import.meta.dir}/dist`,
+	packages: "external",
+	splitting: true,
+	target: "browser",
+});
+
+if (!result.success) {
+	for (const log of result.logs) console.error(log);
+	throw new Error("Failed to build @chatjs/thread");
+}
+
+const reactPath = `${import.meta.dir}/dist/react.js`;
+const reactSource = await Bun.file(reactPath).text();
+await Bun.write(reactPath, `"use client";\n${reactSource}`);

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -58,6 +58,14 @@
 		"ai": "^6.0.0",
 		"react": ">=18"
 	},
+	"peerDependenciesMeta": {
+		"@ai-sdk/react": {
+			"optional": true
+		},
+		"react": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@ai-sdk/react": "^3.0.152",
 		"@types/bun": "^1.3.12",

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -62,8 +62,10 @@
 		"@ai-sdk/react": "^3.0.152",
 		"@types/bun": "^1.3.12",
 		"@types/react": "19.2.7",
+		"@types/react-test-renderer": "19.1.0",
 		"ai": "^6.0.150",
 		"react": "19.2.3",
+		"react-test-renderer": "19.2.3",
 		"typescript": "6.0.2"
 	}
 }

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -28,7 +28,7 @@
 			"default": "./dist/index.js"
 		},
 		"./react": {
-			"types": "./src/react.ts",
+			"types": "./dist/react.d.ts",
 			"bun": "./src/react.ts",
 			"development": "./src/react.ts",
 			"default": "./dist/react.js"
@@ -45,9 +45,9 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external && bun build ./src/use-thread.ts --outfile ./dist/react.js --target=browser --format=esm --packages external --banner='\"use client\";'",
-		"format": "bunx @biomejs/biome@2.4.10 check --write src test *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
-		"lint": "bunx @biomejs/biome@2.4.10 check src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun ./build.ts",
+		"format": "bunx @biomejs/biome@2.4.10 check --write src test build.ts *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
+		"lint": "bunx @biomejs/biome@2.4.10 check src test build.ts ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
 		"test": "bun test --pass-with-no-tests",
 		"test:unit": "bun test --pass-with-no-tests",

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -26,6 +26,12 @@
 			"bun": "./src/index.ts",
 			"development": "./src/index.ts",
 			"default": "./dist/index.js"
+		},
+		"./react": {
+			"types": "./src/react.ts",
+			"bun": "./src/react.ts",
+			"development": "./src/react.ts",
+			"default": "./dist/react.js"
 		}
 	},
 	"types": "./dist/index.d.ts",
@@ -39,7 +45,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external",
+		"build": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\" && tsc -p tsconfig.build.json && bun build ./src/index.ts --outfile ./dist/index.js --target=browser --format=esm --packages external && bun build ./src/use-thread.ts --outfile ./dist/react.js --target=browser --format=esm --packages external --banner='\"use client\";'",
 		"format": "bunx @biomejs/biome@2.4.10 check --write src test *.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"lint": "bunx @biomejs/biome@2.4.10 check src test ARCHITECTURE.md package.json tsconfig.json tsconfig.build.json biome.jsonc",
 		"prepublishOnly": "bun run build",
@@ -48,12 +54,16 @@
 		"test:types": "bun run build"
 	},
 	"peerDependencies": {
-		"ai": "^6.0.0"
+		"@ai-sdk/react": "^3.0.0",
+		"ai": "^6.0.0",
+		"react": ">=18"
 	},
 	"devDependencies": {
 		"@ai-sdk/react": "^3.0.152",
 		"@types/bun": "^1.3.12",
+		"@types/react": "19.2.7",
 		"ai": "^6.0.150",
+		"react": "19.2.3",
 		"typescript": "6.0.2"
 	}
 }

--- a/packages/thread/src/react.ts
+++ b/packages/thread/src/react.ts
@@ -1,0 +1,8 @@
+"use client";
+
+export {
+	type TreeHelpers,
+	type UseThreadHelpers,
+	type UseThreadOptions,
+	useThread,
+} from "./use-thread";

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -1,0 +1,181 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { ChatRequestOptions, UIMessage } from "ai";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { ThreadChat } from "./thread-chat";
+import type {
+	MessageTreeSnapshot,
+	ThreadChatOptions,
+	ThreadRun,
+	ThreadRunHandle,
+	ThreadStartRunOptions,
+	TreeSendOptions,
+} from "./types";
+
+type ThreadHookOptions = {
+	experimental_throttle?: number;
+	resume?: boolean;
+};
+
+type ExternalThreadOptions<TMessage extends UIMessage> = ThreadHookOptions & {
+	chat: ThreadChat<TMessage>;
+};
+
+export type UseThreadOptions<TMessage extends UIMessage = UIMessage> =
+	| ExternalThreadOptions<TMessage>
+	| (ThreadHookOptions &
+			ThreadChatOptions<TMessage> & {
+				chat?: never;
+			});
+
+function hasSuppliedChat<TMessage extends UIMessage>(
+	options: UseThreadOptions<TMessage>,
+): options is ExternalThreadOptions<TMessage> {
+	return "chat" in options && options.chat !== undefined;
+}
+
+export type TreeHelpers<TMessage extends UIMessage = UIMessage> = {
+	activeRuns: ThreadRun[];
+	childrenByParentId: Record<string, string[]>;
+	cursorId: string | null;
+	getChildren: (messageId: string | null) => TMessage[];
+	getLeaves: (messageId?: string | null) => TMessage[];
+	getMessage: (messageId: string) => TMessage | undefined;
+	getParent: (messageId: string) => TMessage | undefined;
+	getPath: (messageId?: string | null) => TMessage[];
+	getRun: (runId: string) => ThreadRun | undefined;
+	getRunForMessage: (messageId: string) => ThreadRun | undefined;
+	getSiblings: (messageId: string) => TMessage[];
+	getSnapshot: () => MessageTreeSnapshot<TMessage>;
+	messagesById: Record<string, TMessage>;
+	parentById: Record<string, string | null>;
+	resumeRun: (runId: string, options?: ChatRequestOptions) => Promise<void>;
+	rootIds: string[];
+	runs: ThreadRun[];
+	setCursor: (messageId: string | null) => void;
+	setCursorToParentOf: (messageId: string) => void;
+	startRun: (
+		options?: ThreadStartRunOptions<TMessage>,
+	) => Promise<ThreadRunHandle>;
+	status: ReturnType<ThreadChat<TMessage>["getSnapshot"]>["treeStatus"];
+	stopAll: () => Promise<void>;
+	stopRun: (runId: string) => Promise<void>;
+	stopRunForMessage: (messageId: string) => Promise<void>;
+};
+
+export type UseThreadHelpers<TMessage extends UIMessage = UIMessage> =
+	UseChatHelpers<TMessage> & {
+		sendMessage: (
+			message?: Parameters<UseChatHelpers<TMessage>["sendMessage"]>[0],
+			options?: TreeSendOptions,
+		) => Promise<void>;
+		tree: TreeHelpers<TMessage>;
+	};
+
+function useThreadChatSnapshot<TMessage extends UIMessage>(
+	chat: ThreadChat<TMessage>,
+	throttleWaitMs?: number,
+) {
+	const subscribe = useCallback(
+		(listener: () => void) => {
+			if (!throttleWaitMs) return chat.subscribe(listener);
+
+			let lastCall = 0;
+			let timeout: ReturnType<typeof setTimeout> | undefined;
+			const notify = () => {
+				const elapsed = Date.now() - lastCall;
+				if (elapsed >= throttleWaitMs) {
+					lastCall = Date.now();
+					listener();
+					return;
+				}
+				if (timeout) return;
+				timeout = setTimeout(() => {
+					timeout = undefined;
+					lastCall = Date.now();
+					listener();
+				}, throttleWaitMs - elapsed);
+			};
+
+			const unsubscribe = chat.subscribe(notify);
+			return () => {
+				unsubscribe();
+				if (timeout) clearTimeout(timeout);
+			};
+		},
+		[chat, throttleWaitMs],
+	);
+
+	return useSyncExternalStore(subscribe, chat.getSnapshot, chat.getSnapshot);
+}
+
+export function useThread<TMessage extends UIMessage = UIMessage>(
+	options: UseThreadOptions<TMessage> = {},
+): UseThreadHelpers<TMessage> {
+	const chatRef = useRef<ThreadChat<TMessage> | null>(null);
+	const suppliedChat = hasSuppliedChat(options) ? options.chat : undefined;
+	const chatOptions = hasSuppliedChat(options) ? undefined : options;
+	if (suppliedChat) {
+		chatRef.current = suppliedChat;
+	} else if (
+		!chatRef.current ||
+		(chatOptions?.id !== undefined && chatRef.current.id !== chatOptions.id)
+	) {
+		chatRef.current = new ThreadChat(chatOptions);
+	}
+
+	const chat = chatRef.current;
+	if (chatOptions) chat.updateOptions(chatOptions);
+	const snapshot = useThreadChatSnapshot(chat, options.experimental_throttle);
+
+	useEffect(() => {
+		if (options.resume) chat.resumeStream();
+	}, [options.resume, chat]);
+
+	const setMessages = useCallback<UseChatHelpers<TMessage>["setMessages"]>(
+		(messages) => chat.setMessages(messages),
+		[chat],
+	);
+
+	return {
+		addToolApprovalResponse: chat.addToolApprovalResponse,
+		addToolOutput: chat.addToolOutput,
+		addToolResult: chat.addToolResult,
+		clearError: chat.clearError,
+		error: snapshot.error,
+		id: chat.id,
+		messages: snapshot.messages,
+		regenerate: chat.regenerate,
+		resumeStream: chat.resumeStream,
+		sendMessage: chat.sendMessage,
+		setMessages,
+		status: snapshot.status,
+		stop: chat.stop,
+		tree: {
+			activeRuns: snapshot.activeRuns,
+			childrenByParentId: snapshot.childrenByParentId,
+			cursorId: snapshot.cursorId,
+			getChildren: (messageId) => chat.getChildren(messageId),
+			getLeaves: (messageId) => chat.getLeaves(messageId),
+			getMessage: (messageId) => chat.getMessage(messageId),
+			getParent: (messageId) => chat.getParent(messageId),
+			getPath: (messageId) => chat.getPath(messageId),
+			getRun: (runId) => chat.getRun(runId),
+			getRunForMessage: (messageId) => chat.getRunForMessage(messageId),
+			getSiblings: (messageId) => chat.getSiblings(messageId),
+			getSnapshot: () => chat.getTreeSnapshot(),
+			messagesById: snapshot.messagesById,
+			parentById: snapshot.parentById,
+			resumeRun: (runId, requestOptions) =>
+				chat.resumeRun(runId, requestOptions),
+			rootIds: snapshot.rootIds,
+			runs: snapshot.runs,
+			setCursor: (messageId) => chat.setCursor(messageId),
+			setCursorToParentOf: (messageId) => chat.setCursorToParentOf(messageId),
+			startRun: (runOptions) => chat.startRun(runOptions),
+			status: snapshot.treeStatus,
+			stopAll: () => chat.stopAll(),
+			stopRun: (runId) => chat.stopRun(runId),
+			stopRunForMessage: (messageId) => chat.stopRunForMessage(messageId),
+		},
+	};
+}

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -8,6 +8,7 @@ import type {
 	ThreadRun,
 	ThreadRunHandle,
 	ThreadStartRunOptions,
+	ThreadStateSnapshot,
 	TreeSendOptions,
 } from "./types";
 
@@ -80,9 +81,25 @@ function useThreadChatSnapshot<TMessage extends UIMessage>(
 	chat: ThreadChat<TMessage>,
 	throttleWaitMs?: number,
 ) {
+	const stateRef = useRef({
+		chat,
+		snapshot: chat.getSnapshot(),
+	});
+	if (stateRef.current.chat !== chat) {
+		stateRef.current = {
+			chat,
+			snapshot: chat.getSnapshot(),
+		};
+	}
+
 	const subscribe = useCallback(
 		(listener: () => void) => {
-			if (!throttleWaitMs) return chat.subscribe(listener);
+			stateRef.current.snapshot = chat.getSnapshot();
+			const publish = () => {
+				stateRef.current.snapshot = chat.getSnapshot();
+				listener();
+			};
+			if (!throttleWaitMs) return chat.subscribe(publish);
 
 			let lastCall = 0;
 			let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -90,14 +107,14 @@ function useThreadChatSnapshot<TMessage extends UIMessage>(
 				const elapsed = Date.now() - lastCall;
 				if (elapsed >= throttleWaitMs) {
 					lastCall = Date.now();
-					listener();
+					publish();
 					return;
 				}
 				if (timeout) return;
 				timeout = setTimeout(() => {
 					timeout = undefined;
 					lastCall = Date.now();
-					listener();
+					publish();
 				}, throttleWaitMs - elapsed);
 			};
 
@@ -109,8 +126,21 @@ function useThreadChatSnapshot<TMessage extends UIMessage>(
 		},
 		[chat, throttleWaitMs],
 	);
+	const getSnapshot = useCallback(() => stateRef.current.snapshot, []);
 
-	return useSyncExternalStore(subscribe, chat.getSnapshot, chat.getSnapshot);
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function useThreadChatField<
+	TMessage extends UIMessage,
+	TKey extends keyof ThreadStateSnapshot<TMessage>,
+>(chat: ThreadChat<TMessage>, key: TKey) {
+	const subscribe = useCallback(
+		(listener: () => void) => chat.subscribe(listener),
+		[chat],
+	);
+	const getSnapshot = useCallback(() => chat.getSnapshot()[key], [chat, key]);
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useThread<TMessage extends UIMessage = UIMessage>(
@@ -163,6 +193,9 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 	}
 
 	const snapshot = useThreadChatSnapshot(chat, options.experimental_throttle);
+	const status = useThreadChatField(chat, "status");
+	const error = useThreadChatField(chat, "error");
+	const treeStatus = useThreadChatField(chat, "treeStatus");
 
 	useEffect(() => {
 		if (options.resume) chatRef.current?.resumeStream();
@@ -178,14 +211,14 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 		addToolOutput: chat.addToolOutput,
 		addToolResult: chat.addToolResult,
 		clearError: chat.clearError,
-		error: snapshot.error,
+		error,
 		id: chat.id,
 		messages: snapshot.messages,
 		regenerate: chat.regenerate,
 		resumeStream: chat.resumeStream,
 		sendMessage: chat.sendMessage,
 		setMessages,
-		status: snapshot.status,
+		status,
 		stop: chat.stop,
 		tree: {
 			activeRuns: snapshot.activeRuns,
@@ -209,7 +242,7 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 			setCursor: (messageId) => chat.setCursor(messageId),
 			setCursorToParentOf: (messageId) => chat.setCursorToParentOf(messageId),
 			startRun: (runOptions) => chat.startRun(runOptions),
-			status: snapshot.treeStatus,
+			status: treeStatus,
 			stopAll: () => chat.stopAll(),
 			stopRun: (runId) => chat.stopRun(runId),
 			stopRunForMessage: (messageId) => chat.stopRunForMessage(messageId),

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -16,6 +16,11 @@ type ThreadHookOptions = {
 	resume?: boolean;
 };
 
+type ThreadCallbacks<TMessage extends UIMessage> = Pick<
+	ThreadChatOptions<TMessage>,
+	"onData" | "onError" | "onFinish" | "onToolCall" | "sendAutomaticallyWhen"
+>;
+
 type ExternalThreadOptions<TMessage extends UIMessage> = ThreadHookOptions & {
 	chat: ThreadChat<TMessage>;
 };
@@ -111,29 +116,61 @@ function useThreadChatSnapshot<TMessage extends UIMessage>(
 export function useThread<TMessage extends UIMessage = UIMessage>(
 	options: UseThreadOptions<TMessage> = {},
 ): UseThreadHelpers<TMessage> {
-	const chatRef = useRef<ThreadChat<TMessage> | null>(null);
-	const suppliedChat = hasSuppliedChat(options) ? options.chat : undefined;
-	const chatOptions = hasSuppliedChat(options) ? undefined : options;
-	if (suppliedChat) {
-		chatRef.current = suppliedChat;
-	} else if (
-		!chatRef.current ||
-		(chatOptions?.id !== undefined && chatRef.current.id !== chatOptions.id)
-	) {
-		chatRef.current = new ThreadChat(chatOptions);
+	const hasExternalChat = hasSuppliedChat(options);
+	const callbacksRef = useRef<ThreadCallbacks<TMessage>>(
+		hasExternalChat
+			? {}
+			: {
+					onData: options.onData,
+					onError: options.onError,
+					onFinish: options.onFinish,
+					onToolCall: options.onToolCall,
+					sendAutomaticallyWhen: options.sendAutomaticallyWhen,
+				},
+	);
+
+	if (!hasExternalChat) {
+		callbacksRef.current = {
+			onData: options.onData,
+			onError: options.onError,
+			onFinish: options.onFinish,
+			onToolCall: options.onToolCall,
+			sendAutomaticallyWhen: options.sendAutomaticallyWhen,
+		};
 	}
 
-	const chat = chatRef.current;
-	if (chatOptions) chat.updateOptions(chatOptions);
+	const chatOptions: ThreadChatOptions<TMessage> | undefined = hasExternalChat
+		? undefined
+		: {
+				...options,
+				onData: (dataPart) => callbacksRef.current.onData?.(dataPart),
+				onError: (error) => callbacksRef.current.onError?.(error),
+				onFinish: (event) => callbacksRef.current.onFinish?.(event),
+				onToolCall: (event) => callbacksRef.current.onToolCall?.(event),
+				sendAutomaticallyWhen: (event) =>
+					callbacksRef.current.sendAutomaticallyWhen?.(event) ?? false,
+			};
+
+	const chatRef = useRef<ThreadChat<TMessage> | null>(null);
+	let chat = chatRef.current;
+	if (
+		chat === null ||
+		(hasExternalChat && options.chat !== chat) ||
+		(!hasExternalChat && options.id !== undefined && chat.id !== options.id)
+	) {
+		chat = hasExternalChat ? options.chat : new ThreadChat(chatOptions);
+		chatRef.current = chat;
+	}
+
 	const snapshot = useThreadChatSnapshot(chat, options.experimental_throttle);
 
 	useEffect(() => {
-		if (options.resume) chat.resumeStream();
-	}, [options.resume, chat]);
+		if (options.resume) chatRef.current?.resumeStream();
+	}, [options.resume]);
 
 	const setMessages = useCallback<UseChatHelpers<TMessage>["setMessages"]>(
-		(messages) => chat.setMessages(messages),
-		[chat],
+		(messages) => chatRef.current?.setMessages(messages),
+		[],
 	);
 
 	return {

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -69,9 +69,16 @@ test("the packed package loads its core and React entry points", async () => {
 			join(installedPackage, "dist/react.js"),
 			"utf8",
 		);
+		const packageMetadata = await Bun.file(
+			join(installedPackage, "package.json"),
+		).json();
 		const indexChunk = indexSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
 		const reactChunk = reactSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
 
+		expect(packageMetadata.peerDependenciesMeta).toEqual({
+			"@ai-sdk/react": { optional: true },
+			react: { optional: true },
+		});
 		expect(reactSource.startsWith('"use client";')).toBeTrue();
 		expect(indexChunk).toBeDefined();
 		expect(reactChunk).toBe(indexChunk);
@@ -90,10 +97,14 @@ if (typeof chat.id !== "string" || typeof useThread !== "function") {
   throw new Error("Package exports did not load");
 }
 `;
-		const consumerPath = join(temporaryDirectory, "consumer.ts");
-		await writeFile(consumerPath, consumerSource);
+		const runtimeConsumerPath = join(temporaryDirectory, "consumer.mjs");
+		const typeConsumerPath = join(temporaryDirectory, "consumer.ts");
+		await Promise.all([
+			writeFile(runtimeConsumerPath, consumerSource),
+			writeFile(typeConsumerPath, consumerSource),
+		]);
 
-		run(["bun", consumerPath], temporaryDirectory);
+		run(["node", runtimeConsumerPath], temporaryDirectory);
 		run(
 			[
 				join(packageDirectory, "node_modules/.bin/tsc"),
@@ -107,7 +118,7 @@ if (typeof chat.id !== "string" || typeof useThread !== "function") {
 				"ESNext",
 				"--moduleResolution",
 				"Bundler",
-				consumerPath,
+				typeConsumerPath,
 			],
 			temporaryDirectory,
 		);

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -8,8 +8,10 @@ function run(command: string[], cwd: string) {
 	const result = Bun.spawnSync({
 		cmd: command,
 		cwd,
+		killSignal: "SIGKILL",
 		stderr: "pipe",
 		stdout: "pipe",
+		timeout: 25_000,
 	});
 	if (result.exitCode !== 0) {
 		throw new Error(

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const packageDirectory = resolve(import.meta.dir, "..");
+
+function run(command: string[], cwd: string) {
+	const result = Bun.spawnSync({
+		cmd: command,
+		cwd,
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	if (result.exitCode !== 0) {
+		throw new Error(
+			[
+				`Command failed: ${command.join(" ")}`,
+				result.stdout.toString(),
+				result.stderr.toString(),
+			].join("\n"),
+		);
+	}
+}
+
+test("the packed package loads its core and React entry points", async () => {
+	const temporaryDirectory = await mkdtemp(
+		join(packageDirectory, ".package-smoke-"),
+	);
+
+	try {
+		run(["bun", "run", "build"], packageDirectory);
+		run(
+			[
+				"bun",
+				"pm",
+				"pack",
+				"--filename",
+				join(temporaryDirectory, "thread.tgz"),
+				"--ignore-scripts",
+				"--quiet",
+			],
+			packageDirectory,
+		);
+
+		const installedPackage = join(
+			temporaryDirectory,
+			"node_modules",
+			"@chatjs",
+			"thread",
+		);
+		await mkdir(installedPackage, { recursive: true });
+		run(
+			[
+				"tar",
+				"-xzf",
+				join(temporaryDirectory, "thread.tgz"),
+				"-C",
+				installedPackage,
+				"--strip-components=1",
+			],
+			packageDirectory,
+		);
+
+		const indexSource = await readFile(
+			join(installedPackage, "dist/index.js"),
+			"utf8",
+		);
+		const reactSource = await readFile(
+			join(installedPackage, "dist/react.js"),
+			"utf8",
+		);
+		const indexChunk = indexSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
+		const reactChunk = reactSource.match(/from "(\.\/chunk-[^"]+\.js)"/)?.[1];
+
+		expect(reactSource.startsWith('"use client";')).toBeTrue();
+		expect(indexChunk).toBeDefined();
+		expect(reactChunk).toBe(indexChunk);
+		expect(reactSource).not.toContain("class ThreadChat");
+		if (!reactChunk) throw new Error("Expected a shared package chunk");
+		expect(
+			await Bun.file(resolve(installedPackage, "dist", reactChunk)).exists(),
+		).toBeTrue();
+
+		const consumerSource = `
+import { ThreadChat } from "@chatjs/thread";
+import { useThread } from "@chatjs/thread/react";
+
+const chat = new ThreadChat();
+if (typeof chat.id !== "string" || typeof useThread !== "function") {
+  throw new Error("Package exports did not load");
+}
+`;
+		const consumerPath = join(temporaryDirectory, "consumer.ts");
+		await writeFile(consumerPath, consumerSource);
+
+		run(["bun", consumerPath], temporaryDirectory);
+		run(
+			[
+				join(packageDirectory, "node_modules/.bin/tsc"),
+				"--ignoreConfig",
+				"--noEmit",
+				"--strict",
+				"--skipLibCheck",
+				"--target",
+				"ES2022",
+				"--module",
+				"ESNext",
+				"--moduleResolution",
+				"Bundler",
+				consumerPath,
+			],
+			temporaryDirectory,
+		);
+	} finally {
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	}
+}, 30_000);

--- a/packages/thread/test/use-thread-types.ts
+++ b/packages/thread/test/use-thread-types.ts
@@ -1,0 +1,39 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { type UseThreadHelpers, useThread } from "../src/react";
+import { ThreadChat } from "../src/thread-chat";
+
+declare const messageId: string;
+
+function useCompatibilityCheck() {
+	const thread = useThread();
+	const chatCompatible: UseChatHelpers<UIMessage> = thread;
+
+	chatCompatible.messages;
+	chatCompatible.sendMessage({ text: "hello" });
+	chatCompatible.setMessages((messages) => messages);
+
+	thread.tree.setCursor(messageId);
+	thread.tree.setCursor(null);
+	thread.tree.getPath(messageId);
+	thread.tree.getChildren(null);
+	thread.tree.getSiblings(messageId);
+	thread.tree.stopAll();
+	thread.tree.activeRuns;
+	thread.tree.runs;
+	thread.tree.status;
+	thread.tree.getRunForMessage(messageId);
+	thread.tree.getSnapshot();
+	thread.tree.startRun({ from: messageId, message: { text: "branch" } });
+
+	const explicitHelpers: UseThreadHelpers<UIMessage> = thread;
+	return explicitHelpers;
+}
+
+function useExternalChatCheck() {
+	const chat = new ThreadChat<UIMessage>();
+	return useThread({ chat });
+}
+
+void useCompatibilityCheck;
+void useExternalChatCheck;

--- a/packages/thread/test/use-thread.test.ts
+++ b/packages/thread/test/use-thread.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { getMessageText } from "../src/message-utils";
+import { ThreadChat } from "../src/thread-chat";
+import {
+	type UseThreadHelpers,
+	type UseThreadOptions,
+	useThread,
+} from "../src/use-thread";
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+class RejectingTransport implements ChatTransport<UIMessage> {
+	requests = 0;
+
+	sendMessages: ChatTransport<UIMessage>["sendMessages"] = () => {
+		this.requests += 1;
+		return Promise.reject(new Error("transport failed"));
+	};
+
+	reconnectToStream() {
+		return Promise.resolve(null);
+	}
+}
+
+class ControlledTransport implements ChatTransport<UIMessage> {
+	readonly requests: Array<ReadableStreamDefaultController<UIMessageChunk>> =
+		[];
+
+	sendMessages: ChatTransport<UIMessage>["sendMessages"] = () =>
+		Promise.resolve(
+			new ReadableStream({
+				start: (controller) => {
+					this.requests.push(controller);
+				},
+			}),
+		);
+
+	reconnectToStream() {
+		return Promise.resolve(null);
+	}
+
+	emit(requestIndex: number, chunk: UIMessageChunk) {
+		this.requests[requestIndex]?.enqueue(chunk);
+	}
+
+	finish(requestIndex: number) {
+		this.requests[requestIndex]?.close();
+	}
+}
+
+class ResumeTransport implements ChatTransport<UIMessage> {
+	reconnects = 0;
+
+	sendMessages() {
+		throw new Error("Unexpected send");
+	}
+
+	reconnectToStream() {
+		this.reconnects += 1;
+		return Promise.resolve(null);
+	}
+}
+
+function user(id: string): UIMessage {
+	return { id, parts: [{ text: id, type: "text" }], role: "user" };
+}
+
+function assistant(id: string): UIMessage {
+	return { id, parts: [], role: "assistant" };
+}
+
+function HookHarness({
+	onRender,
+	options,
+}: {
+	onRender: (helpers: UseThreadHelpers) => void;
+	options: UseThreadOptions;
+}) {
+	onRender(useThread(options));
+	return null;
+}
+
+function renderUseThread(initialOptions: UseThreadOptions) {
+	let current: UseThreadHelpers | undefined;
+	let renderer: ReactTestRenderer | undefined;
+	const render = (options: UseThreadOptions) =>
+		createElement(HookHarness, {
+			onRender: (helpers) => {
+				current = helpers;
+			},
+			options,
+		});
+
+	act(() => {
+		renderer = create(render(initialOptions));
+	});
+
+	return {
+		get current() {
+			if (!current) throw new Error("Expected useThread to render");
+			return current;
+		},
+		unmount() {
+			act(() => renderer?.unmount());
+		},
+		update(options: UseThreadOptions) {
+			act(() => renderer?.update(render(options)));
+		},
+	};
+}
+
+async function waitFor(predicate: () => boolean) {
+	for (let attempt = 0; attempt < 500; attempt += 1) {
+		if (predicate()) return;
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for condition");
+}
+
+describe("useThread", () => {
+	test("uses current callbacks without replacing the chat transport", async () => {
+		const firstTransport = new RejectingTransport();
+		const secondTransport = new RejectingTransport();
+		const firstError = mock(() => {});
+		const secondError = mock(() => {});
+		const hook = renderUseThread({
+			id: "thread-1",
+			onError: firstError,
+			transport: firstTransport,
+		});
+
+		hook.update({
+			id: "thread-1",
+			onError: secondError,
+			transport: secondTransport,
+		});
+		await act(async () => {
+			await hook.current.sendMessage({ text: "first request" });
+		});
+
+		expect(firstTransport.requests).toBe(1);
+		expect(secondTransport.requests).toBe(0);
+		expect(firstError).not.toHaveBeenCalled();
+		expect(secondError).toHaveBeenCalledTimes(1);
+
+		hook.update({
+			id: "thread-2",
+			onError: secondError,
+			transport: secondTransport,
+		});
+		await act(async () => {
+			await hook.current.sendMessage({ text: "second request" });
+		});
+
+		expect(hook.current.id).toBe("thread-2");
+		expect(secondTransport.requests).toBe(1);
+		hook.unmount();
+	});
+
+	test("resubscribes when the supplied chat changes", () => {
+		const first = new ThreadChat({ messages: [user("user-a")] });
+		const second = new ThreadChat({ messages: [user("user-b")] });
+		const hook = renderUseThread({ chat: first });
+
+		expect(hook.current.messages.map(({ id }) => id)).toEqual(["user-a"]);
+		hook.update({ chat: second });
+		expect(hook.current.messages.map(({ id }) => id)).toEqual(["user-b"]);
+		hook.unmount();
+	});
+
+	test("automatically resumes the supplied chat", async () => {
+		const transport = new ResumeTransport();
+		const chat = new ThreadChat({
+			messages: [user("user-1"), assistant("assistant-1")],
+			transport,
+		});
+		const hook = renderUseThread({ chat, resume: true });
+
+		await act(async () => {
+			await Bun.sleep(0);
+		});
+
+		expect(transport.reconnects).toBe(1);
+		hook.unmount();
+	});
+
+	test("keeps status immediate while throttling message snapshots", async () => {
+		const transport = new ControlledTransport();
+		const hook = renderUseThread({
+			experimental_throttle: 100,
+			messages: [user("user-1")],
+			transport,
+		});
+
+		act(() => hook.current.tree.setCursor("user-1"));
+
+		let run:
+			| Awaited<ReturnType<UseThreadHelpers["tree"]["startRun"]>>
+			| undefined;
+		await act(async () => {
+			run = await hook.current.tree.startRun({ from: "user-1" });
+			await waitFor(() => transport.requests.length === 1);
+		});
+		expect(hook.current.status).toBe("submitted");
+		expect(hook.current.tree.status).toBe("submitted");
+
+		await act(async () => {
+			transport.emit(0, { messageId: "assistant-1", type: "start" });
+			transport.emit(0, { id: "text", type: "text-start" });
+			transport.emit(0, {
+				delta: "streaming",
+				id: "text",
+				type: "text-delta",
+			});
+			await Bun.sleep(0);
+		});
+		expect(hook.current.status).toBe("streaming");
+		expect(hook.current.tree.status).toBe("streaming");
+		expect(hook.current.messages.map(({ id }) => id)).toEqual(["user-1"]);
+
+		await act(async () => {
+			await Bun.sleep(110);
+		});
+		expect(
+			getMessageText(
+				hook.current.messages.find(({ id }) => id === "assistant-1") ??
+					assistant("missing"),
+			),
+		).toBe("streaming");
+
+		await act(async () => {
+			transport.finish(0);
+			await run?.finished;
+		});
+		expect(hook.current.status).toBe("ready");
+		hook.unmount();
+	});
+});


### PR DESCRIPTION
## Summary
- Adds the React `useThread` facade over `ThreadChat`.
- Returns normal `UseChatHelpers` for the active path plus additive `tree` helpers.
- Supports supplied imperative instances and hook-owned instances.

## Behavior
Existing `useChat` call sites can migrate while continuing to read `messages`, `status`, `sendMessage`, and `stop`.

## Verification
- Type tests prove `UseThreadHelpers` is assignable to `UseChatHelpers`.
- `bun test:types` passes at the stack tip.

## Review focus
Compatibility of the normal chat surface and naming of the additive tree API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a React `useThread` hook compatible with `useChat`, plus a client-ready `@chatjs/thread/react` entry. Hardens the package with a shared browser ESM chunk, a `"use client"` preamble, and optional `react`/`@ai-sdk/react` peers.

- **New Features**
  - Uses a supplied `ThreadChat` or creates one; recreates on `id`/external `chat` change; callbacks hot-swap; `resume` reconnects streams; optional `experimental_throttle` for snapshots.
  - Mirrors `@ai-sdk/react` `useChat`; returns `UseChatHelpers` plus `tree` helpers (cursor, path/children/siblings/leaves, getters, snapshot/status, run controls `startRun`/`resumeRun`/`stop*`, maps). `sendMessage` accepts `TreeSendOptions`.
  - Ships `./react` entry with shared ESM chunk across core/React builds and `"use client"` at the top.

- **Bug Fixes**
  - Strengthened package boundary and smoke tests to verify shared chunks and optional peers; bounded smoke test commands to avoid hangs.

<sup>Written for commit 31ba11832fd87de4ead25eea3e36c0f4e1a55a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a React `useThread` hook with streaming status, lifecycle callbacks, and thread tree navigation helpers.
  * Introduced a client-ready React entry point for `@chatjs/thread`, including React-specific exports.
* **Bug Fixes**
  * Improved resume/reconnect behavior and kept hook subscriptions consistent when the provided chat instance changes.
  * Refined streaming state updates during throttled message snapshotting.
* **Tests**
  * Added Bun smoke tests validating package exports, the React `"use client"` directive, and bundled output integrity.
  * Added runtime and TypeScript type-surface tests for `useThread`.
* **Chores**
  * Updated the package build/publish flow and export map, including React peer dependency metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. #235
5. #236
6. #237
7. #238
8. **#239** 👈 current
9. #240
10. #241
11. #242
12. #243
13. #244
14. #245
15. #246
16. #247
17. #248
18. #249
19. #250
20. #251
21. #252
22. #253
23. #254
<!-- stack:links:end -->