### PR TITLE
Threads 11: Mount useThread in ChatJS

### DIFF
--- a/apps/chat/components/chat-sync.tsx
+++ b/apps/chat/components/chat-sync.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DefaultChatTransport } from "ai";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { toast } from "sonner";
 import { useSaveMessageMutation } from "@/hooks/chat-sync-hooks";
 import { useCompleteDataPart } from "@/hooks/use-complete-data-part";
@@ -11,7 +11,7 @@ import type { ApplicationThread } from "@/lib/application-thread";
 import { useChat } from "@/lib/stores/base";
 import { useChatPersistenceActions } from "@/lib/stores/hooks-chat-persistence";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
-import { fetchWithErrorHandlers, generateUUID } from "@/lib/utils";
+import { fetchWithErrorHandlers } from "@/lib/utils";
 import { useSession } from "@/providers/session-provider";
 
 function isResumableActiveStreamId(activeStreamId: string | null | undefined) {
@@ -31,24 +31,17 @@ export function ChatSync({
   const { setDataStream } = useDataStream();
 
   const isAuthenticated = !!session?.user;
-  const threadInitialMessages = thread.getSnapshot().messages;
   const hasReportedConfirmationRef = useRef(false);
-
-  const lastMessage = threadInitialMessages.at(-1);
+  const lastMessage = thread.getSnapshot().messages.at(-1);
   const lastMessageRef = useRef(lastMessage);
   lastMessageRef.current = lastMessage;
   const isLastMessagePartial = isResumableActiveStreamId(
     lastMessage?.metadata?.activeStreamId
   );
 
-  const chat = useChat<ChatMessage>({
+  useChat<ChatMessage>({
     experimental_throttle: 100,
-    id,
-    // TODO: this is a special "snapshot" value in the store that is only updated
-    // on store init + sibling switch. Once the store can guarantee up-to-date
-    // messages at ChatSync remount time, we can likely remove this override.
-    messages: threadInitialMessages,
-    generateId: generateUUID,
+    thread,
     onFinish: ({ message }) => {
       saveChatMessage({ message, chatId: id });
     },
@@ -96,12 +89,6 @@ export function ChatSync({
       toast.error(message, description ? { description } : undefined);
     },
   });
-
-  // PR #241 replaces this compatibility bridge by mounting useThread on the
-  // same ApplicationThread controller.
-  useEffect(() => {
-    thread.setMessages(chat.messages);
-  }, [chat.messages, thread]);
 
   useCompleteDataPart();
 

--- a/apps/chat/lib/stores/base/hooks.ts
+++ b/apps/chat/lib/stores/base/hooks.ts
@@ -3,6 +3,7 @@
 "use client";
 
 import type { UIMessage, UseChatHelpers } from "@ai-sdk/react";
+import type { UseThreadHelpers } from "@chatjs/thread/react";
 import type { ChatStatus } from "ai";
 import * as React from "react";
 import { createContext, useCallback, useContext, useRef } from "react";
@@ -255,6 +256,7 @@ export interface StoreState<TMessage extends UIMessage = UIMessage> {
 
   // Transient data methods
   setTransientDataPart: (type: string, data: any) => void;
+  startRun?: UseThreadHelpers<TMessage>["tree"]["startRun"];
   status: ChatStatus;
   stop?: UseChatHelpers<TMessage>["stop"];
 }
@@ -304,6 +306,7 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
 
       // Chat helpers
       sendMessage: undefined,
+      startRun: undefined,
       regenerate: undefined,
       stop: undefined,
       resumeStream: undefined,
@@ -796,6 +799,11 @@ const fallbackSendMessage = async () => {
     "sendMessage not configured - make sure useChat is called with transport"
   );
 };
+const fallbackStartRun = async () => {
+  throw new Error(
+    "startRun not configured - make sure useChat is called with transport"
+  );
+};
 const fallbackRegenerate = async () => {
   debug.warn(
     "regenerate not configured - make sure useChat is called with transport"
@@ -834,6 +842,7 @@ export type ChatActions<TMessage extends UIMessage = UIMessage> = {
   setNewChat: (id: string, messages: TMessage[]) => void;
   reset: () => void;
   sendMessage: UseChatHelpers<TMessage>["sendMessage"];
+  startRun: UseThreadHelpers<TMessage>["tree"]["startRun"];
   regenerate: UseChatHelpers<TMessage>["regenerate"];
   stop: UseChatHelpers<TMessage>["stop"];
   resumeStream: UseChatHelpers<TMessage>["resumeStream"];
@@ -857,6 +866,7 @@ export const useChatActions = <
       setNewChat: state.setNewChat,
       reset: state.reset,
       sendMessage: state.sendMessage || fallbackSendMessage,
+      startRun: state.startRun || fallbackStartRun,
       regenerate: state.regenerate || fallbackRegenerate,
       stop: state.stop || fallbackStop,
       resumeStream: state.resumeStream || fallbackResumeStream,

--- a/apps/chat/lib/stores/base/use-chat.ts
+++ b/apps/chat/lib/stores/base/use-chat.ts
@@ -4,13 +4,27 @@ import {
   type UIMessage,
   type UseChatHelpers,
   type UseChatOptions,
-  useChat as useOriginalChat,
 } from "@ai-sdk/react";
+import {
+  type MessageTreeSnapshot,
+  ROOT_PARENT_ID,
+  type ThreadChatOptions,
+} from "@chatjs/thread";
+import {
+  type UseThreadHelpers,
+  type UseThreadOptions,
+  useThread as useOriginalChat,
+} from "@chatjs/thread/react";
+import type { ChatInit } from "ai";
 import { useCallback, useEffect, useRef } from "react";
-import { useStore } from "zustand";
 import { type StoreState, useChatStoreApi } from "./hooks";
 
-export type { UseChatHelpers, UseChatOptions };
+export type {
+  UseChatHelpers,
+  UseChatOptions,
+  UseThreadHelpers,
+  UseThreadOptions,
+};
 
 // Type for a compatible chat store
 export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
@@ -21,26 +35,95 @@ export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
 
 export type UseChatOptionsWithPerformance<
   TMessage extends UIMessage = UIMessage,
-> = UseChatOptions<TMessage> & {
-  store?: CompatibleChatStore<TMessage>;
-  // Additional performance options
-  enableBatching?: boolean;
-};
+> = ChatInit<TMessage> & {
+  experimental_throttle?: number;
+  resume?: boolean;
+} & Pick<ThreadChatOptions<TMessage>, "concurrency" | "initialTree"> & {
+    store?: CompatibleChatStore<TMessage>;
+    // Additional performance options
+    enableBatching?: boolean;
+  };
+
+function getInitialTree<TMessage extends UIMessage>(
+  store: CompatibleChatStore<TMessage> | { getState?: () => any },
+  fallbackMessages: TMessage[] | undefined,
+  explicitInitialTree: MessageTreeSnapshot<TMessage> | undefined
+) {
+  if (explicitInitialTree) {
+    return explicitInitialTree;
+  }
+
+  const state = (store as any).getState?.();
+  const messages = fallbackMessages ?? [];
+  const childrenByParentId = Object.fromEntries(
+    messages.map((message, index, allMessages) => [
+      index === 0 ? ROOT_PARENT_ID : allMessages[index - 1]?.id,
+      [message.id],
+    ])
+  );
+
+  return (
+    (state?.treeSnapshot as MessageTreeSnapshot<TMessage> | undefined) ??
+    ({
+      childrenByParentId,
+      cursorId: messages.at(-1)?.id ?? null,
+      messagesById: Object.fromEntries(
+        messages.map((message) => [message.id, message])
+      ),
+      parentById: Object.fromEntries(
+        messages.map((message, index, allMessages) => [
+          message.id,
+          index === 0 ? null : allMessages[index - 1]?.id,
+        ])
+      ),
+      rootIds: messages[0] ? [messages[0].id] : [],
+      version: 1,
+    } satisfies MessageTreeSnapshot<TMessage>)
+  );
+}
+
+function messagesSignature<TMessage extends UIMessage>(messages: TMessage[]) {
+  return JSON.stringify(messages);
+}
+
+function treeSignature<TMessage extends UIMessage>(
+  snapshot: MessageTreeSnapshot<TMessage>
+) {
+  return JSON.stringify({
+    childrenByParentId: snapshot.childrenByParentId,
+    cursorId: snapshot.cursorId,
+    messagesById: snapshot.messagesById,
+    parentById: snapshot.parentById,
+    rootIds: snapshot.rootIds,
+  });
+}
 
 export function useChat<TMessage extends UIMessage = UIMessage>(
   options: UseChatOptionsWithPerformance<TMessage> = {} as UseChatOptionsWithPerformance<TMessage>
-): UseChatHelpers<TMessage> {
+): UseThreadHelpers<TMessage> {
   const {
     store: customStore,
     enableBatching = true,
+    initialTree,
     ...originalOptions
   } = options;
 
   const originalOnData = (options as any).onData;
+  const externalMessages = (originalOptions as any).messages as
+    | TMessage[]
+    | undefined;
 
   // Use custom store if provided, otherwise use the context store
   const contextStore = useChatStoreApi<TMessage>();
   const store = customStore || contextStore;
+  const initialTreeRef = useRef<MessageTreeSnapshot<TMessage> | null>(null);
+  if (!initialTreeRef.current) {
+    initialTreeRef.current = getInitialTree(
+      store,
+      (originalOptions as any).messages as TMessage[] | undefined,
+      initialTree
+    );
+  }
 
   // Wrap onData to capture transient data parts
   const wrappedOnData = useCallback(
@@ -71,11 +154,18 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
 
   const chatHelpers = useOriginalChat<TMessage>({
     ...originalOptions,
+    initialTree: initialTreeRef.current,
     onData: wrappedOnData,
-  });
+  }) as UseThreadHelpers<TMessage>;
 
   const storeRef = useRef<CompatibleChatStore<TMessage> | typeof contextStore>(
     store
+  );
+
+  const lastSyncedStateRef = useRef<string | null>(null);
+  const lastSyncedTreeRef = useRef<string | null>(null);
+  const lastExternalMessagesRef = useRef<string | null>(
+    externalMessages ? messagesSignature(externalMessages) : null
   );
 
   // Memoize the sync function to avoid recreating it on every render
@@ -97,18 +187,40 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     }
   }, []);
 
+  const setMessages = useCallback<UseThreadHelpers<TMessage>["setMessages"]>(
+    (messagesOrUpdater) => {
+      const currentMessages =
+        ((store as any).getState?.().messages as TMessage[] | undefined) ??
+        chatHelpers.messages;
+      const nextMessages =
+        typeof messagesOrUpdater === "function"
+          ? messagesOrUpdater(currentMessages)
+          : messagesOrUpdater;
+
+      chatHelpers.setMessages(nextMessages);
+    },
+    [chatHelpers.messages, chatHelpers.setMessages, store]
+  );
+
+  useEffect(() => {
+    if (!externalMessages) {
+      return;
+    }
+
+    const externalSignature = messagesSignature(externalMessages);
+    if (lastExternalMessagesRef.current === externalSignature) {
+      return;
+    }
+
+    lastExternalMessagesRef.current = externalSignature;
+    if (messagesSignature(chatHelpers.messages) !== externalSignature) {
+      setMessages(externalMessages);
+    }
+  }, [externalMessages, chatHelpers.messages, setMessages]);
+
   // Simple sync - but don't overwrite store messages if chat has no messages
   // This preserves server-side messages during hydration
   useEffect(() => {
-    const currentStoreState = (store as any).getState?.() || { messages: [] };
-
-    // Skip syncing messages if store has messages but chat doesn't
-    // This prevents clearing server-side messages on hydration
-    const shouldSyncMessages = !(
-      currentStoreState.messages?.length > 0 &&
-      chatHelpers.messages.length === 0
-    );
-
     // Only sync state data
     const stateData: any = {
       id: chatHelpers.id,
@@ -116,36 +228,54 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
       status: chatHelpers.status,
     };
 
-    // Only add messages to sync object if we should sync them
-    if (shouldSyncMessages) {
-      stateData.messages = chatHelpers.messages;
-    }
-
     // Sync functions separately and only once
     const functionsData = {
       sendMessage: chatHelpers.sendMessage,
+      startRun: chatHelpers.tree.startRun,
       regenerate: chatHelpers.regenerate,
       stop: chatHelpers.stop,
       resumeStream: chatHelpers.resumeStream,
       addToolResult: chatHelpers.addToolResult,
-      setMessages: chatHelpers.setMessages,
+      setMessages,
       clearError: chatHelpers.clearError,
     };
 
     const chatState = { ...stateData, ...functionsData };
+    const syncSignature = JSON.stringify({
+      error: chatHelpers.error?.message,
+      id: chatHelpers.id,
+      status: chatHelpers.status,
+    });
 
-    if (enableBatching) {
-      // Use requestAnimationFrame for batching if available
-      if (
-        typeof window !== "undefined" &&
-        typeof window.requestAnimationFrame === "function"
-      ) {
-        window.requestAnimationFrame(() => syncState(chatState));
+    if (lastSyncedStateRef.current !== syncSignature) {
+      lastSyncedStateRef.current = syncSignature;
+
+      if (enableBatching) {
+        // Use requestAnimationFrame for batching if available
+        if (
+          typeof window !== "undefined" &&
+          typeof window.requestAnimationFrame === "function"
+        ) {
+          window.requestAnimationFrame(() => {
+            syncState(chatState);
+          });
+        } else {
+          syncState(chatState);
+        }
       } else {
         syncState(chatState);
       }
-    } else {
-      syncState(chatState);
+    }
+
+    const setTreeSnapshot = (store as any).getState?.().setTreeSnapshot;
+    if (typeof setTreeSnapshot === "function") {
+      const snapshot = chatHelpers.tree.getSnapshot();
+      const signature = treeSignature(snapshot);
+
+      if (lastSyncedTreeRef.current !== signature) {
+        lastSyncedTreeRef.current = signature;
+        setTreeSnapshot(snapshot);
+      }
     }
   }, [
     // Only depend on data that actually changes, not function references
@@ -158,22 +288,17 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     chatHelpers.resumeStream,
     chatHelpers.clearError,
     chatHelpers.sendMessage,
+    chatHelpers.tree.startRun,
     store,
-    chatHelpers.setMessages,
+    setMessages,
     chatHelpers.stop,
     chatHelpers.regenerate,
     chatHelpers.addToolResult,
   ]);
 
-  // Return the store's messages as the source of truth, not chatHelpers.messages
-  // Subscribe to store messages so this is reactive
-  const storeMessages = useStore(
-    store as any,
-    (state: any) => state.messages as TMessage[]
-  );
-
   return {
     ...chatHelpers,
-    messages: storeMessages || chatHelpers.messages,
+    setMessages,
+    messages: chatHelpers.messages,
   };
 }

--- a/apps/chat/lib/stores/base/use-chat.ts
+++ b/apps/chat/lib/stores/base/use-chat.ts
@@ -5,11 +5,7 @@ import {
   type UseChatHelpers,
   type UseChatOptions,
 } from "@ai-sdk/react";
-import {
-  type MessageTreeSnapshot,
-  ROOT_PARENT_ID,
-  type ThreadChatOptions,
-} from "@chatjs/thread";
+import { type MessageTreeSnapshot, type ThreadInit } from "@chatjs/thread";
 import {
   type UseThreadHelpers,
   type UseThreadOptions,
@@ -27,10 +23,14 @@ export type {
 };
 
 // Type for a compatible chat store
+type CompatibleChatStoreState<TMessage extends UIMessage> =
+  StoreState<TMessage> & {
+    setTreeSnapshot?: (snapshot: MessageTreeSnapshot<TMessage>) => void;
+    treeSnapshot?: MessageTreeSnapshot<TMessage>;
+  };
+
 export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
-  _syncState?: (partial: Partial<StoreState<TMessage>>) => void;
-  setState?: (partial: Partial<StoreState<TMessage>>) => void;
-  <T>(selector: (state: StoreState<TMessage>) => T): T;
+  getState: () => CompatibleChatStoreState<TMessage>;
 }
 
 export type UseChatOptionsWithPerformance<
@@ -38,14 +38,14 @@ export type UseChatOptionsWithPerformance<
 > = ChatInit<TMessage> & {
   experimental_throttle?: number;
   resume?: boolean;
-} & Pick<ThreadChatOptions<TMessage>, "concurrency" | "initialTree"> & {
+} & Pick<ThreadInit<TMessage>, "concurrency" | "initialTree"> & {
     store?: CompatibleChatStore<TMessage>;
     // Additional performance options
     enableBatching?: boolean;
   };
 
 function getInitialTree<TMessage extends UIMessage>(
-  store: CompatibleChatStore<TMessage> | { getState?: () => any },
+  store: CompatibleChatStore<TMessage>,
   fallbackMessages: TMessage[] | undefined,
   explicitInitialTree: MessageTreeSnapshot<TMessage> | undefined
 ) {
@@ -53,94 +53,67 @@ function getInitialTree<TMessage extends UIMessage>(
     return explicitInitialTree;
   }
 
-  const state = (store as any).getState?.();
+  const state = store.getState();
   const messages = fallbackMessages ?? [];
-  const childrenByParentId = Object.fromEntries(
-    messages.map((message, index, allMessages) => [
-      index === 0 ? ROOT_PARENT_ID : allMessages[index - 1]?.id,
-      [message.id],
-    ])
-  );
 
   return (
-    (state?.treeSnapshot as MessageTreeSnapshot<TMessage> | undefined) ??
+    state.treeSnapshot ??
     ({
-      childrenByParentId,
       cursorId: messages.at(-1)?.id ?? null,
-      messagesById: Object.fromEntries(
-        messages.map((message) => [message.id, message])
-      ),
-      parentById: Object.fromEntries(
-        messages.map((message, index, allMessages) => [
-          message.id,
-          index === 0 ? null : allMessages[index - 1]?.id,
-        ])
-      ),
-      rootIds: messages[0] ? [messages[0].id] : [],
+      nodes: messages.map((message, index, allMessages) => ({
+        message,
+        parentId: index === 0 ? null : (allMessages[index - 1]?.id ?? null),
+      })),
       version: 1,
     } satisfies MessageTreeSnapshot<TMessage>)
   );
 }
 
-function messagesSignature<TMessage extends UIMessage>(messages: TMessage[]) {
-  return JSON.stringify(messages);
-}
-
 function treeSignature<TMessage extends UIMessage>(
   snapshot: MessageTreeSnapshot<TMessage>
 ) {
-  return JSON.stringify({
-    childrenByParentId: snapshot.childrenByParentId,
-    cursorId: snapshot.cursorId,
-    messagesById: snapshot.messagesById,
-    parentById: snapshot.parentById,
-    rootIds: snapshot.rootIds,
-  });
+  return JSON.stringify(snapshot);
 }
 
 export function useChat<TMessage extends UIMessage = UIMessage>(
-  options: UseChatOptionsWithPerformance<TMessage> = {} as UseChatOptionsWithPerformance<TMessage>
+  options: UseChatOptionsWithPerformance<TMessage> = {}
 ): UseThreadHelpers<TMessage> {
   const {
     store: customStore,
     enableBatching = true,
     initialTree,
+    messages: externalMessages,
     ...originalOptions
   } = options;
 
-  const originalOnData = (options as any).onData;
-  const externalMessages = (originalOptions as any).messages as
-    | TMessage[]
-    | undefined;
+  const originalOnData = options.onData;
 
   // Use custom store if provided, otherwise use the context store
   const contextStore = useChatStoreApi<TMessage>();
-  const store = customStore || contextStore;
-  const initialTreeRef = useRef<MessageTreeSnapshot<TMessage> | null>(null);
+  const store: CompatibleChatStore<TMessage> = customStore ?? contextStore;
+  const initialTreeRef = useRef<MessageTreeSnapshot<TMessage> | undefined>(
+    undefined
+  );
   if (!initialTreeRef.current) {
     initialTreeRef.current = getInitialTree(
       store,
-      (originalOptions as any).messages as TMessage[] | undefined,
+      externalMessages,
       initialTree
     );
   }
 
   // Wrap onData to capture transient data parts
-  const wrappedOnData = useCallback(
-    (dataPart: any) => {
+  const wrappedOnData = useCallback<NonNullable<ChatInit<TMessage>["onData"]>>(
+    (dataPart) => {
       // Check if it's a data part (starts with 'data-')
       if (dataPart.type?.startsWith("data-")) {
         // Store transient data parts in the store
-        if (typeof (store as any).getState === "function") {
-          const storeState = (store as any).getState();
-          // If data is null or undefined, remove the transient data part
-          if (dataPart.data === null || dataPart.data === undefined) {
-            if (storeState.removeTransientDataPart) {
-              storeState.removeTransientDataPart(dataPart.type);
-            }
-          } else if (storeState.setTransientDataPart) {
-            storeState.setTransientDataPart(dataPart.type, dataPart.data);
-          }
+        const storeState = store.getState();
+        // If data is null or undefined, remove the transient data part
+        if (dataPart.data === null || dataPart.data === undefined) {
+          storeState.removeTransientDataPart(dataPart.type);
+        } else {
+          storeState.setTransientDataPart(dataPart.type, dataPart.data);
         }
       }
 
@@ -156,17 +129,16 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     ...originalOptions,
     initialTree: initialTreeRef.current,
     onData: wrappedOnData,
-  }) as UseThreadHelpers<TMessage>;
+  });
+  const currentTreeSnapshot = chatHelpers.tree.getSnapshot();
+  const currentTreeSignature = treeSignature(currentTreeSnapshot);
+  const currentTreeSnapshotRef = useRef(currentTreeSnapshot);
+  currentTreeSnapshotRef.current = currentTreeSnapshot;
 
-  const storeRef = useRef<CompatibleChatStore<TMessage> | typeof contextStore>(
-    store
-  );
+  const storeRef = useRef<CompatibleChatStore<TMessage>>(store);
 
   const lastSyncedStateRef = useRef<string | null>(null);
   const lastSyncedTreeRef = useRef<string | null>(null);
-  const lastExternalMessagesRef = useRef<string | null>(
-    externalMessages ? messagesSignature(externalMessages) : null
-  );
 
   // Memoize the sync function to avoid recreating it on every render
   const syncState = useCallback((chatState: Partial<StoreState<TMessage>>) => {
@@ -174,24 +146,12 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
       return;
     }
 
-    // Check if store has _syncState method (our internal stores)
-    if (typeof (storeRef.current as any).getState === "function") {
-      // For vanilla Zustand stores
-      const vanillaStore = storeRef.current as any;
-      vanillaStore.getState()._syncState(chatState);
-    } else if (typeof (storeRef.current as any)._syncState === "function") {
-      (storeRef.current as any)._syncState(chatState);
-    } else if (typeof (storeRef.current as any).setState === "function") {
-      // For standard Zustand stores
-      (storeRef.current as any).setState(chatState);
-    }
+    storeRef.current.getState()._syncState(chatState);
   }, []);
 
   const setMessages = useCallback<UseThreadHelpers<TMessage>["setMessages"]>(
     (messagesOrUpdater) => {
-      const currentMessages =
-        ((store as any).getState?.().messages as TMessage[] | undefined) ??
-        chatHelpers.messages;
+      const currentMessages = store.getState().messages ?? chatHelpers.messages;
       const nextMessages =
         typeof messagesOrUpdater === "function"
           ? messagesOrUpdater(currentMessages)
@@ -202,27 +162,11 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     [chatHelpers.messages, chatHelpers.setMessages, store]
   );
 
-  useEffect(() => {
-    if (!externalMessages) {
-      return;
-    }
-
-    const externalSignature = messagesSignature(externalMessages);
-    if (lastExternalMessagesRef.current === externalSignature) {
-      return;
-    }
-
-    lastExternalMessagesRef.current = externalSignature;
-    if (messagesSignature(chatHelpers.messages) !== externalSignature) {
-      setMessages(externalMessages);
-    }
-  }, [externalMessages, chatHelpers.messages, setMessages]);
-
   // Simple sync - but don't overwrite store messages if chat has no messages
   // This preserves server-side messages during hydration
   useEffect(() => {
     // Only sync state data
-    const stateData: any = {
+    const stateData: Partial<StoreState<TMessage>> = {
       id: chatHelpers.id,
       error: chatHelpers.error,
       status: chatHelpers.status,
@@ -267,14 +211,11 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
       }
     }
 
-    const setTreeSnapshot = (store as any).getState?.().setTreeSnapshot;
+    const setTreeSnapshot = store.getState().setTreeSnapshot;
     if (typeof setTreeSnapshot === "function") {
-      const snapshot = chatHelpers.tree.getSnapshot();
-      const signature = treeSignature(snapshot);
-
-      if (lastSyncedTreeRef.current !== signature) {
-        lastSyncedTreeRef.current = signature;
-        setTreeSnapshot(snapshot);
+      if (lastSyncedTreeRef.current !== currentTreeSignature) {
+        lastSyncedTreeRef.current = currentTreeSignature;
+        setTreeSnapshot(currentTreeSnapshotRef.current);
       }
     }
   }, [
@@ -294,6 +235,7 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     chatHelpers.stop,
     chatHelpers.regenerate,
     chatHelpers.addToolResult,
+    currentTreeSignature,
   ]);
 
   return {

--- a/apps/chat/lib/stores/base/use-chat.ts
+++ b/apps/chat/lib/stores/base/use-chat.ts
@@ -5,7 +5,11 @@ import {
   type UseChatHelpers,
   type UseChatOptions,
 } from "@ai-sdk/react";
-import { type MessageTreeSnapshot, type ThreadInit } from "@chatjs/thread";
+import {
+  type AbstractThread,
+  type MessageTreeSnapshot,
+  type ThreadInit,
+} from "@chatjs/thread";
 import {
   type UseThreadHelpers,
   type UseThreadOptions,
@@ -25,8 +29,7 @@ export type {
 // Type for a compatible chat store
 type CompatibleChatStoreState<TMessage extends UIMessage> =
   StoreState<TMessage> & {
-    setTreeSnapshot?: (snapshot: MessageTreeSnapshot<TMessage>) => void;
-    treeSnapshot?: MessageTreeSnapshot<TMessage>;
+    threadSnapshot?: MessageTreeSnapshot<TMessage>;
   };
 
 export interface CompatibleChatStore<TMessage extends UIMessage = UIMessage> {
@@ -40,6 +43,7 @@ export type UseChatOptionsWithPerformance<
   resume?: boolean;
 } & Pick<ThreadInit<TMessage>, "concurrency" | "initialTree"> & {
     store?: CompatibleChatStore<TMessage>;
+    thread?: AbstractThread<TMessage>;
     // Additional performance options
     enableBatching?: boolean;
   };
@@ -57,7 +61,7 @@ function getInitialTree<TMessage extends UIMessage>(
   const messages = fallbackMessages ?? [];
 
   return (
-    state.treeSnapshot ??
+    state.threadSnapshot ??
     ({
       cursorId: messages.at(-1)?.id ?? null,
       nodes: messages.map((message, index, allMessages) => ({
@@ -69,12 +73,6 @@ function getInitialTree<TMessage extends UIMessage>(
   );
 }
 
-function treeSignature<TMessage extends UIMessage>(
-  snapshot: MessageTreeSnapshot<TMessage>
-) {
-  return JSON.stringify(snapshot);
-}
-
 export function useChat<TMessage extends UIMessage = UIMessage>(
   options: UseChatOptionsWithPerformance<TMessage> = {}
 ): UseThreadHelpers<TMessage> {
@@ -83,6 +81,9 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     enableBatching = true,
     initialTree,
     messages: externalMessages,
+    thread: suppliedThread,
+    experimental_throttle,
+    resume,
     ...originalOptions
   } = options;
 
@@ -125,21 +126,37 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     [store, originalOnData]
   );
 
-  const chatHelpers = useOriginalChat<TMessage>({
-    ...originalOptions,
-    initialTree: initialTreeRef.current,
-    onData: wrappedOnData,
-  });
-  const currentTreeSnapshot = chatHelpers.tree.getSnapshot();
-  const currentTreeSignature = treeSignature(currentTreeSnapshot);
-  const currentTreeSnapshotRef = useRef(currentTreeSnapshot);
-  currentTreeSnapshotRef.current = currentTreeSnapshot;
+  if (suppliedThread) {
+    suppliedThread.onData = wrappedOnData;
+    suppliedThread.onError = originalOptions.onError;
+    suppliedThread.onFinish = originalOptions.onFinish;
+    suppliedThread.onToolCall = originalOptions.onToolCall;
+    suppliedThread.sendAutomaticallyWhen =
+      originalOptions.sendAutomaticallyWhen;
+    if (originalOptions.transport) {
+      suppliedThread.transport = originalOptions.transport;
+    }
+  }
+
+  const chatHelpers = useOriginalChat<TMessage>(
+    suppliedThread
+      ? {
+          experimental_throttle,
+          resume,
+          thread: suppliedThread,
+        }
+      : {
+          ...originalOptions,
+          experimental_throttle,
+          initialTree: initialTreeRef.current,
+          onData: wrappedOnData,
+          resume,
+        }
+  );
 
   const storeRef = useRef<CompatibleChatStore<TMessage>>(store);
 
   const lastSyncedStateRef = useRef<string | null>(null);
-  const lastSyncedTreeRef = useRef<string | null>(null);
-
   // Memoize the sync function to avoid recreating it on every render
   const syncState = useCallback((chatState: Partial<StoreState<TMessage>>) => {
     if (!storeRef.current) {
@@ -149,28 +166,11 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     storeRef.current.getState()._syncState(chatState);
   }, []);
 
-  const setMessages = useCallback<UseThreadHelpers<TMessage>["setMessages"]>(
-    (messagesOrUpdater) => {
-      const currentMessages = store.getState().messages ?? chatHelpers.messages;
-      const nextMessages =
-        typeof messagesOrUpdater === "function"
-          ? messagesOrUpdater(currentMessages)
-          : messagesOrUpdater;
-
-      chatHelpers.setMessages(nextMessages);
-    },
-    [chatHelpers.messages, chatHelpers.setMessages, store]
-  );
-
-  // Simple sync - but don't overwrite store messages if chat has no messages
-  // This preserves server-side messages during hydration
+  // Keep imperative helpers available to legacy store consumers. Observable
+  // chat state is projected atomically by the Zustand ThreadState adapter.
   useEffect(() => {
     // Only sync state data
-    const stateData: Partial<StoreState<TMessage>> = {
-      id: chatHelpers.id,
-      error: chatHelpers.error,
-      status: chatHelpers.status,
-    };
+    const stateData: Partial<StoreState<TMessage>> = { id: chatHelpers.id };
 
     // Sync functions separately and only once
     const functionsData = {
@@ -180,15 +180,13 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
       stop: chatHelpers.stop,
       resumeStream: chatHelpers.resumeStream,
       addToolResult: chatHelpers.addToolResult,
-      setMessages,
+      setMessages: chatHelpers.setMessages,
       clearError: chatHelpers.clearError,
     };
 
     const chatState = { ...stateData, ...functionsData };
     const syncSignature = JSON.stringify({
-      error: chatHelpers.error?.message,
       id: chatHelpers.id,
-      status: chatHelpers.status,
     });
 
     if (lastSyncedStateRef.current !== syncSignature) {
@@ -210,20 +208,9 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
         syncState(chatState);
       }
     }
-
-    const setTreeSnapshot = store.getState().setTreeSnapshot;
-    if (typeof setTreeSnapshot === "function") {
-      if (lastSyncedTreeRef.current !== currentTreeSignature) {
-        lastSyncedTreeRef.current = currentTreeSignature;
-        setTreeSnapshot(currentTreeSnapshotRef.current);
-      }
-    }
   }, [
     // Only depend on data that actually changes, not function references
     chatHelpers.id,
-    chatHelpers.messages,
-    chatHelpers.error,
-    chatHelpers.status,
     syncState,
     enableBatching,
     chatHelpers.resumeStream,
@@ -231,16 +218,11 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
     chatHelpers.sendMessage,
     chatHelpers.tree.startRun,
     store,
-    setMessages,
+    chatHelpers.setMessages,
     chatHelpers.stop,
     chatHelpers.regenerate,
     chatHelpers.addToolResult,
-    currentTreeSignature,
   ]);
 
-  return {
-    ...chatHelpers,
-    setMessages,
-    messages: chatHelpers.messages,
-  };
+  return chatHelpers;
 }

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "prebuild": "bun run check-env",
+    "prebuild": "bun --filter @chatjs/thread build && bun run check-env",
     "dev": "bun run check-env && bash scripts/with-db.sh next dev",
     "dev:inspect": "bash scripts/with-db.sh next dev --inspect",
     "build": "tsx lib/db/migrate && next build",

--- a/packages/cli/src/helpers/scaffold.test.ts
+++ b/packages/cli/src/helpers/scaffold.test.ts
@@ -212,10 +212,11 @@ describe("scaffoldFromTemplate", () => {
 			true,
 		);
 		const chatStoreSource = await readFile(
-			join(destination, "lib", "stores", "with-threads.ts"),
+			join(destination, "lib", "stores", "base", "use-chat.ts"),
 			"utf8",
 		);
 		expect(chatStoreSource).toContain('from "@/lib/thread"');
+		expect(chatStoreSource).toContain('from "@/lib/thread/react"');
 	});
 
 	it("rewrites the generated web app to be npm-friendly", async () => {


### PR DESCRIPTION
## Summary
- Replaces the ChatJS `useChat` wrapper internals with `useThread`.
- Keeps the hook mounted in the existing persistent `ChatSync` runtime slot.
- Exposes tree run actions through the compatibility store.

## Behavior
Normal linear chat continues through the same app surface while gaining tree-backed state.

## Verification
- Normal authenticated message sending verified in the browser.
- `bun test:types` and app unit tests pass at the stack tip.

## Review focus
The integration boundary: `AppRuntimeSlot -> ChatSync -> useThread`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts `useThread` from `@chatjs/thread/react` in the persistent ChatJS runtime slot so chats run on a message tree with no UI changes. The thread initializes from `options.initialTree`, a stored snapshot, or ordered messages, and is wired directly into `ChatSync`.

- **Refactors**
  - Replaces the internal hook with `useThread`; supports a supplied `thread` and removes the old messages bridge and `generateId`.
  - Batches and dedupes store sync of `id` and imperative helpers via rAF; relies on thread state as the source of truth; wraps `onData` to persist/remove `data-*` parts.

- **New Features**
  - Exposes `tree.startRun` via store/actions with a clear fallback error.
  - Accepts `initialTree`, `concurrency`, `resume`, and `experimental_throttle`; `prebuild` builds `@chatjs/thread` before env checks.

<sup>Written for commit a408efccc51c56810fcff9061b2e6c2d370fc3d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #233
2. #258
3. #234
4. #235
5. #236
6. #237
7. #238
8. #239
9. #261
10. #240
11. #262
12. #266
13. #267
14. **#241** 👈 current
15. #242
16. #243
17. #244
18. #263
19. #245
20. #246
21. #247
22. #248
23. #249
24. #250
25. #251
26. #252
27. #253
28. #254
<!-- stack:links:end -->