### PR TITLE
Threads 10: Store ordered thread snapshots in ChatJS

### DIFF
--- a/apps/chat/lib/stores/with-threads.test.ts
+++ b/apps/chat/lib/stores/with-threads.test.ts
@@ -13,6 +13,7 @@ function createMessage({
   parallelGroupId = null,
   parallelIndex = null,
   activeStreamId = null,
+  text = "",
 }: {
   id: string;
   role: ChatMessage["role"];
@@ -21,11 +22,12 @@ function createMessage({
   parallelGroupId?: string | null;
   parallelIndex?: number | null;
   activeStreamId?: string | null;
+  text?: string;
 }): ChatMessage {
   return {
     id,
     role,
-    parts: [],
+    parts: text ? [{ type: "text", text }] : [],
     metadata: {
       createdAt: new Date(createdAt),
       parentMessageId,
@@ -44,14 +46,82 @@ function createThreadStore(initialMessages: ChatMessage[]) {
     withThreads<ChatMessage, BaseChatStoreState<ChatMessage>>(
       (set) =>
         ({
+          _messageIndex: { update: () => undefined },
+          _memoizedSelectors: new Map(),
+          _throttledMessages: initialMessages,
           messages: initialMessages,
           setMessages: (messages: ChatMessage[]) => set({ messages }),
-        }) as BaseChatStoreState<ChatMessage>
+        }) as unknown as BaseChatStoreState<ChatMessage>
     )
   );
 }
 
 describe("withThreads", () => {
+  it("preserves hidden branches when ThreadChat publishes an active-path snapshot", () => {
+    const userA = createMessage({
+      id: "user-a",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistantA = createMessage({
+      id: "assistant-a",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: userA.id,
+    });
+    const userB = createMessage({
+      id: "user-b",
+      role: "user",
+      createdAt: "2024-01-01T00:00:02.000Z",
+    });
+    const assistantB = createMessage({
+      id: "assistant-b",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:03.000Z",
+      parentMessageId: userB.id,
+    });
+    const store = createThreadStore([userB, assistantB]);
+
+    store.getState().setAllMessages([userA, assistantA, userB, assistantB]);
+    store.getState().setTreeSnapshot({
+      childrenByParentId: {
+        __root__: [userB.id],
+        [userB.id]: [assistantB.id],
+      },
+      cursorId: assistantB.id,
+      messagesById: {
+        [userB.id]: userB,
+        [assistantB.id]: assistantB,
+      },
+      parentById: {
+        [userB.id]: null,
+        [assistantB.id]: userB.id,
+      },
+      rootIds: [userB.id],
+      version: 1,
+    });
+
+    const siblingInfo = store.getState().getMessageSiblingInfo(userB.id);
+    assert.deepEqual(
+      siblingInfo?.siblings.map((message) => message.id),
+      [userA.id, userB.id]
+    );
+    const previousThread = store.getState().switchToSibling(userB.id, "prev");
+    const previousThreadIds = [userA.id, assistantA.id];
+    assert.deepEqual(
+      previousThread?.map((message) => message.id),
+      previousThreadIds
+    );
+    assert.deepEqual(
+      store.getState().messages.map((message) => message.id),
+      previousThreadIds
+    );
+    assert.deepEqual(
+      store.getState()._throttledMessages?.map((message) => message.id),
+      previousThreadIds
+    );
+  });
+
   it("preserves local-only optimistic branch nodes across server syncs", () => {
     const rootUser = createMessage({
       id: "user-root",
@@ -118,9 +188,9 @@ describe("withThreads", () => {
     assert.deepEqual(allMessageIds, [
       "user-root",
       "assistant-a",
-      "assistant-b",
       "user-nested",
       "assistant-nested-a",
+      "assistant-b",
       "assistant-nested-b",
     ]);
 
@@ -133,5 +203,183 @@ describe("withThreads", () => {
       restoredThread?.at(-1)?.metadata.activeStreamId,
       "pending:assistant-nested-b"
     );
+  });
+
+  it("preserves a pending stream marker when a run inserts its assistant shell", () => {
+    const rootUser = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistant = createMessage({
+      id: "assistant-a",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: rootUser.id,
+      activeStreamId: "pending:assistant-a",
+    });
+    const assistantWithoutMetadata = {
+      id: assistant.id,
+      parts: [],
+      role: "assistant",
+    } as unknown as ChatMessage;
+
+    const store = createThreadStore([rootUser, assistant]);
+    store.getState().addMessageToTree(assistantWithoutMetadata);
+
+    const updatedAssistant = store.getState().allMessages.at(-1);
+    assert.equal(
+      updatedAssistant?.metadata.activeStreamId,
+      "pending:assistant-a"
+    );
+    assert.equal(
+      updatedAssistant?.metadata.selectedModel,
+      assistant.metadata.selectedModel
+    );
+  });
+
+  it("replaces a selected placeholder with completed server content when ready", () => {
+    const rootUser = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const placeholder = createMessage({
+      id: "assistant-b",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: rootUser.id,
+      parallelGroupId: "group-root",
+      parallelIndex: 1,
+      activeStreamId: "pending:assistant-b",
+    });
+    const completed = createMessage({
+      id: placeholder.id,
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: rootUser.id,
+      parallelGroupId: "group-root",
+      parallelIndex: 1,
+      text: "Completed secondary response",
+    });
+    const store = createThreadStore([rootUser, placeholder]);
+
+    store.getState().setAllMessages([rootUser, completed]);
+
+    const completedPart = store.getState().messages.at(-1)?.parts.at(0);
+    assert.equal(completedPart?.type, "text");
+    assert.equal(
+      completedPart?.type === "text" ? completedPart.text : null,
+      "Completed secondary response"
+    );
+    assert.equal(
+      store.getState().messages.at(-1)?.metadata.activeStreamId,
+      null
+    );
+    const throttledPart = store
+      .getState()
+      ._throttledMessages?.at(-1)
+      ?.parts.at(0);
+    assert.equal(
+      throttledPart?.type === "text" ? throttledPart.text : null,
+      "Completed secondary response"
+    );
+  });
+
+  it("fills metadata for ThreadChat assistant shells in tree snapshots", () => {
+    const rootUser = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistantWithoutMetadata = {
+      id: "assistant-a",
+      parts: [],
+      role: "assistant",
+    } as unknown as ChatMessage;
+
+    const store = createThreadStore([rootUser]);
+
+    store.getState().setTreeSnapshot({
+      childrenByParentId: {
+        __root__: [rootUser.id],
+        [rootUser.id]: [assistantWithoutMetadata.id],
+      },
+      cursorId: assistantWithoutMetadata.id,
+      messagesById: {
+        [rootUser.id]: rootUser,
+        [assistantWithoutMetadata.id]: assistantWithoutMetadata,
+      },
+      parentById: {
+        [rootUser.id]: null,
+        [assistantWithoutMetadata.id]: rootUser.id,
+      },
+      rootIds: [rootUser.id],
+      version: 1,
+    });
+
+    const assistant = store.getState().messages.at(-1);
+    assert.equal(assistant?.metadata.parentMessageId, rootUser.id);
+    assert.equal(
+      assistant?.metadata.selectedModel,
+      rootUser.metadata.selectedModel
+    );
+  });
+
+  it("adds exactly one user sibling when editing after branch navigation", () => {
+    const userA = createMessage({
+      id: "user-a",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistantA = createMessage({
+      id: "assistant-a",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: userA.id,
+    });
+    const userB = createMessage({
+      id: "user-b",
+      role: "user",
+      createdAt: "2024-01-01T00:00:02.000Z",
+    });
+    const assistantB = createMessage({
+      id: "assistant-b",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:03.000Z",
+      parentMessageId: userB.id,
+    });
+    const userC = createMessage({
+      id: "user-c",
+      role: "user",
+      createdAt: "2024-01-01T00:00:04.000Z",
+    });
+    const assistantC = createMessage({
+      id: "assistant-c",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:05.000Z",
+      parentMessageId: userC.id,
+    });
+
+    const store = createThreadStore([userA, assistantA]);
+    store.getState().addMessageToTree(userB);
+    store.getState().addMessageToTree(assistantB);
+
+    assert.equal(
+      store.getState().getMessageSiblingInfo(userB.id)?.siblings.length,
+      2
+    );
+
+    store.getState().switchToSibling(userB.id, "prev");
+    store.getState().setMessages([]);
+    store.getState().addMessageToTree(userC);
+    store.getState().addMessageToTree(assistantC);
+
+    const rootSiblingIds = store
+      .getState()
+      .getMessageSiblingInfo(userC.id)
+      ?.siblings.map((message: ChatMessage) => message.id);
+
+    assert.deepEqual(rootSiblingIds, [userA.id, userB.id, userC.id]);
   });
 });

--- a/apps/chat/lib/stores/with-threads.test.ts
+++ b/apps/chat/lib/stores/with-threads.test.ts
@@ -57,6 +57,205 @@ function createThreadStore(initialMessages: ChatMessage[]) {
 }
 
 describe("withThreads", () => {
+  it("preserves explicit topology for messages without app metadata", () => {
+    const root = {
+      id: "root",
+      parts: [{ type: "text", text: "Root" }],
+      role: "user",
+    } as ChatMessage;
+    const assistant = {
+      id: "assistant",
+      parts: [{ type: "text", text: "Response" }],
+      role: "assistant",
+    } as ChatMessage;
+    const store = createThreadStore([]);
+
+    store.getState().setTreeSnapshot({
+      cursorId: assistant.id,
+      nodes: [
+        { message: root, parentId: null },
+        { message: assistant, parentId: root.id },
+      ],
+      version: 1,
+    });
+
+    assert.deepEqual(
+      store.getState().messages.map((message) => message.id),
+      [root.id, assistant.id]
+    );
+    assert.deepEqual(
+      store
+        .getState()
+        .treeSnapshot.nodes.map(({ message, parentId }) => [
+          message.id,
+          parentId,
+        ]),
+      [
+        [root.id, null],
+        [assistant.id, root.id],
+      ]
+    );
+  });
+
+  it("treats a null cursor as an empty selected path", () => {
+    const root = createMessage({
+      id: "root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const store = createThreadStore([root]);
+
+    store.getState().setTreeSnapshot({
+      cursorId: null,
+      nodes: [{ message: root, parentId: null }],
+      version: 1,
+    });
+
+    assert.deepEqual(store.getState().messages, []);
+    assert.deepEqual(
+      store.getState().allMessages.map((message) => message.id),
+      [root.id]
+    );
+  });
+
+  it("preserves paths deeper than 100 messages", () => {
+    const messages = Array.from({ length: 125 }, (_, index) =>
+      createMessage({
+        id: `message-${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        createdAt: new Date(index * 1000).toISOString(),
+        parentMessageId: index === 0 ? null : `message-${index - 1}`,
+      })
+    );
+    const store = createThreadStore([]);
+
+    store.getState().setTreeSnapshot({
+      cursorId: messages.at(-1)?.id ?? null,
+      nodes: messages.map((message, index) => ({
+        message,
+        parentId: index === 0 ? null : (messages[index - 1]?.id ?? null),
+      })),
+      version: 1,
+    });
+
+    assert.equal(store.getState().messages.length, messages.length);
+    assert.equal(store.getState().messages.at(0)?.id, messages.at(0)?.id);
+  });
+
+  it("keeps known root parents when metadata points outside the tree", () => {
+    const rootA = createMessage({
+      id: "root-a",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      parentMessageId: "missing-parent",
+    });
+    const rootB = createMessage({
+      id: "root-b",
+      role: "user",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: "missing-parent",
+    });
+    const store = createThreadStore([]);
+
+    store.getState().setTreeSnapshot({
+      cursorId: rootB.id,
+      nodes: [
+        { message: rootA, parentId: null },
+        { message: rootB, parentId: null },
+      ],
+      version: 1,
+    });
+
+    assert.deepEqual(
+      store
+        .getState()
+        .getMessageSiblingInfo(rootB.id)
+        ?.siblings.map((message) => message.id),
+      [rootA.id, rootB.id]
+    );
+  });
+
+  it("hydrates an empty visible path from the server tree", () => {
+    const root = createMessage({
+      id: "root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistant = createMessage({
+      id: "assistant",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: root.id,
+    });
+    const store = createThreadStore([]);
+
+    store.getState().setAllMessages([root, assistant]);
+
+    assert.deepEqual(
+      store.getState().messages.map((message) => message.id),
+      [root.id, assistant.id]
+    );
+    assert.equal(store.getState().treeSnapshot.cursorId, assistant.id);
+  });
+
+  it("inherits deterministic fallback metadata from the parent", () => {
+    const root = createMessage({
+      id: "root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const assistant = {
+      id: "assistant",
+      parts: [],
+      role: "assistant",
+    } as unknown as ChatMessage;
+    const store = createThreadStore([root]);
+
+    store.getState().setTreeSnapshot({
+      cursorId: assistant.id,
+      nodes: [
+        { message: root, parentId: null },
+        { message: assistant, parentId: root.id },
+      ],
+      version: 1,
+    });
+
+    assert.deepEqual(
+      store.getState().messages.at(-1)?.metadata.createdAt,
+      root.metadata.createdAt
+    );
+  });
+
+  it("keeps initial messages stable across server synchronization", () => {
+    const root = createMessage({
+      id: "root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const placeholder = createMessage({
+      id: "assistant",
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: root.id,
+    });
+    const completed = createMessage({
+      id: placeholder.id,
+      role: "assistant",
+      createdAt: "2024-01-01T00:00:01.000Z",
+      parentMessageId: root.id,
+      text: "Completed",
+    });
+    const store = createThreadStore([root, placeholder]);
+
+    store.getState().setAllMessages([root, completed]);
+
+    assert.deepEqual(store.getState().threadInitialMessages, [
+      root,
+      placeholder,
+    ]);
+    assert.equal(store.getState().messages.at(-1)?.parts.at(0)?.type, "text");
+  });
+
   it("describes a parallel group before any assistant message exists", () => {
     const user = createMessage({
       id: "user-root",

--- a/apps/chat/lib/stores/with-threads.test.ts
+++ b/apps/chat/lib/stores/with-threads.test.ts
@@ -57,7 +57,23 @@ function createThreadStore(initialMessages: ChatMessage[]) {
 }
 
 describe("withThreads", () => {
-  it("preserves hidden branches when ThreadChat publishes an active-path snapshot", () => {
+  it("describes a parallel group before any assistant message exists", () => {
+    const user = createMessage({
+      id: "user-root",
+      role: "user",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      parallelGroupId: "group-root",
+    });
+    const store = createThreadStore([user]);
+
+    assert.deepEqual(store.getState().getParallelGroupInfo(user.id), {
+      messages: [],
+      parallelGroupId: "group-root",
+      selectedMessageId: null,
+    });
+  });
+
+  it("preserves hidden branches when Thread publishes an active-path snapshot", () => {
     const userA = createMessage({
       id: "user-a",
       role: "user",
@@ -84,20 +100,11 @@ describe("withThreads", () => {
 
     store.getState().setAllMessages([userA, assistantA, userB, assistantB]);
     store.getState().setTreeSnapshot({
-      childrenByParentId: {
-        __root__: [userB.id],
-        [userB.id]: [assistantB.id],
-      },
       cursorId: assistantB.id,
-      messagesById: {
-        [userB.id]: userB,
-        [assistantB.id]: assistantB,
-      },
-      parentById: {
-        [userB.id]: null,
-        [assistantB.id]: userB.id,
-      },
-      rootIds: [userB.id],
+      nodes: [
+        { message: userB, parentId: null },
+        { message: assistantB, parentId: userB.id },
+      ],
       version: 1,
     });
 
@@ -205,7 +212,7 @@ describe("withThreads", () => {
     );
   });
 
-  it("preserves a pending stream marker when a run inserts its assistant shell", () => {
+  it("preserves existing metadata when a message update omits it", () => {
     const rootUser = createMessage({
       id: "user-root",
       role: "user",
@@ -286,7 +293,7 @@ describe("withThreads", () => {
     );
   });
 
-  it("fills metadata for ThreadChat assistant shells in tree snapshots", () => {
+  it("fills fallback metadata for assistant messages in tree snapshots", () => {
     const rootUser = createMessage({
       id: "user-root",
       role: "user",
@@ -301,20 +308,11 @@ describe("withThreads", () => {
     const store = createThreadStore([rootUser]);
 
     store.getState().setTreeSnapshot({
-      childrenByParentId: {
-        __root__: [rootUser.id],
-        [rootUser.id]: [assistantWithoutMetadata.id],
-      },
       cursorId: assistantWithoutMetadata.id,
-      messagesById: {
-        [rootUser.id]: rootUser,
-        [assistantWithoutMetadata.id]: assistantWithoutMetadata,
-      },
-      parentById: {
-        [rootUser.id]: null,
-        [assistantWithoutMetadata.id]: rootUser.id,
-      },
-      rootIds: [rootUser.id],
+      nodes: [
+        { message: rootUser, parentId: null },
+        { message: assistantWithoutMetadata, parentId: rootUser.id },
+      ],
       version: 1,
     });
 

--- a/apps/chat/lib/stores/with-threads.ts
+++ b/apps/chat/lib/stores/with-threads.ts
@@ -4,15 +4,11 @@
 // and complete message tree management for branching/sibling navigation.
 // The store owns allMessages (the full tree); React Query feeds data into it.
 
+import { type MessageTreeSnapshot, ROOT_PARENT_ID } from "@chatjs/thread";
 import type { UIMessage } from "ai";
 import type { StateCreator } from "zustand";
 import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 import type { MessageNode } from "@/lib/thread-utils";
-import {
-  buildChildrenMap,
-  buildThreadFromLeaf,
-  findLeafDfsToRightFromMessageId,
-} from "@/lib/thread-utils";
 
 export interface MessageSiblingInfo<UM> {
   siblingIndex: number;
@@ -36,11 +32,16 @@ export type ThreadAugmentedState<UM extends UIMessage> =
     threadInitialMessages: UM[];
     /** Complete message tree (all branches). Source of truth for sibling navigation. */
     allMessages: UM[];
+    /** Headless package snapshot for the same message tree. */
+    treeSnapshot: MessageTreeSnapshot<UM>;
+    treeSnapshotSignature: string;
     /** Parent→children mapping, rebuilt when allMessages changes. */
     childrenMap: Map<string | null, UM[]>;
     bumpThreadEpoch: () => void;
     resetThreadEpoch: () => void;
     setMessagesWithEpoch: (messages: UM[]) => void;
+    /** Replace the package tree snapshot and derive store fields from it. */
+    setTreeSnapshot: (snapshot: MessageTreeSnapshot<UM>) => void;
     /** Replace the full message tree (used when syncing from server). */
     setAllMessages: (messages: UM[]) => void;
     /** Add or replace a single message in the tree (used during streaming/sending). */
@@ -59,6 +60,221 @@ export type ThreadAugmentedState<UM extends UIMessage> =
     switchToMessage: (messageId: string) => UM[] | null;
   };
 
+function parentKey(parentId: string | null) {
+  return parentId ?? ROOT_PARENT_ID;
+}
+
+function getMetadataParentId<UM extends UIMessage>(message: UM) {
+  return ((message as UM & MessageNode).metadata?.parentMessageId ?? null) as
+    | string
+    | null;
+}
+
+function getMessageTimestamp<UM extends UIMessage>(message: UM) {
+  const createdAt = (message as UM & MessageNode).metadata?.createdAt;
+  if (!createdAt) {
+    return 0;
+  }
+  return createdAt instanceof Date
+    ? createdAt.getTime()
+    : new Date(createdAt).getTime();
+}
+
+function compareSiblingMessages<UM extends UIMessage>(a: UM, b: UM) {
+  const aMetadata = (a as UM & MessageNode).metadata;
+  const bMetadata = (b as UM & MessageNode).metadata;
+  const sameParallelGroup =
+    aMetadata?.parallelGroupId &&
+    aMetadata.parallelGroupId === bMetadata?.parallelGroupId;
+
+  if (
+    sameParallelGroup &&
+    typeof aMetadata.parallelIndex === "number" &&
+    typeof bMetadata?.parallelIndex === "number" &&
+    aMetadata.parallelIndex !== bMetadata.parallelIndex
+  ) {
+    return aMetadata.parallelIndex - bMetadata.parallelIndex;
+  }
+
+  return getMessageTimestamp(a) - getMessageTimestamp(b);
+}
+
+function buildTreeSnapshotFromMessages<UM extends UIMessage>(
+  messages: UM[],
+  cursorId: string | null = messages.at(-1)?.id ?? null
+): MessageTreeSnapshot<UM> {
+  const messagesById: Record<string, UM> = {};
+  const parentById: Record<string, string | null> = {};
+  const childrenByParentId: Record<string, string[]> = {};
+
+  for (const message of messages) {
+    const parentId = getMetadataParentId(message);
+    messagesById[message.id] = message;
+    parentById[message.id] = parentId;
+
+    const key = parentKey(parentId);
+    childrenByParentId[key] = [...(childrenByParentId[key] ?? []), message.id];
+  }
+
+  for (const childIds of Object.values(childrenByParentId)) {
+    childIds.sort((a, b) =>
+      compareSiblingMessages(messagesById[a] as UM, messagesById[b] as UM)
+    );
+  }
+
+  return {
+    childrenByParentId,
+    cursorId,
+    messagesById,
+    parentById,
+    rootIds: childrenByParentId[ROOT_PARENT_ID] ?? [],
+    version: 1,
+  };
+}
+
+function buildChildrenMapFromSnapshot<UM extends UIMessage>(
+  messages: UM[],
+  snapshot: MessageTreeSnapshot<UM>
+): Map<string | null, UM[]> {
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message])
+  );
+  const map = new Map<string | null, UM[]>();
+
+  for (const [key, childIds] of Object.entries(snapshot.childrenByParentId)) {
+    const parentId = key === ROOT_PARENT_ID ? null : key;
+    map.set(
+      parentId,
+      childIds
+        .map((id) => messagesById.get(id))
+        .filter((message): message is UM => Boolean(message))
+    );
+  }
+
+  return map;
+}
+
+function buildThreadFromSnapshot<UM extends UIMessage>(
+  messages: UM[],
+  snapshot: MessageTreeSnapshot<UM>,
+  leafMessageId: string
+): UM[] {
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message])
+  );
+  const thread: UM[] = [];
+  let currentMessageId: string | null = leafMessageId;
+  let iteration = 0;
+
+  while (currentMessageId) {
+    iteration += 1;
+    if (iteration > 100) {
+      break;
+    }
+
+    const currentMessage = messagesById.get(currentMessageId);
+    if (!currentMessage) {
+      break;
+    }
+
+    thread.unshift(currentMessage);
+    currentMessageId = snapshot.parentById[currentMessageId] ?? null;
+  }
+
+  return thread;
+}
+
+function findLeafDfsToRightFromSnapshot<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>,
+  messageId: string
+): string | null {
+  const children = snapshot.childrenByParentId[messageId] ?? [];
+  const rightmostChild = children.at(-1);
+
+  if (!rightmostChild) {
+    return null;
+  }
+
+  return (
+    findLeafDfsToRightFromSnapshot(snapshot, rightmostChild) ?? rightmostChild
+  );
+}
+
+function getSnapshotSignature<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>
+) {
+  return JSON.stringify({
+    childrenByParentId: snapshot.childrenByParentId,
+    cursorId: snapshot.cursorId,
+    messagesById: snapshot.messagesById,
+    parentById: snapshot.parentById,
+    rootIds: snapshot.rootIds,
+  });
+}
+
+type MetadataWithSelectedModel = MessageNode["metadata"] & {
+  selectedModel?: unknown;
+  selectedTool?: unknown;
+};
+
+function mergeMessageIntoMap<UM extends UIMessage>(
+  merged: Map<string, UM>,
+  message: UM
+) {
+  const existing = merged.get(message.id);
+  const existingMetadata = (existing as (UM & MessageNode) | undefined)
+    ?.metadata;
+  if (
+    existing &&
+    (message as UM & MessageNode).metadata === undefined &&
+    existingMetadata !== undefined
+  ) {
+    merged.set(message.id, {
+      ...message,
+      metadata: {
+        ...existingMetadata,
+      },
+    } as UM);
+    return;
+  }
+
+  merged.set(message.id, message);
+}
+
+function addFallbackMetadataToMessages<UM extends UIMessage>(
+  merged: Map<string, UM>,
+  parentById: Record<string, string | null>
+) {
+  for (const [messageId, message] of merged) {
+    if ((message as UM & MessageNode).metadata !== undefined) {
+      continue;
+    }
+
+    const parentId = parentById[messageId] ?? null;
+    const parent = parentId ? merged.get(parentId) : undefined;
+    const parentMetadata = (parent as (UM & MessageNode) | undefined)
+      ?.metadata as MetadataWithSelectedModel | undefined;
+
+    if (!(parentMetadata && "selectedModel" in parentMetadata)) {
+      continue;
+    }
+
+    merged.set(messageId, {
+      ...message,
+      metadata: {
+        activeStreamId: null,
+        createdAt: new Date(),
+        isPrimaryParallel: null,
+        parallelGroupId: null,
+        parallelIndex: null,
+        parentMessageId: parentId,
+        selectedModel: parentMetadata.selectedModel,
+        selectedTool: parentMetadata.selectedTool,
+      },
+    } as UM);
+  }
+}
+
 export const withThreads =
   <UI_MESSAGE extends UIMessage, T extends BaseChatStoreState<UI_MESSAGE>>(
     creator: StateCreator<T, [], []>
@@ -69,33 +285,33 @@ export const withThreads =
     // Wrap the original setMessages to auto-bump epoch
     const originalSetMessages = base.setMessages;
 
-    const rebuildMap = (msgs: UI_MESSAGE[]) =>
-      buildChildrenMap(msgs as (UI_MESSAGE & MessageNode)[]);
+    const rebuildMap = (
+      msgs: UI_MESSAGE[],
+      snapshot = buildTreeSnapshotFromMessages(msgs)
+    ) => buildChildrenMapFromSnapshot(msgs, snapshot);
 
     const mergeTreeMessages = (
       serverMessages: UI_MESSAGE[],
       existingTreeMessages: UI_MESSAGE[],
-      currentVisibleMessages: UI_MESSAGE[]
+      currentVisibleMessages: UI_MESSAGE[],
+      parentById: Record<string, string | null> = {}
     ): UI_MESSAGE[] => {
       const merged = new Map<string, UI_MESSAGE>();
 
-      for (const message of serverMessages) {
-        merged.set(message.id, message);
-      }
-
-      // Preserve every local-only tree node until the server returns a message with
-      // the same id. Restricting this to pending assistant shells orphaned optimistic
-      // user messages when switching away from an in-flight branch mid-stream.
       for (const message of existingTreeMessages) {
-        if (!merged.has(message.id)) {
-          merged.set(message.id, message);
-        }
+        mergeMessageIntoMap(merged, message);
       }
 
+      for (const message of serverMessages) {
+        mergeMessageIntoMap(merged, message);
+      }
+
+      // Preserve in-flight visible messages when server data is still stale.
       for (const message of currentVisibleMessages) {
-        merged.set(message.id, message);
+        mergeMessageIntoMap(merged, message);
       }
 
+      addFallbackMetadataToMessages(merged, parentById);
       return Array.from(merged.values());
     };
 
@@ -104,6 +320,10 @@ export const withThreads =
       threadEpoch: 0,
       threadInitialMessages: base.messages,
       allMessages: base.messages,
+      treeSnapshot: buildTreeSnapshotFromMessages(base.messages),
+      treeSnapshotSignature: getSnapshotSignature(
+        buildTreeSnapshotFromMessages(base.messages)
+      ),
       childrenMap: rebuildMap(base.messages),
 
       bumpThreadEpoch: () => {
@@ -122,12 +342,66 @@ export const withThreads =
       },
 
       setMessagesWithEpoch: (messages: UI_MESSAGE[]) => {
-        originalSetMessages(messages);
-        set((state) => ({
-          ...state,
-          threadEpoch: state.threadEpoch + 1,
-          threadInitialMessages: messages,
-        }));
+        const cursorId = messages.at(-1)?.id ?? null;
+        set((state) => {
+          const snapshot = buildTreeSnapshotFromMessages(
+            state.allMessages,
+            cursorId
+          );
+          state._messageIndex.update(messages);
+          return {
+            ...state,
+            messages,
+            _memoizedSelectors: new Map(),
+            _throttledMessages: messages,
+            threadEpoch: state.threadEpoch + 1,
+            threadInitialMessages: messages,
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(state.allMessages, snapshot),
+          };
+        });
+      },
+
+      setTreeSnapshot: (snapshot: MessageTreeSnapshot<UI_MESSAGE>) => {
+        const state = get();
+        const snapshotMessages = Object.values(snapshot.messagesById);
+        const mergedMessages = mergeTreeMessages(
+          snapshotMessages,
+          state.allMessages,
+          [],
+          snapshot.parentById
+        );
+        const mergedSnapshot = buildTreeSnapshotFromMessages(
+          mergedMessages,
+          snapshot.cursorId
+        );
+        const signature = getSnapshotSignature(mergedSnapshot);
+        if (state.treeSnapshotSignature === signature) {
+          return;
+        }
+
+        const nextVisibleThread = mergedSnapshot.cursorId
+          ? buildThreadFromSnapshot(
+              mergedMessages,
+              mergedSnapshot,
+              mergedSnapshot.cursorId
+            )
+          : [];
+
+        set((prev) => {
+          prev._messageIndex.update(nextVisibleThread);
+          return {
+            ...prev,
+            messages: nextVisibleThread,
+            _memoizedSelectors: new Map(),
+            _throttledMessages: nextVisibleThread,
+            allMessages: mergedMessages,
+            treeSnapshot: mergedSnapshot,
+            treeSnapshotSignature: signature,
+            childrenMap: rebuildMap(mergedMessages, mergedSnapshot),
+          };
+        });
       },
 
       setAllMessages: (messages: UI_MESSAGE[]) => {
@@ -137,7 +411,13 @@ export const withThreads =
         const mergedMessages = mergeTreeMessages(
           messages,
           existingTreeMessages,
-          currentVisibleMessages
+          state.status === "streaming" || state.status === "submitted"
+            ? currentVisibleMessages
+            : []
+        );
+        const snapshot = buildTreeSnapshotFromMessages(
+          mergedMessages,
+          currentVisibleMessages.at(-1)?.id ?? null
         );
 
         // While the SDK is actively streaming, updating the visible thread with
@@ -150,26 +430,29 @@ export const withThreads =
           set((prev) => ({
             ...prev,
             allMessages: mergedMessages,
-            childrenMap: rebuildMap(mergedMessages),
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(mergedMessages, snapshot),
           }));
           return;
         }
 
         const currentLeafId = currentVisibleMessages.at(-1)?.id;
         const nextVisibleThread = currentLeafId
-          ? (buildThreadFromLeaf(
-              mergedMessages as (UI_MESSAGE & MessageNode)[],
-              currentLeafId
-            ) as UI_MESSAGE[])
+          ? buildThreadFromSnapshot(mergedMessages, snapshot, currentLeafId)
           : currentVisibleMessages;
 
         originalSetMessages(nextVisibleThread);
         set((prev) => ({
           ...prev,
           messages: nextVisibleThread,
+          _memoizedSelectors: new Map(),
+          _throttledMessages: nextVisibleThread,
           threadInitialMessages: nextVisibleThread,
           allMessages: mergedMessages,
-          childrenMap: rebuildMap(mergedMessages),
+          treeSnapshot: snapshot,
+          treeSnapshotSignature: getSnapshotSignature(snapshot),
+          childrenMap: rebuildMap(mergedMessages, snapshot),
         }));
       },
 
@@ -181,24 +464,49 @@ export const withThreads =
             next = [...state.allMessages, message];
           } else {
             next = [...state.allMessages];
-            next[idx] = message;
+            const existing = next[idx];
+            const existingMetadata = (
+              existing as (UI_MESSAGE & MessageNode) | undefined
+            )?.metadata;
+            next[idx] =
+              existing &&
+              (message as UI_MESSAGE & MessageNode).metadata === undefined &&
+              existingMetadata !== undefined
+                ? ({
+                    ...message,
+                    metadata: {
+                      ...existingMetadata,
+                    },
+                  } as UI_MESSAGE)
+                : message;
           }
-          return { ...state, allMessages: next, childrenMap: rebuildMap(next) };
+          const snapshot = buildTreeSnapshotFromMessages(
+            next,
+            state.messages.at(-1)?.id ?? null
+          );
+          return {
+            ...state,
+            allMessages: next,
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(next, snapshot),
+          };
         });
       },
 
       getMessageSiblingInfo: (
         messageId: string
       ): MessageSiblingInfo<UI_MESSAGE> | null => {
-        const { allMessages, childrenMap } = get();
+        const state = get();
+        const { allMessages, childrenMap } = state;
         const message = allMessages.find((m) => m.id === messageId);
         if (!message) {
           return null;
         }
 
         const parentId =
-          (message as UI_MESSAGE & MessageNode).metadata?.parentMessageId ||
-          null;
+          state.treeSnapshot.parentById[message.id] ??
+          getMetadataParentId(message);
         const siblings = (childrenMap.get(parentId) ?? []) as UI_MESSAGE[];
         const siblingIndex = siblings.findIndex((s) => s.id === messageId);
 
@@ -219,7 +527,9 @@ export const withThreads =
         const parentId =
           message.role === "user"
             ? message.id
-            : metadata?.parentMessageId || null;
+            : (state.treeSnapshot.parentById[message.id] ??
+              metadata?.parentMessageId ??
+              null);
 
         if (!(parentId && parallelGroupId)) {
           return null;
@@ -269,7 +579,7 @@ export const withThreads =
         direction: "prev" | "next"
       ): UI_MESSAGE[] | null => {
         const state = get();
-        const { allMessages, childrenMap } = state;
+        const { allMessages } = state;
         if (!allMessages.length) {
           return null;
         }
@@ -286,13 +596,14 @@ export const withThreads =
             : (siblingIndex - 1 + siblings.length) % siblings.length;
 
         const targetSibling = siblings[nextIndex];
-        const leaf = findLeafDfsToRightFromMessageId(
-          childrenMap as Map<string | null, (UI_MESSAGE & MessageNode)[]>,
+        const leafId = findLeafDfsToRightFromSnapshot(
+          state.treeSnapshot,
           targetSibling.id
         );
-        const newThread = buildThreadFromLeaf(
-          allMessages as (UI_MESSAGE & MessageNode)[],
-          leaf ? leaf.id : targetSibling.id
+        const newThread = buildThreadFromSnapshot(
+          allMessages,
+          state.treeSnapshot,
+          leafId ?? targetSibling.id
         ) as UI_MESSAGE[];
 
         state.setMessagesWithEpoch(newThread);
@@ -301,7 +612,7 @@ export const withThreads =
 
       switchToMessage: (messageId: string): UI_MESSAGE[] | null => {
         const state = get();
-        const { allMessages, childrenMap } = state;
+        const { allMessages } = state;
         const message = allMessages.find(
           (candidate) => candidate.id === messageId
         );
@@ -309,13 +620,14 @@ export const withThreads =
           return null;
         }
 
-        const leaf = findLeafDfsToRightFromMessageId(
-          childrenMap as Map<string | null, (UI_MESSAGE & MessageNode)[]>,
+        const leafId = findLeafDfsToRightFromSnapshot(
+          state.treeSnapshot,
           messageId
         );
-        const newThread = buildThreadFromLeaf(
-          allMessages as (UI_MESSAGE & MessageNode)[],
-          leaf ? leaf.id : messageId
+        const newThread = buildThreadFromSnapshot(
+          allMessages,
+          state.treeSnapshot,
+          leafId ?? messageId
         ) as UI_MESSAGE[];
 
         state.setMessagesWithEpoch(newThread);
@@ -332,9 +644,16 @@ export const withThreads =
 
         // Only bump epoch if the thread structure actually changed
         if (currentIds !== newIds) {
+          const snapshot = buildTreeSnapshotFromMessages(
+            get().allMessages,
+            messages.at(-1)?.id ?? null
+          );
           set((state) => ({
             ...state,
             threadEpoch: state.threadEpoch + 1,
+            treeSnapshot: snapshot,
+            treeSnapshotSignature: getSnapshotSignature(snapshot),
+            childrenMap: rebuildMap(state.allMessages, snapshot),
           }));
         }
       },

--- a/apps/chat/lib/stores/with-threads.ts
+++ b/apps/chat/lib/stores/with-threads.ts
@@ -163,7 +163,12 @@ function getSnapshotIndexes<UM extends UIMessage>(
 
   for (const { message, parentId } of snapshot.nodes) {
     const key = parentKey(parentId);
-    childrenByParentId[key] = [...(childrenByParentId[key] ?? []), message.id];
+    const children = childrenByParentId[key];
+    if (children) {
+      children.push(message.id);
+    } else {
+      childrenByParentId[key] = [message.id];
+    }
     messagesById[message.id] = message;
     parentById[message.id] = parentId;
     if (parentId === null) {
@@ -172,6 +177,97 @@ function getSnapshotIndexes<UM extends UIMessage>(
   }
 
   return { childrenByParentId, messagesById, parentById, rootIds };
+}
+
+function getSnapshotParentId<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>,
+  message: UM
+) {
+  const { parentById } = getSnapshotIndexes(snapshot);
+  return Object.hasOwn(parentById, message.id)
+    ? parentById[message.id]
+    : getMetadataParentId(message);
+}
+
+function mergeTreeSnapshot<UM extends UIMessage>(
+  incomingSnapshot: MessageTreeSnapshot<UM>,
+  existingSnapshot: MessageTreeSnapshot<UM>,
+  messages: UM[]
+): MessageTreeSnapshot<UM> {
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message])
+  );
+  const incomingParents = getSnapshotIndexes(incomingSnapshot).parentById;
+  const existingParents = getSnapshotIndexes(existingSnapshot).parentById;
+  const orderedMessageIds = [
+    ...existingSnapshot.nodes.map(({ message }) => message.id),
+    ...incomingSnapshot.nodes.map(({ message }) => message.id),
+    ...messages.map((message) => message.id),
+  ];
+  const uniqueOrderedMessageIds = [...new Set(orderedMessageIds)].filter((id) =>
+    messagesById.has(id)
+  );
+  const parentById = new Map<string, string | null>();
+  const childrenByParentId = new Map<string | null, string[]>();
+
+  for (const messageId of uniqueOrderedMessageIds) {
+    const message = messagesById.get(messageId);
+    if (!message) {
+      continue;
+    }
+
+    let parentId = getMetadataParentId(message);
+    if (Object.hasOwn(incomingParents, messageId)) {
+      parentId = incomingParents[messageId] ?? null;
+    } else if (Object.hasOwn(existingParents, messageId)) {
+      parentId = existingParents[messageId] ?? null;
+    }
+    const validParentId =
+      parentId !== messageId && parentId !== null && messagesById.has(parentId)
+        ? parentId
+        : null;
+    parentById.set(messageId, validParentId);
+
+    const children = childrenByParentId.get(validParentId);
+    if (children) {
+      children.push(messageId);
+    } else {
+      childrenByParentId.set(validParentId, [messageId]);
+    }
+  }
+
+  const nodes: MessageTreeSnapshot<UM>["nodes"] = [];
+  const visited = new Set<string>();
+  const visit = (messageId: string, parentId: string | null) => {
+    if (visited.has(messageId)) {
+      return;
+    }
+    const message = messagesById.get(messageId);
+    if (!message) {
+      return;
+    }
+
+    visited.add(messageId);
+    nodes.push({ message, parentId });
+    for (const childId of childrenByParentId.get(messageId) ?? []) {
+      visit(childId, messageId);
+    }
+  };
+
+  for (const rootId of childrenByParentId.get(null) ?? []) {
+    visit(rootId, null);
+  }
+  // Invalid cyclic topology is recovered as an additional root rather than
+  // leaking a cycle into traversal or into ThreadChat on the next remount.
+  for (const messageId of uniqueOrderedMessageIds) {
+    visit(messageId, null);
+  }
+
+  return {
+    cursorId: incomingSnapshot.cursorId,
+    nodes,
+    version: 1,
+  };
 }
 
 function buildChildrenMapFromSnapshot<UM extends UIMessage>(
@@ -208,24 +304,24 @@ function buildThreadFromSnapshot<UM extends UIMessage>(
   const { parentById } = getSnapshotIndexes(snapshot);
   const thread: UM[] = [];
   let currentMessageId: string | null = leafMessageId;
-  let iteration = 0;
+  const visited = new Set<string>();
 
   while (currentMessageId) {
-    iteration += 1;
-    if (iteration > 100) {
+    if (visited.has(currentMessageId)) {
       break;
     }
+    visited.add(currentMessageId);
 
     const currentMessage = messagesById.get(currentMessageId);
     if (!currentMessage) {
       break;
     }
 
-    thread.unshift(currentMessage);
+    thread.push(currentMessage);
     currentMessageId = parentById[currentMessageId] ?? null;
   }
 
-  return thread;
+  return thread.reverse();
 }
 
 function findLeafDfsToRightFromSnapshot<UM extends UIMessage>(
@@ -233,15 +329,31 @@ function findLeafDfsToRightFromSnapshot<UM extends UIMessage>(
   messageId: string
 ): string | null {
   const { childrenByParentId } = getSnapshotIndexes(snapshot);
-  const children = childrenByParentId[messageId] ?? [];
-  const rightmostChild = children.at(-1);
+  const visited = new Set([messageId]);
+  let currentMessageId = messageId;
+  let leafMessageId: string | null = null;
 
-  if (!rightmostChild) {
+  while (true) {
+    const rightmostChild = childrenByParentId[currentMessageId]?.at(-1);
+    if (!rightmostChild || visited.has(rightmostChild)) {
+      return leafMessageId;
+    }
+    visited.add(rightmostChild);
+    leafMessageId = rightmostChild;
+    currentMessageId = rightmostChild;
+  }
+}
+
+function findRightmostLeafFromSnapshot<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>
+) {
+  const { rootIds } = getSnapshotIndexes(snapshot);
+  const rightmostRoot = rootIds.at(-1);
+  if (!rightmostRoot) {
     return null;
   }
-
   return (
-    findLeafDfsToRightFromSnapshot(snapshot, rightmostChild) ?? rightmostChild
+    findLeafDfsToRightFromSnapshot(snapshot, rightmostRoot) ?? rightmostRoot
   );
 }
 
@@ -302,7 +414,7 @@ function addFallbackMetadataToMessages<UM extends UIMessage>(
       ...message,
       metadata: {
         activeStreamId: null,
-        createdAt: new Date(),
+        createdAt: parentMetadata.createdAt,
         isPrimaryParallel: null,
         parallelGroupId: null,
         parallelIndex: null,
@@ -353,17 +465,16 @@ export const withThreads =
       addFallbackMetadataToMessages(merged, parentById);
       return Array.from(merged.values());
     };
+    const initialSnapshot = buildTreeSnapshotFromMessages(base.messages);
 
     return {
       ...base,
       threadEpoch: 0,
       threadInitialMessages: base.messages,
       allMessages: base.messages,
-      treeSnapshot: buildTreeSnapshotFromMessages(base.messages),
-      treeSnapshotSignature: getSnapshotSignature(
-        buildTreeSnapshotFromMessages(base.messages)
-      ),
-      childrenMap: rebuildMap(base.messages),
+      treeSnapshot: initialSnapshot,
+      treeSnapshotSignature: getSnapshotSignature(initialSnapshot),
+      childrenMap: rebuildMap(base.messages, initialSnapshot),
 
       bumpThreadEpoch: () => {
         set((state) => ({
@@ -382,12 +493,12 @@ export const withThreads =
 
       setMessagesWithEpoch: (messages: UI_MESSAGE[]) => {
         const cursorId = messages.at(-1)?.id ?? null;
+        get()._messageIndex.update(messages);
         set((state) => {
           const snapshot = buildTreeSnapshotFromMessages(
             state.allMessages,
             cursorId
           );
-          state._messageIndex.update(messages);
           return {
             ...state,
             messages,
@@ -412,9 +523,10 @@ export const withThreads =
           [],
           snapshotIndexes.parentById
         );
-        const mergedSnapshot = buildTreeSnapshotFromMessages(
-          mergedMessages,
-          snapshot.cursorId
+        const mergedSnapshot = mergeTreeSnapshot(
+          snapshot,
+          state.treeSnapshot,
+          mergedMessages
         );
         const signature = getSnapshotSignature(mergedSnapshot);
         if (state.treeSnapshotSignature === signature) {
@@ -429,19 +541,17 @@ export const withThreads =
             )
           : [];
 
-        set((prev) => {
-          prev._messageIndex.update(nextVisibleThread);
-          return {
-            ...prev,
-            messages: nextVisibleThread,
-            _memoizedSelectors: new Map(),
-            _throttledMessages: nextVisibleThread,
-            allMessages: mergedMessages,
-            treeSnapshot: mergedSnapshot,
-            treeSnapshotSignature: signature,
-            childrenMap: rebuildMap(mergedMessages, mergedSnapshot),
-          };
-        });
+        state._messageIndex.update(nextVisibleThread);
+        set((prev) => ({
+          ...prev,
+          messages: nextVisibleThread,
+          _memoizedSelectors: new Map(),
+          _throttledMessages: nextVisibleThread,
+          allMessages: mergedMessages,
+          treeSnapshot: mergedSnapshot,
+          treeSnapshotSignature: signature,
+          childrenMap: rebuildMap(mergedMessages, mergedSnapshot),
+        }));
       },
 
       setAllMessages: (messages: UI_MESSAGE[]) => {
@@ -455,7 +565,7 @@ export const withThreads =
             ? currentVisibleMessages
             : []
         );
-        const snapshot = buildTreeSnapshotFromMessages(
+        let snapshot = buildTreeSnapshotFromMessages(
           mergedMessages,
           currentVisibleMessages.at(-1)?.id ?? null
         );
@@ -475,8 +585,16 @@ export const withThreads =
         }
 
         const currentLeafId = currentVisibleMessages.at(-1)?.id;
-        const nextVisibleThread = currentLeafId
-          ? buildThreadFromSnapshot(mergedMessages, snapshot, currentLeafId)
+        const selectedLeafId =
+          currentLeafId ?? findRightmostLeafFromSnapshot(snapshot);
+        if (selectedLeafId && snapshot.cursorId !== selectedLeafId) {
+          snapshot = {
+            ...snapshot,
+            cursorId: selectedLeafId,
+          };
+        }
+        const nextVisibleThread = selectedLeafId
+          ? buildThreadFromSnapshot(mergedMessages, snapshot, selectedLeafId)
           : currentVisibleMessages;
 
         originalSetMessages(nextVisibleThread);
@@ -485,7 +603,6 @@ export const withThreads =
           messages: nextVisibleThread,
           _memoizedSelectors: new Map(),
           _throttledMessages: nextVisibleThread,
-          threadInitialMessages: nextVisibleThread,
           allMessages: mergedMessages,
           treeSnapshot: snapshot,
           treeSnapshotSignature: getSnapshotSignature(snapshot),
@@ -541,9 +658,7 @@ export const withThreads =
           return null;
         }
 
-        const parentId =
-          getSnapshotIndexes(state.treeSnapshot).parentById[message.id] ??
-          getMetadataParentId(message);
+        const parentId = getSnapshotParentId(state.treeSnapshot, message);
         const siblings = (childrenMap.get(parentId) ?? []) as UI_MESSAGE[];
         const siblingIndex = siblings.findIndex((s) => s.id === messageId);
 
@@ -564,9 +679,7 @@ export const withThreads =
         const parentId =
           message.role === "user"
             ? message.id
-            : (getSnapshotIndexes(state.treeSnapshot).parentById[message.id] ??
-              metadata?.parentMessageId ??
-              null);
+            : getSnapshotParentId(state.treeSnapshot, message);
 
         if (!(parentId && parallelGroupId)) {
           return null;

--- a/apps/chat/lib/stores/with-threads.ts
+++ b/apps/chat/lib/stores/with-threads.ts
@@ -4,11 +4,13 @@
 // and complete message tree management for branching/sibling navigation.
 // The store owns allMessages (the full tree); React Query feeds data into it.
 
-import { type MessageTreeSnapshot, ROOT_PARENT_ID } from "@chatjs/thread";
+import type { MessageTreeSnapshot } from "@chatjs/thread";
 import type { UIMessage } from "ai";
 import type { StateCreator } from "zustand";
 import type { StoreState as BaseChatStoreState } from "@/lib/stores/base";
 import type { MessageNode } from "@/lib/thread-utils";
+
+const ROOT_PARENT_KEY = "__root__";
 
 export interface MessageSiblingInfo<UM> {
   siblingIndex: number;
@@ -61,7 +63,7 @@ export type ThreadAugmentedState<UM extends UIMessage> =
   };
 
 function parentKey(parentId: string | null) {
-  return parentId ?? ROOT_PARENT_ID;
+  return parentId ?? ROOT_PARENT_KEY;
 }
 
 function getMetadataParentId<UM extends UIMessage>(message: UM) {
@@ -103,33 +105,73 @@ function buildTreeSnapshotFromMessages<UM extends UIMessage>(
   messages: UM[],
   cursorId: string | null = messages.at(-1)?.id ?? null
 ): MessageTreeSnapshot<UM> {
-  const messagesById: Record<string, UM> = {};
-  const parentById: Record<string, string | null> = {};
-  const childrenByParentId: Record<string, string[]> = {};
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message])
+  );
+  const childrenByParentId = new Map<string | null, UM[]>();
 
   for (const message of messages) {
-    const parentId = getMetadataParentId(message);
-    messagesById[message.id] = message;
-    parentById[message.id] = parentId;
-
-    const key = parentKey(parentId);
-    childrenByParentId[key] = [...(childrenByParentId[key] ?? []), message.id];
+    const metadataParentId = getMetadataParentId(message);
+    const parentId =
+      metadataParentId && messagesById.has(metadataParentId)
+        ? metadataParentId
+        : null;
+    childrenByParentId.set(parentId, [
+      ...(childrenByParentId.get(parentId) ?? []),
+      message,
+    ]);
   }
 
-  for (const childIds of Object.values(childrenByParentId)) {
-    childIds.sort((a, b) =>
-      compareSiblingMessages(messagesById[a] as UM, messagesById[b] as UM)
-    );
+  for (const children of childrenByParentId.values()) {
+    children.sort(compareSiblingMessages);
+  }
+
+  const nodes: MessageTreeSnapshot<UM>["nodes"] = [];
+  const visited = new Set<string>();
+  const visit = (message: UM, parentId: string | null) => {
+    if (visited.has(message.id)) {
+      return;
+    }
+    visited.add(message.id);
+    nodes.push({ message, parentId });
+    for (const child of childrenByParentId.get(message.id) ?? []) {
+      visit(child, message.id);
+    }
+  };
+
+  for (const root of childrenByParentId.get(null) ?? []) {
+    visit(root, null);
+  }
+  for (const message of messages) {
+    visit(message, null);
   }
 
   return {
-    childrenByParentId,
     cursorId,
-    messagesById,
-    parentById,
-    rootIds: childrenByParentId[ROOT_PARENT_ID] ?? [],
+    nodes,
     version: 1,
   };
+}
+
+function getSnapshotIndexes<UM extends UIMessage>(
+  snapshot: MessageTreeSnapshot<UM>
+) {
+  const childrenByParentId: Record<string, string[]> = {};
+  const messagesById: Record<string, UM> = {};
+  const parentById: Record<string, string | null> = {};
+  const rootIds: string[] = [];
+
+  for (const { message, parentId } of snapshot.nodes) {
+    const key = parentKey(parentId);
+    childrenByParentId[key] = [...(childrenByParentId[key] ?? []), message.id];
+    messagesById[message.id] = message;
+    parentById[message.id] = parentId;
+    if (parentId === null) {
+      rootIds.push(message.id);
+    }
+  }
+
+  return { childrenByParentId, messagesById, parentById, rootIds };
 }
 
 function buildChildrenMapFromSnapshot<UM extends UIMessage>(
@@ -140,9 +182,10 @@ function buildChildrenMapFromSnapshot<UM extends UIMessage>(
     messages.map((message) => [message.id, message])
   );
   const map = new Map<string | null, UM[]>();
+  const { childrenByParentId } = getSnapshotIndexes(snapshot);
 
-  for (const [key, childIds] of Object.entries(snapshot.childrenByParentId)) {
-    const parentId = key === ROOT_PARENT_ID ? null : key;
+  for (const [key, childIds] of Object.entries(childrenByParentId)) {
+    const parentId = key === ROOT_PARENT_KEY ? null : key;
     map.set(
       parentId,
       childIds
@@ -162,6 +205,7 @@ function buildThreadFromSnapshot<UM extends UIMessage>(
   const messagesById = new Map(
     messages.map((message) => [message.id, message])
   );
+  const { parentById } = getSnapshotIndexes(snapshot);
   const thread: UM[] = [];
   let currentMessageId: string | null = leafMessageId;
   let iteration = 0;
@@ -178,7 +222,7 @@ function buildThreadFromSnapshot<UM extends UIMessage>(
     }
 
     thread.unshift(currentMessage);
-    currentMessageId = snapshot.parentById[currentMessageId] ?? null;
+    currentMessageId = parentById[currentMessageId] ?? null;
   }
 
   return thread;
@@ -188,7 +232,8 @@ function findLeafDfsToRightFromSnapshot<UM extends UIMessage>(
   snapshot: MessageTreeSnapshot<UM>,
   messageId: string
 ): string | null {
-  const children = snapshot.childrenByParentId[messageId] ?? [];
+  const { childrenByParentId } = getSnapshotIndexes(snapshot);
+  const children = childrenByParentId[messageId] ?? [];
   const rightmostChild = children.at(-1);
 
   if (!rightmostChild) {
@@ -203,13 +248,7 @@ function findLeafDfsToRightFromSnapshot<UM extends UIMessage>(
 function getSnapshotSignature<UM extends UIMessage>(
   snapshot: MessageTreeSnapshot<UM>
 ) {
-  return JSON.stringify({
-    childrenByParentId: snapshot.childrenByParentId,
-    cursorId: snapshot.cursorId,
-    messagesById: snapshot.messagesById,
-    parentById: snapshot.parentById,
-    rootIds: snapshot.rootIds,
-  });
+  return JSON.stringify(snapshot);
 }
 
 type MetadataWithSelectedModel = MessageNode["metadata"] & {
@@ -365,12 +404,13 @@ export const withThreads =
 
       setTreeSnapshot: (snapshot: MessageTreeSnapshot<UI_MESSAGE>) => {
         const state = get();
-        const snapshotMessages = Object.values(snapshot.messagesById);
+        const snapshotIndexes = getSnapshotIndexes(snapshot);
+        const snapshotMessages = snapshot.nodes.map(({ message }) => message);
         const mergedMessages = mergeTreeMessages(
           snapshotMessages,
           state.allMessages,
           [],
-          snapshot.parentById
+          snapshotIndexes.parentById
         );
         const mergedSnapshot = buildTreeSnapshotFromMessages(
           mergedMessages,
@@ -420,12 +460,9 @@ export const withThreads =
           currentVisibleMessages.at(-1)?.id ?? null
         );
 
-        // While the SDK is actively streaming, updating the visible thread with
-        // server data would mix the SDK's client-generated message ID with the
-        // server's assistantMessageId. The mismatch causes the SDK to push a
-        // second assistant message on the next chunk, bumping the epoch and
-        // remounting ChatSync mid-stream. Only update the tree index here and
-        // let the normal post-stream invalidation apply the full visible update.
+        // The live runtime remains authoritative while streaming. Query data can
+        // lag behind stream chunks, so merge it into the tree index without
+        // replacing the visible path until post-stream invalidation.
         if (state.status === "streaming" || state.status === "submitted") {
           set((prev) => ({
             ...prev,
@@ -505,7 +542,7 @@ export const withThreads =
         }
 
         const parentId =
-          state.treeSnapshot.parentById[message.id] ??
+          getSnapshotIndexes(state.treeSnapshot).parentById[message.id] ??
           getMetadataParentId(message);
         const siblings = (childrenMap.get(parentId) ?? []) as UI_MESSAGE[];
         const siblingIndex = siblings.findIndex((s) => s.id === messageId);
@@ -527,7 +564,7 @@ export const withThreads =
         const parentId =
           message.role === "user"
             ? message.id
-            : (state.treeSnapshot.parentById[message.id] ??
+            : (getSnapshotIndexes(state.treeSnapshot).parentById[message.id] ??
               metadata?.parentMessageId ??
               null);
 
@@ -557,10 +594,6 @@ export const withThreads =
 
             return 0;
           });
-
-        if (groupMessages.length <= 1) {
-          return null;
-        }
 
         const visibleMessageIds = new Set(state.messages.map((m) => m.id));
         const selectedMessageId =

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -47,6 +47,7 @@
     "@ai-sdk/openai-compatible": "2.0.56",
     "@ai-sdk/provider": "3.0.13",
     "@ai-sdk/react": "3.0.221",
+    "@chatjs/thread": "workspace:*",
     "@better-auth/core": "1.5.6",
     "@better-auth/electron": "^1.5.6",
     "@codemirror/lang-javascript": "^6.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@ai-sdk/react": "3.0.221",
         "@better-auth/core": "1.5.6",
         "@better-auth/electron": "^1.5.6",
+        "@chatjs/thread": "workspace:*",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/state": "^6.5.0",

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -280,7 +280,7 @@ message ID remains unknown until AI SDK first publishes the response and may
 then come from the server. Message-based helpers resolve the run associated with
 that node after this binding occurs.
 
-`Thread` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
+`AbstractThread` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
 reconnection needs an AI SDK request lifecycle. Completed run records are
 currently retained so their status and ownership information remain
 addressable.
@@ -291,15 +291,26 @@ run has independent status, error, request serialization, and cancellation.
 Automatic tool continuations remain in the same run and update the same
 assistant response node.
 
-A new live run requires a non-assistant response parent. AI SDK interprets an
-assistant message at the end of a request as the response to continue, not as
-the parent of another response. Therefore, a bare `startRun` from an assistant
-message is rejected. Branching from an assistant remains supported by attaching
-a new input message with `sendMessage` and generating from that input.
+A new independent response requires a non-assistant response parent. AI SDK
+interprets an assistant message at the end of a request as the response to
+continue, not as the parent of another response. Therefore, a bare `startRun`
+from an assistant message is rejected.
+
+The `useChat`-compatible `sendMessage` surface keeps AI SDK's continuation
+semantics. Calling `sendMessage()` on a selected assistant continues that node,
+and passing an explicit assistant message attaches and streams into that same
+message ID. Neither operation creates a child response under the assistant.
+Applications create a branch below an assistant by attaching a new input
+message and generating from that input.
 
 This is a `Thread` live-run invariant, not a `MessageTree` invariant. The
 tree remains role-agnostic so persisted, restored, or server-created data may
 contain assistant-to-assistant edges.
+
+Reconnection does not create response topology. It reactivates the existing
+assistant node, so its parent may have any role or be `null`. Resume checks
+concurrency capacity but does not apply the new-response parent-role rule,
+matching AI SDK's `resumeStream` behavior over the current message history.
 
 ## AI SDK Integration
 
@@ -315,9 +326,10 @@ behavior for:
 - `sendAutomaticallyWhen`
 - regeneration and reconnection
 
-The internal `ThreadRunState` presents one linear branch path to
-`AbstractChat`. It writes accumulated assistant snapshots into `Thread`
-when AI SDK publishes the streaming response.
+The internal `ThreadRunState` presents one run-local linear branch path to
+`AbstractChat`. AI SDK may truncate that local path for regeneration without
+deleting nodes from the canonical tree. The state writes accumulated assistant
+snapshots into `Thread` when AI SDK publishes the streaming response.
 
 `ThreadRunChat` does not insert a synthetic response into that path. AI SDK
 creates the provisional assistant response using its normal last-message rules
@@ -368,6 +380,34 @@ As in AI SDK, expected transport and stream failures resolve after publishing
 `error` status. Unexpected application or state-layer exceptions that escape
 `AbstractChat` reject `sendMessage`, `resumeRun`, and the corresponding
 `finished` promise.
+
+## Regeneration
+
+`regenerate({ messageId })` invokes `AbstractChat.regenerate` inside an isolated
+run adapter. The transport therefore receives AI SDK's native
+`regenerate-message` trigger and target `messageId`.
+
+AI SDK truncates only the adapter's linear request path. The canonical tree
+retains the target response, then inserts the streamed replacement beside it
+using the run's reserved sibling order. A root assistant regenerates into
+another root. The cursor follows the replacement on its first write only when
+it still points to the regeneration target, so navigation during submission or
+streaming is not overwritten.
+
+### Known AI SDK Blocker
+
+Regenerating an assistant whose parent is another assistant remains rejected.
+This is blocked by an AI SDK regeneration bug: after truncating the path to the
+assistant parent, AI SDK treats that trailing assistant as the response to
+continue. Regenerating `[user, assistant A, assistant B]` therefore produces
+`[user, assistant A']` instead of creating a replacement sibling for
+`assistant B`.
+
+The intended tree result is to preserve `assistant B` and create another child
+of `assistant A`. Once AI SDK distinguishes regeneration from normal trailing
+assistant continuation, `Thread` can remove this rejection and keep using the
+native regeneration lifecycle. Until then, rejecting the operation avoids
+silently mutating a shared ancestor.
 
 ## Status and Cancellation
 

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -51,7 +51,7 @@
 		"prepublishOnly": "bun run build",
 		"test": "bun test --pass-with-no-tests",
 		"test:unit": "bun test --pass-with-no-tests",
-		"test:types": "bun run build"
+		"test:types": "tsc -p tsconfig.json --noEmit && bun run build"
 	},
 	"peerDependencies": {
 		"@ai-sdk/react": "^3.0.0",

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -7,6 +7,7 @@ import {
 	convertFileListToFileUIParts,
 	DefaultChatTransport,
 	generateId,
+	isToolUIPart,
 	type UIMessage,
 } from "ai";
 import {
@@ -141,12 +142,12 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 
 	addToolApprovalResponse: AbstractChat<TMessage>["addToolApprovalResponse"] =
 		async (response) => {
-			const run = this.#runs.getForApproval(response.id);
+			const run = this.getOrCreateRunForApproval(response.id);
 			await run.chat.addToolApprovalResponse(response);
 		};
 
 	addToolOutput: AbstractChat<TMessage>["addToolOutput"] = async (output) => {
-		const run = this.#runs.getForToolCall(output.toolCallId);
+		const run = this.getOrCreateRunForToolCall(output.toolCallId);
 		await run.chat.addToolOutput(output);
 	};
 
@@ -190,11 +191,8 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		this.updateTree((tree) => tree.setCursorToParentOf(messageId));
 	}
 
-	private getRunPath(runId: string) {
-		const run = this.#runs.require(runId);
-		return this.readTree((tree) =>
-			tree.getPath(run.spec.messageId ?? run.spec.parentMessageId),
-		);
+	private getMessagePath(messageId: string | null) {
+		return this.readTree((tree) => tree.getPath(messageId));
 	}
 
 	private writeRunMessage(runId: string, message: TMessage) {
@@ -227,7 +225,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			this.indexMessageOwnership(runId, message);
 			if (
 				this.#runs.isExplicitlySelected(runId) &&
-				tree.cursorId === run.spec.parentMessageId
+				tree.cursorId === run.spec.initialPathMessageId
 			) {
 				tree.setCursor(message.id);
 			}
@@ -247,9 +245,11 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 					: tree.getMessage(messageId);
 			return {
 				parentMessageId:
-					selectedTarget?.role === "assistant"
-						? tree.getParentId(selectedTarget.id)
-						: selectedTarget?.id,
+					selectedTarget == null
+						? null
+						: selectedTarget.role === "assistant"
+							? (tree.getParentId(selectedTarget.id) ?? null)
+							: selectedTarget.id,
 				target: selectedTarget,
 			};
 		});
@@ -257,15 +257,41 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			throw new Error(`message ${messageId} not found`);
 		}
 
-		if (!parentMessageId) return;
+		if (target.role === "assistant") {
+			if (parentMessageId) {
+				const parentMessage = this.getMessage(parentMessageId);
+				if (!parentMessage) {
+					throw new Error(`Unknown message ${parentMessageId}`);
+				}
+				if (parentMessage.role === "assistant") {
+					// AI SDK regeneration currently reuses a trailing assistant instead
+					// of creating a new response, which would mutate this shared parent.
+					throw new Error(
+						`Cannot regenerate assistant message ${target.id} because its parent ${parentMessage.id} is also an assistant`,
+					);
+				}
+				this.assertCanGenerateFrom(parentMessage);
+			} else {
+				this.#runs.assertHasCapacity(null);
+			}
+		} else {
+			this.assertCanGenerateFrom(target);
+		}
 
-		this.assertCanStartRun(parentMessageId);
-		const run = this.startRunFromParent({
-			follow: true,
+		const spec: ThreadRunSpec = {
 			id: this.#runs.reserveId(this.generateMessageId),
-			options,
+			initialPathMessageId: target.id,
 			parentMessageId,
-		});
+			siblingOrder: this.#runs.reserveSiblingOrder(
+				parentMessageId,
+				this.getChildren(parentMessageId).length,
+			),
+		};
+		this.#runs.select(spec.id);
+		this.updateTree((tree) => tree.setCursor(target.id));
+		const run = this.startRunRequest(spec, (chat) =>
+			chat.regenerateMessage(target.id, options),
+		);
 		await run.finished;
 	};
 
@@ -314,6 +340,22 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		options?: TreeSendOptions,
 	) => {
 		const { tree, ...request } = options ?? {};
+		if (!input) {
+			const cursorId =
+				tree && "from" in tree
+					? (tree.from ?? null)
+					: this.getSnapshot().cursorId;
+			const cursorMessage = cursorId ? this.getMessage(cursorId) : undefined;
+			if (cursorMessage?.role === "assistant") {
+				const run = this.continueAssistant({
+					follow: tree?.follow ?? cursorId === this.getSnapshot().cursorId,
+					messageId: cursorMessage.id,
+					options: request,
+				});
+				await run.finished;
+				return;
+			}
+		}
 		const run = await this.startRun({
 			follow: tree?.follow,
 			from: tree && "from" in tree ? (tree.from ?? null) : undefined,
@@ -348,7 +390,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			if (!originMessage) {
 				throw new Error("Select a message before starting a run");
 			}
-			this.assertCanStartRun(originMessage.id);
+			this.assertCanGenerateFrom(originMessage);
 			return this.startRunFromParent({
 				follow,
 				id: this.#runs.reserveId(this.generateMessageId),
@@ -361,8 +403,15 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			fallbackId: getInputMessageId(input) ?? this.generateMessageId(),
 			input,
 		});
-		this.assertValidRunParent(message);
-		this.assertCanStartRun(message.id);
+		if (message.role === "assistant") {
+			return this.startAssistantMessage({
+				follow,
+				message,
+				options,
+				parentMessageId: cursorId,
+			});
+		}
+		this.assertCanGenerateFrom(message);
 		this.updateTree((tree) => {
 			const existingMessage = tree.getMessage(message.id);
 			const attachmentId = existingMessage
@@ -460,7 +509,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 				return thread.dataPartSchemas;
 			},
 			generateMessageId: () => thread.generateMessageId(),
-			getRunPath: (runId) => thread.getRunPath(runId),
+			getMessagePath: (messageId) => thread.getMessagePath(messageId),
 			get id() {
 				return thread.id;
 			},
@@ -560,11 +609,9 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		}
 	}
 
-	private assertCanStartRun(parentMessageId: string | null) {
-		const parentMessage =
-			parentMessageId == null ? undefined : this.getMessage(parentMessageId);
-		if (parentMessage) this.assertValidRunParent(parentMessage);
-		this.#runs.assertCanStart(parentMessageId);
+	private assertCanGenerateFrom(parentMessage: TMessage) {
+		this.assertValidRunParent(parentMessage);
+		this.#runs.assertHasCapacity(parentMessage.id);
 	}
 
 	private assertValidRunParent(message: TMessage) {
@@ -582,23 +629,97 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		});
 	}
 
+	private findAssistantOwningPart({
+		id,
+		label,
+		matches,
+	}: {
+		id: string;
+		label: string;
+		matches: (part: TMessage["parts"][number]) => boolean;
+	}) {
+		let owner: TMessage | undefined;
+		for (const { message } of this.getTreeSnapshot().nodes) {
+			if (message.role !== "assistant" || !message.parts.some(matches)) {
+				continue;
+			}
+			if (owner && owner.id !== message.id) {
+				throw new Error(
+					`${label} ${id} appears in more than one assistant message`,
+				);
+			}
+			owner = message;
+		}
+		return owner;
+	}
+
+	private getOrCreateRunForApproval(approvalId: string) {
+		const existing = this.#runs.findForApproval(approvalId);
+		if (existing) return existing;
+		const owner = this.findAssistantOwningPart({
+			id: approvalId,
+			label: "Tool approval",
+			matches: (part) => isToolUIPart(part) && part.approval?.id === approvalId,
+		});
+		if (!owner) {
+			throw new Error(`No run owns tool approval ${approvalId}`);
+		}
+		const run = this.createRunForAssistant(owner.id);
+		if (!run) {
+			throw new Error(`Assistant message ${owner.id} cannot own a run`);
+		}
+		return run;
+	}
+
+	private getOrCreateRunForToolCall(toolCallId: string) {
+		const existing = this.#runs.findForToolCall(toolCallId);
+		if (existing) return existing;
+		const owner = this.findAssistantOwningPart({
+			id: toolCallId,
+			label: "Tool call",
+			matches: (part) => isToolUIPart(part) && part.toolCallId === toolCallId,
+		});
+		if (!owner) {
+			throw new Error(`No run owns tool call ${toolCallId}`);
+		}
+		const run = this.createRunForAssistant(owner.id);
+		if (!run) {
+			throw new Error(`Assistant message ${owner.id} cannot own a run`);
+		}
+		return run;
+	}
+
 	private createRunForSelectedAssistant() {
 		const tree = this.createTree();
 		const messageId = tree.cursorId;
 		if (!messageId) return;
+		return this.createRunForAssistant(messageId, true);
+	}
+
+	private createRunForAssistant(messageId: string, select = false) {
+		const existing = this.#runs.getForResponseMessage(messageId);
+		if (existing) {
+			if (select) this.#runs.select(existing.spec.id);
+			return existing;
+		}
+		const tree = this.createTree();
 		const message = tree.getMessage(messageId);
 		if (!message || message.role !== "assistant") {
 			return;
 		}
-		const parentMessageId = tree.getParentId(messageId);
-		if (!parentMessageId) return;
+		const parentMessageId = tree.getParentId(messageId) ?? null;
+		const siblingOrder = tree
+			.getChildren(parentMessageId)
+			.findIndex((child) => child.id === messageId);
+		if (siblingOrder === -1) {
+			throw new Error(`Message ${messageId} is missing from its sibling order`);
+		}
 
-		const spec: ThreadRunSpec & { parentMessageId: string } = {
+		const spec: ThreadRunSpec = {
+			initialPathMessageId: messageId,
 			messageId,
 			parentMessageId,
-			siblingOrder: tree
-				.getChildren(parentMessageId)
-				.findIndex((child) => child.id === messageId),
+			siblingOrder,
 			id: this.#runs.reserveId(this.generateMessageId),
 		};
 		const record: RunRecord<TMessage> = {
@@ -609,7 +730,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			status: "ready",
 		};
 		this.#runs.add(record);
-		this.#runs.select(spec.id);
+		if (select) this.#runs.select(spec.id);
 		this.indexMessageOwnership(spec.id, message);
 		this.publish();
 		return record;
@@ -626,13 +747,17 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		id,
 		options,
 		parentMessageId,
-	}: Omit<ThreadRunSpec, "messageId" | "parentMessageId" | "siblingOrder"> & {
+	}: Omit<
+		ThreadRunSpec,
+		"initialPathMessageId" | "messageId" | "parentMessageId" | "siblingOrder"
+	> & {
 		follow: boolean;
 		options?: ChatRequestOptions;
 		parentMessageId: string;
 	}) {
 		const spec: ThreadRunSpec & { parentMessageId: string } = {
 			id,
+			initialPathMessageId: parentMessageId,
 			parentMessageId,
 			siblingOrder: this.#runs.reserveSiblingOrder(
 				parentMessageId,
@@ -643,15 +768,14 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			this.#runs.select(id);
 			this.updateTree((tree) => tree.setCursor(parentMessageId));
 		}
-		return this.startRunRequest(spec, options);
+		return this.startRunRequest(spec, (chat) => chat.start(options));
 	}
 
 	private startRunRequest(
-		spec: ThreadRunSpec & { parentMessageId: string },
-		options?: ChatRequestOptions,
+		spec: ThreadRunSpec,
+		start: (chat: ThreadRunChat<TMessage>) => Promise<void>,
 	) {
-		const parentMessage = this.getMessage(spec.parentMessageId);
-		if (!parentMessage) {
+		if (spec.parentMessageId && !this.getMessage(spec.parentMessageId)) {
 			throw new Error(`Unknown message ${spec.parentMessageId}`);
 		}
 		const chat = new ThreadRunChat(this.#runHost, spec);
@@ -664,9 +788,68 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		};
 		this.#runs.add(record);
 		this.publish();
-		const finished = chat.start(options).finally(() => this.publish());
+		const finished = start(chat).finally(() => this.publish());
 		record.finished = finished;
 		return this.createRunHandle(record);
+	}
+
+	private continueAssistant({
+		follow,
+		messageId,
+		options,
+	}: {
+		follow: boolean;
+		messageId: string;
+		options?: ChatRequestOptions;
+	}) {
+		const run = this.createRunForAssistant(messageId);
+		if (!run) {
+			throw new Error(`Message ${messageId} is not an assistant message`);
+		}
+		if (run.status === "submitted" || run.status === "streaming") {
+			throw new Error(
+				`Assistant message ${messageId} already has an active run`,
+			);
+		}
+		this.#runs.assertHasCapacity(run.spec.parentMessageId);
+		if (follow) {
+			this.#runs.select(run.spec.id);
+			this.updateTree((tree) => tree.setCursor(messageId));
+		}
+		const finished = run.chat.start(options).finally(() => this.publish());
+		run.finished = finished;
+		this.publish();
+		return this.createRunHandle(run);
+	}
+
+	private startAssistantMessage({
+		follow,
+		message,
+		options,
+		parentMessageId,
+	}: {
+		follow: boolean;
+		message: TMessage;
+		options?: ChatRequestOptions;
+		parentMessageId: string | null;
+	}) {
+		this.#runs.assertHasCapacity(parentMessageId);
+		const spec: ThreadRunSpec = {
+			id: this.#runs.reserveId(this.generateMessageId),
+			initialPathMessageId: parentMessageId,
+			messageId: message.id,
+			parentMessageId,
+			siblingOrder: this.#runs.reserveSiblingOrder(
+				parentMessageId,
+				this.getChildren(parentMessageId).length,
+			),
+		};
+		if (follow) {
+			this.#runs.select(spec.id);
+		}
+		return this.startRunRequest(spec, (chat) =>
+			chat.startWithMessage(message, options),
+		);
 	}
 
 	private createRunHandle(run: RunRecord<TMessage>): ThreadRunHandle {
@@ -684,7 +867,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		run: RunRecord<TMessage>,
 		options: ChatRequestOptions,
 	) {
-		this.assertCanStartRun(run.spec.parentMessageId);
+		this.#runs.assertHasCapacity(run.spec.parentMessageId);
 		const finished = run.chat
 			.resumeStream(options)
 			.finally(() => this.publish());

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -10,6 +10,7 @@ import {
 
 export type ThreadRunSpec = {
 	id: string;
+	initialPathMessageId: string | null;
 	messageId?: string;
 	parentMessageId: string | null;
 	siblingOrder: number;
@@ -26,7 +27,7 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	sendAutomaticallyWhen: ChatInit<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
 	generateMessageId: () => string;
-	getRunPath: (runId: string) => TMessage[];
+	getMessagePath: (messageId: string | null) => TMessage[];
 	updateRunPath: (messages: TMessage[]) => void;
 	registerToolCall: (runId: string, toolCallId: string) => void;
 	removeMessage: (messageId: string) => void;
@@ -40,11 +41,13 @@ class ThreadRunState<TMessage extends UIMessage>
 {
 	#error: Error | undefined;
 	readonly #host: ThreadRunHost<TMessage>;
+	#messages: TMessage[];
 	readonly #spec: ThreadRunSpec;
 	#status: ChatStatus = "ready";
 
 	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
 		this.#host = host;
+		this.#messages = host.getMessagePath(spec.initialPathMessageId);
 		this.#spec = spec;
 	}
 
@@ -58,10 +61,11 @@ class ThreadRunState<TMessage extends UIMessage>
 	}
 
 	get messages() {
-		return this.#host.getRunPath(this.#spec.id);
+		return this.#messages;
 	}
 
 	set messages(messages: TMessage[]) {
+		this.#messages = messages;
 		this.#host.updateRunPath(messages);
 	}
 
@@ -75,18 +79,20 @@ class ThreadRunState<TMessage extends UIMessage>
 	}
 
 	popMessage = () => {
-		const lastMessage = this.messages.at(-1);
+		const lastMessage = this.#messages.pop();
 		if (lastMessage) this.#host.removeMessage(lastMessage.id);
 	};
 
 	pushMessage = (message: TMessage) => {
+		this.#messages.push(message);
 		this.writeMessage(message);
 	};
 
 	replaceMessage = (index: number, message: TMessage) => {
-		if (index !== this.messages.length - 1) {
+		if (index !== this.#messages.length - 1) {
 			throw new Error("A thread run can only replace its current response");
 		}
+		this.#messages[index] = message;
 		this.writeMessage(message);
 	};
 
@@ -108,7 +114,9 @@ export class ThreadRunChat<
 				return host.transport.sendMessages({
 					...options,
 					messageId:
-						spec.messageId === undefined ? undefined : options.messageId,
+						spec.messageId === undefined && options.trigger === "submit-message"
+							? undefined
+							: options.messageId,
 				});
 			},
 		};
@@ -124,7 +132,7 @@ export class ThreadRunChat<
 			onFinish: (event) => {
 				host.onFinish?.({
 					...event,
-					messages: host.getRunPath(spec.id),
+					messages: host.getMessagePath(spec.messageId ?? spec.parentMessageId),
 				});
 			},
 			onToolCall: async (event) => {
@@ -140,5 +148,16 @@ export class ThreadRunChat<
 
 	start(options?: ChatRequestOptions) {
 		return this.sendMessage(undefined, options);
+	}
+
+	startWithMessage(
+		message: NonNullable<Parameters<AbstractChat<TMessage>["sendMessage"]>[0]>,
+		options?: ChatRequestOptions,
+	) {
+		return this.sendMessage(message, options);
+	}
+
+	regenerateMessage(messageId: string, options?: ChatRequestOptions) {
+		return this.regenerate({ ...options, messageId });
 	}
 }

--- a/packages/thread/src/run-registry.ts
+++ b/packages/thread/src/run-registry.ts
@@ -32,7 +32,7 @@ export class RunRegistry<TMessage extends UIMessage> {
 		this.#runsById.set(record.spec.id, record);
 	}
 
-	assertCanStart(parentMessageId: string | null) {
+	assertHasCapacity(parentMessageId: string | null) {
 		const activeRuns = this.getActive();
 		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
 			throw new Error("Cannot start run: max active runs reached");
@@ -62,10 +62,9 @@ export class RunRegistry<TMessage extends UIMessage> {
 		);
 	}
 
-	getForApproval(approvalId: string) {
+	findForApproval(approvalId: string) {
 		const runId = this.#runIdByApprovalId.get(approvalId);
-		if (!runId) throw new Error(`No run owns tool approval ${approvalId}`);
-		return this.require(runId);
+		return runId ? this.#runsById.get(runId) : undefined;
 	}
 
 	getForMessage(messageId: string) {
@@ -82,10 +81,15 @@ export class RunRegistry<TMessage extends UIMessage> {
 		);
 	}
 
-	getForToolCall(toolCallId: string) {
+	findForToolCall(toolCallId: string) {
 		const runId = this.#runIdByToolCallId.get(toolCallId);
-		if (!runId) throw new Error(`No run owns tool call ${toolCallId}`);
-		return this.require(runId);
+		return runId ? this.#runsById.get(runId) : undefined;
+	}
+
+	getForResponseMessage(messageId: string) {
+		return this.values()
+			.reverse()
+			.find((candidate) => candidate.spec.messageId === messageId);
 	}
 
 	getInsertionIndex({

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -73,8 +73,7 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 		this.tree = new MessageTree({ messages: [userMessage] });
 	}
 
-	getRunPath = () =>
-		this.tree.getPath(this.spec.messageId ?? this.spec.parentMessageId);
+	getMessagePath = (messageId: string | null) => this.tree.getPath(messageId);
 	updateRunPath = (messages: UIMessage[]) => {
 		this.tree.updatePath(messages);
 	};
@@ -109,6 +108,7 @@ function userMessage(): UIMessage {
 function createSpec(): ThreadRunSpec {
 	return {
 		id: "run-1",
+		initialPathMessageId: "user-1",
 		parentMessageId: "user-1",
 		siblingOrder: 0,
 	};

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -10,6 +10,7 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 	readonly requests: Array<{
 		abortSignal: AbortSignal | undefined;
 		controller: ReadableStreamDefaultController<UIMessageChunk>;
+		options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0];
 	}> = [];
 	#reconnectStream: ReadableStream<UIMessageChunk> | null = null;
 
@@ -20,6 +21,7 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 					this.requests.push({
 						abortSignal: options.abortSignal,
 						controller,
+						options,
 					});
 					options.abortSignal?.addEventListener(
 						"abort",
@@ -294,23 +296,61 @@ describe("Thread", () => {
 		expect(chat.getSnapshot().runs).toHaveLength(0);
 	});
 
-	test("rejects an assistant input without mutating the tree", async () => {
+	test("continues an explicit assistant input in the same tree node", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({ messages: [user("user-1")], transport });
 
-		await expect(
-			chat.sendMessage({
-				id: "assistant-input",
-				parts: [{ text: "prebuilt response", type: "text" }],
-				role: "assistant",
-			}),
-		).rejects.toThrow(
-			"Cannot start a new run directly from assistant message assistant-input; attach an input message first",
+		const sending = chat.sendMessage({
+			id: "assistant-input",
+			parts: [{ text: "prebuilt response", type: "text" }],
+			role: "assistant",
+		});
+		await waitFor(() => transport.requests.length === 1);
+
+		expect(transport.requests[0]?.options.trigger).toBe("submit-message");
+		expect(transport.requests[0]?.options.messageId).toBeUndefined();
+		expect(transport.requests[0]?.options.messages.map(({ id }) => id)).toEqual(
+			["user-1", "assistant-input"],
 		);
-		expect(transport.requests).toHaveLength(0);
-		expect(chat.getMessage("assistant-input")).toBeUndefined();
-		expect(chat.getSnapshot().cursorId).toBe("user-1");
-		expect(chat.getSnapshot().runs).toHaveLength(0);
+		expect(chat.getParent("assistant-input")?.id).toBe("user-1");
+		expect(chat.getSnapshot().cursorId).toBe("assistant-input");
+
+		transport.emitText(0, "assistant-input", "continued");
+		await sending;
+
+		expect(chat.getChildren("user-1").map(({ id }) => id)).toEqual([
+			"assistant-input",
+		]);
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-input"))),
+		).toBe("prebuilt responsecontinued");
+	});
+
+	test("continues the selected assistant without creating a sibling", async () => {
+		const transport = new ControlledTransport();
+		const assistant = {
+			...user("assistant-1"),
+			role: "assistant" as const,
+		};
+		const chat = new Thread({
+			messages: [user("user-1"), assistant],
+			transport,
+		});
+
+		const sending = chat.sendMessage();
+		await waitFor(() => transport.requests.length === 1);
+
+		expect(transport.requests[0]?.options.trigger).toBe("submit-message");
+		expect(transport.requests[0]?.options.messageId).toBe("assistant-1");
+		transport.emitText(0, "assistant-1", " continued");
+		await sending;
+
+		expect(chat.getChildren("user-1").map(({ id }) => id)).toEqual([
+			"assistant-1",
+		]);
+		expect(getMessageText(requireMessage(chat.getMessage("assistant-1")))).toBe(
+			"assistant-1 continued",
+		);
 	});
 
 	test("keeps hidden branches when reconciling the selected path", () => {
@@ -496,6 +536,11 @@ describe("Thread", () => {
 
 		const regeneration = chat.regenerate({ messageId: "assistant-1" });
 		await waitFor(() => transport.requests.length === 2);
+		expect(transport.requests[1]?.options.trigger).toBe("regenerate-message");
+		expect(transport.requests[1]?.options.messageId).toBe("assistant-1");
+		expect(transport.requests[1]?.options.messages.map(({ id }) => id)).toEqual(
+			["user-1"],
+		);
 		transport.emitText(1, "assistant-2", "second");
 		await regeneration;
 
@@ -504,6 +549,50 @@ describe("Thread", () => {
 			"assistant-2",
 		]);
 		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
+	});
+
+	test("regenerates a root assistant as a root sibling", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({
+			messages: [{ ...user("assistant-1"), role: "assistant" }],
+			transport,
+		});
+
+		const regeneration = chat.regenerate({ messageId: "assistant-1" });
+		await waitFor(() => transport.requests.length === 1);
+		expect(transport.requests[0]?.options.trigger).toBe("regenerate-message");
+		expect(transport.requests[0]?.options.messageId).toBe("assistant-1");
+		expect(transport.requests[0]?.options.messages).toEqual([]);
+
+		transport.emitText(0, "assistant-2", "second");
+		await regeneration;
+
+		expect(chat.getSiblings("assistant-1").map(({ id }) => id)).toEqual([
+			"assistant-1",
+			"assistant-2",
+		]);
+		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
+	});
+
+	test("does not follow regeneration after navigating to another branch", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({
+			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],
+			transport,
+		});
+		chat.addMessage(user("other-root"), null);
+
+		const regeneration = chat.regenerate({ messageId: "assistant-1" });
+		await waitFor(() => transport.requests.length === 1);
+		chat.setCursor("other-root");
+		transport.emitText(0, "assistant-2", "second");
+		await regeneration;
+
+		expect(chat.getParent("assistant-2")?.id).toBe("user-1");
+		expect(chat.getSnapshot().cursorId).toBe("other-root");
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual([
+			"other-root",
+		]);
 	});
 
 	test("rejects an unknown explicit regeneration target", async () => {
@@ -533,7 +622,7 @@ describe("Thread", () => {
 		await expect(
 			chat.regenerate({ messageId: "assistant-child" }),
 		).rejects.toThrow(
-			"Cannot start a new run directly from assistant message assistant-parent; attach an input message first",
+			"Cannot regenerate assistant message assistant-child because its parent assistant-parent is also an assistant",
 		);
 		expect(transport.requests).toHaveLength(0);
 		expect(chat.getSnapshot().runs).toHaveLength(0);
@@ -636,6 +725,52 @@ describe("Thread", () => {
 		);
 	});
 
+	test("reconstructs tool and approval ownership after restoring a tree", async () => {
+		const source = new Thread();
+		source.addMessage(user("user-1"), null);
+		source.addMessage(
+			{
+				id: "assistant-1",
+				parts: [
+					{
+						approval: { id: "approval-1" },
+						input: { value: 1 },
+						state: "approval-requested",
+						toolCallId: "tool-1",
+						toolName: "test-tool",
+						type: "dynamic-tool",
+					},
+				],
+				role: "assistant",
+			},
+			"user-1",
+		);
+		source.setCursor("assistant-1");
+		const restored = new Thread();
+		restored.restore(source.getTreeSnapshot());
+
+		await restored.addToolApprovalResponse({
+			approved: true,
+			id: "approval-1",
+		});
+		await restored.addToolOutput({
+			output: "restored output",
+			tool: "test-tool",
+			toolCallId: "tool-1",
+		});
+
+		expect(restored.getMessage("assistant-1")?.parts).toContainEqual(
+			expect.objectContaining({
+				approval: expect.objectContaining({
+					approved: true,
+					id: "approval-1",
+				}),
+				output: "restored output",
+				toolCallId: "tool-1",
+			}),
+		);
+	});
+
 	test("enforces the global concurrency limit before resuming", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({
@@ -701,5 +836,70 @@ describe("Thread", () => {
 			"resumed",
 		);
 		expect(transport.lastReconnectOptions?.body).toBeUndefined();
+	});
+
+	test("resumes a restored root assistant", async () => {
+		const transport = new ResumeTransport();
+		const chat = new Thread({
+			initialTree: {
+				cursorId: "assistant-root",
+				nodes: [
+					{
+						message: {
+							id: "assistant-root",
+							parts: [],
+							role: "assistant",
+						},
+						parentId: null,
+					},
+				],
+				version: 1,
+			},
+			transport,
+		});
+
+		await chat.resumeStream();
+
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-root"))),
+		).toBe("resumed");
+	});
+
+	test("resumes a restored assistant whose parent is an assistant", async () => {
+		const transport = new ResumeTransport();
+		const chat = new Thread({
+			initialTree: {
+				cursorId: "assistant-child",
+				nodes: [
+					{
+						message: {
+							id: "assistant-parent",
+							parts: [{ text: "parent", type: "text" }],
+							role: "assistant",
+						},
+						parentId: null,
+					},
+					{
+						message: {
+							id: "assistant-child",
+							parts: [],
+							role: "assistant",
+						},
+						parentId: "assistant-parent",
+					},
+				],
+				version: 1,
+			},
+			transport,
+		});
+
+		await chat.resumeStream();
+
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-parent"))),
+		).toBe("parent");
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-child"))),
+		).toBe("resumed");
 	});
 });


### PR DESCRIPTION
## Summary
- Refactors the ChatJS store to carry the package tree snapshot.
- Derives visible messages, siblings, and tree indexes from one canonical structure.
- Preserves existing store consumers ahead of adopting `useThread`.

## Behavior
Refactor only. No intended user-visible behavior change.

## Verification
- Chat store unit tests pass at the stack tip.

## Review focus
Snapshot synchronization and preservation of current store semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores a canonical `MessageTreeSnapshot` from `@chatjs/thread` in the ChatJS store and derives navigation, sibling order, and indexes from ordered snapshots. Adds ordered snapshot merging and visible-path hydration, and finalizes assistant continuation, native regeneration, and restore-safe tool/approval ownership, with no user-visible changes.

- **Refactors**
  - Add `treeSnapshot`, `treeSnapshotSignature`, and `setTreeSnapshot`; merge incoming snapshots with existing state; rebuild the visible path from `cursorId` (empty when `null`); no-op when unchanged.
  - Build snapshots from messages; derive `childrenMap`, parent links, and sibling order (by `parallelIndex`, then time); recover invalid/cyclic topology as extra roots; preserve paths of any depth; hydrate an empty visible path from server trees.
  - Merge/update rules: preserve hidden branches and optimistic/local nodes; keep metadata when updates omit it; infer assistant fallback metadata from the parent; replace selected placeholders with completed server content (clears `activeStreamId`); dedupe root user siblings.
  - Streaming: while `streaming`/`submitted`, update only the snapshot/indexes; `setMessagesWithEpoch`/`setAllMessages`/`addMessageToTree` rebuild the snapshot and indexes, reset selector caches and `_throttledMessages`, update `_messageIndex`.
  - Navigation uses snapshot-derived indexes for `switchToSibling`/`switchToMessage`; `getParallelGroupInfo` is available before any assistant exists.

- **New Features**
  - Assistant continuation: `sendMessage()` on a selected assistant continues that node; passing an explicit assistant message streams into the same message ID; branching still requires a new input.
  - Regeneration: `regenerate({ messageId })` uses AI SDK’s `regenerate-message` trigger, creates a sibling replacement (including root assistants), and only auto-follows when the cursor still targets the message; rejects assistant-with-assistant parent until an SDK fix.
  - Restore and resume: reconstruct tool/approval ownership after restoring a tree; resume restored assistants (root or with assistant parents) without changing topology.

<sup>Written for commit edf3932536c64b567d9e1dcdc5974c3946ab0e93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversation thread and branch navigation, including more reliable sibling ordering.
  * Preserved message metadata when updates are incomplete or omitted.
  * Replaced placeholder assistant messages with completed server responses more consistently.
  * Improved handling of tree snapshots and message visibility during streaming and editing.

* **Bug Fixes**
  * Fixed branch navigation and synchronization issues that could cause messages or metadata to appear incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. #235
5. #236
6. #237
7. #238
8. #239
9. #261
10. #262
11. **#240** 👈 current
12. #241
13. #242
14. #243
15. #244
16. #263
17. #245
18. #246
19. #247
20. #248
21. #249
22. #250
23. #251
24. #252
25. #253
26. #254
<!-- stack:links:end -->