### PR TITLE
Threads 11: Add branch navigation and retry

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -1078,6 +1078,10 @@ export async function POST(request: NextRequest) {
       requestSelectedModelId,
       selectedModel: userMessage.metadata.selectedModel,
     });
+    const responseParallelGroupId =
+      parallelGroupId === undefined
+        ? (userMessage.metadata.parallelGroupId ?? null)
+        : parallelGroupId;
 
     if (!selectedModelId) {
       log.warn("No selectedModel in user message metadata");
@@ -1135,8 +1139,7 @@ export async function POST(request: NextRequest) {
       previousMessages: executionInputs.previousMessages,
       selectedModelId,
       assistantMessageId,
-      parallelGroupId:
-        parallelGroupId ?? userMessage.metadata.parallelGroupId ?? null,
+      parallelGroupId: responseParallelGroupId,
       parallelIndex: parallelIndex ?? null,
       isPrimaryParallel: isPrimaryParallel ?? null,
       explicitlyRequestedTools,

--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -393,6 +393,15 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   const liveStore = existingStore;
   const hasLiveRuntime = !!(liveRuntime && liveStore);
   const liveRuntimeMessages = liveStore?.getState().messages;
+
+  useEffect(() => {
+    if (!(liveStore && persistedMessages)) {
+      return;
+    }
+
+    liveStore.getState().setAllMessages(persistedMessages);
+  }, [liveStore, persistedMessages]);
+
   const initialMessages =
     liveRuntimeMessages ?? persistedInitialState.initialMessages;
   const initialTool =

--- a/apps/chat/app/(chat)/chat-route-host.tsx
+++ b/apps/chat/app/(chat)/chat-route-host.tsx
@@ -394,14 +394,6 @@ function HostedChatRoute({ route }: { route: HostedParsedChatRoute }) {
   const hasLiveRuntime = !!(liveRuntime && liveStore);
   const liveRuntimeMessages = liveStore?.getState().messages;
 
-  useEffect(() => {
-    if (!(liveStore && persistedMessages)) {
-      return;
-    }
-
-    liveStore.getState().setAllMessages(persistedMessages);
-  }, [liveStore, persistedMessages]);
-
   const initialMessages =
     liveRuntimeMessages ?? persistedInitialState.initialMessages;
   const initialTool =

--- a/apps/chat/components/data-stream-handler.tsx
+++ b/apps/chat/components/data-stream-handler.tsx
@@ -3,7 +3,11 @@ import type { DataUIPart } from "ai";
 import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
 import type { ArtifactMetadata } from "@/components/create-artifact";
 import { useArtifact } from "@/hooks/use-artifact";
-import type { CustomUIDataTypes, UiToolName } from "@/lib/ai/types";
+import type {
+  ChatMessage,
+  CustomUIDataTypes,
+  UiToolName,
+} from "@/lib/ai/types";
 import {
   codeArtifact,
   getCodeArtifactMetadata,
@@ -13,6 +17,8 @@ import {
   sheetArtifact,
 } from "@/lib/artifacts/sheet/client";
 import { textArtifact } from "@/lib/artifacts/text/client";
+import { isDataPartOnMessagePath } from "@/lib/data-stream";
+import { useChatStoreApi } from "@/lib/stores/base";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useChatInput } from "@/providers/chat-input-provider";
 
@@ -95,19 +101,38 @@ function processArtifactStreamPart({
 
 export function DataStreamHandler() {
   const { dataStream } = useDataStream();
+  const chatStore = useChatStoreApi<ChatMessage>();
   const { artifact, setArtifact, setMetadata } = useArtifact();
   const lastProcessedIndex = useRef(-1);
+  const lastProcessedPart = useRef<DataUIPart<CustomUIDataTypes> | undefined>(
+    undefined
+  );
   const { setSelectedTool } = useChatInput();
 
   useEffect(() => {
     if (!dataStream?.length) {
+      lastProcessedIndex.current = -1;
+      lastProcessedPart.current = undefined;
       return;
+    }
+
+    if (
+      lastProcessedIndex.current >= 0 &&
+      dataStream[lastProcessedIndex.current] !== lastProcessedPart.current
+    ) {
+      lastProcessedIndex.current = -1;
     }
 
     const newDeltas = dataStream.slice(lastProcessedIndex.current + 1);
     lastProcessedIndex.current = dataStream.length - 1;
+    lastProcessedPart.current = dataStream.at(-1);
+    const messages = chatStore.getState().messages;
 
     for (const delta of newDeltas) {
+      if (!isDataPartOnMessagePath(delta, messages)) {
+        continue;
+      }
+
       handleResearchUpdate({ delta, setSelectedTool });
 
       processArtifactStreamPart({
@@ -117,7 +142,14 @@ export function DataStreamHandler() {
         setMetadata,
       });
     }
-  }, [dataStream, setArtifact, setMetadata, artifact, setSelectedTool]);
+  }, [
+    artifact,
+    chatStore,
+    dataStream,
+    setArtifact,
+    setMetadata,
+    setSelectedTool,
+  ]);
 
   return null;
 }

--- a/apps/chat/components/multimodal-input.tsx
+++ b/apps/chat/components/multimodal-input.tsx
@@ -45,7 +45,8 @@ import {
   runParallelRequestSpecs,
 } from "@/lib/parallel-chat-requests";
 import { useStartProvisionalChat } from "@/lib/start-provisional-chat";
-import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
+import { useChatActions } from "@/lib/stores/base";
+import { useApplicationThread } from "@/lib/stores/custom-store-provider";
 import { useLastMessageId } from "@/lib/stores/hooks-base";
 import { useAddMessageToTree } from "@/lib/stores/hooks-threads";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
@@ -107,7 +108,7 @@ function PureMultimodalInput({
   parentMessageId: string | null;
   onSendMessage?: (message: ChatMessage) => void | Promise<void>;
 }) {
-  const storeApi = useChatStoreApi<ChatMessage>();
+  const thread = useApplicationThread();
   const { artifact, closeArtifact } = useArtifact();
   const { data: session } = useSession();
   const trpc = useTRPC();
@@ -116,11 +117,7 @@ function PureMultimodalInput({
   const addMessageToTree = useAddMessageToTree();
   const currentRoute = useCurrentChatRoute();
   const startProvisionalChat = useStartProvisionalChat(chatId);
-  const {
-    setMessages,
-    sendMessage,
-    stop: stopHelper,
-  } = useChatActions<ChatMessage>();
+  const { sendMessage, stop: stopHelper } = useChatActions<ChatMessage>();
   const lastMessageId = useLastMessageId();
   const {
     editorRef,
@@ -296,45 +293,17 @@ function PureMultimodalInput({
   // Trim messages in edit mode
   const trimMessagesInEditMode = useCallback(
     (parentId: string | null) => {
-      if (parentId === null) {
-        setMessages([]);
-        // Close artifact if it was visible since all messages are removed
-        if (artifact.isVisible) {
-          closeArtifact();
-        }
-        return;
-      }
-
-      const parentIndex = storeApi
-        .getState()
-        .getThrottledMessages()
-        .findIndex((msg: ChatMessage) => msg.id === parentId);
-
-      if (parentIndex !== -1) {
-        const messagesUpToParent = storeApi
-          .getState()
-          .getThrottledMessages()
-          .slice(0, parentIndex + 1);
-
-        // Close artifact if its message will not be in the trimmed messages
-        if (
-          artifact.isVisible &&
-          artifact.messageId &&
-          !messagesUpToParent.some((m) => m.id === artifact.messageId)
-        ) {
-          closeArtifact();
-        }
-
-        setMessages(messagesUpToParent);
+      thread.setCursor(parentId);
+      const selectedMessages = thread.getSnapshot().messages;
+      if (
+        artifact.isVisible &&
+        artifact.messageId &&
+        !selectedMessages.some((message) => message.id === artifact.messageId)
+      ) {
+        closeArtifact();
       }
     },
-    [
-      artifact.isVisible,
-      artifact.messageId,
-      closeArtifact,
-      setMessages,
-      storeApi,
-    ]
+    [artifact.isVisible, artifact.messageId, closeArtifact, thread]
   );
 
   const invalidatePersistedMessages = useCallback(async () => {

--- a/apps/chat/components/parallel-response-cards.tsx
+++ b/apps/chat/components/parallel-response-cards.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/ai/types";
 import { useMessageById } from "@/lib/stores/base";
 import { useParallelGroupInfo } from "@/lib/stores/hooks-threads";
+import { getParallelResponseForSlot } from "@/lib/thread-utils";
 import { cn } from "@/lib/utils";
 import { useChatInput } from "@/providers/chat-input-provider";
 import { useChatModels } from "@/providers/chat-models-provider";
@@ -70,9 +71,13 @@ function PureParallelResponseCards({ messageId }: { messageId: string }) {
     );
 
     return requestedModelIds.map((modelId, parallelIndex) => {
-      const actualMessage = parallelGroupInfo?.messages.find(
-        (candidate) => candidate.metadata.parallelIndex === parallelIndex
-      );
+      const actualMessage = parallelGroupInfo
+        ? getParallelResponseForSlot(
+            parallelGroupInfo.messages,
+            parallelIndex,
+            parallelGroupInfo.selectedMessageId
+          )
+        : null;
 
       return {
         modelId,

--- a/apps/chat/components/response-error-message.tsx
+++ b/apps/chat/components/response-error-message.tsx
@@ -1,12 +1,10 @@
 import { RefreshCcwIcon } from "lucide-react";
 import type { ChatMessage } from "@/lib/ai/types";
-import { removeTrailingAssistantMessage } from "@/lib/chat-tree-actions";
-import { useChatActions, useChatStoreApi } from "@/lib/stores/base";
+import { useChatActions } from "@/lib/stores/base";
 import { Button } from "./ui/button";
 
 export function ResponseErrorMessage() {
-  const { setMessages, regenerate } = useChatActions<ChatMessage>();
-  const chatStore = useChatStoreApi<ChatMessage>();
+  const { regenerate } = useChatActions<ChatMessage>();
 
   return (
     <div className="mx-auto flex w-full flex-col items-center gap-4 rounded-lg px-6 py-8 shadow-xs md:max-w-2xl">
@@ -32,10 +30,6 @@ export function ResponseErrorMessage() {
       <Button
         className=" "
         onClick={() => {
-          const messagesWithoutLastAssistant = removeTrailingAssistantMessage(
-            chatStore.getState().messages
-          );
-          setMessages(messagesWithoutLastAssistant);
           regenerate();
         }}
         variant="outline"

--- a/apps/chat/components/responsive-tools.tsx
+++ b/apps/chat/components/responsive-tools.tsx
@@ -18,7 +18,6 @@ import { useSession } from "@/providers/session-provider";
 import { enabledTools, toolDefinitions } from "./chat-features-definitions";
 import { Button } from "./ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { LoginPrompt } from "./upgrade-cta/login-prompt";
 
 export function ResponsiveTools({
@@ -57,20 +56,16 @@ export function ResponsiveTools({
     <div className="flex items-center @[500px]:gap-2 gap-1">
       {isAnonymous ? (
         <Popover onOpenChange={setShowLoginPopover} open={showLoginPopover}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5"
-                  variant="ghost"
-                >
-                  <Settings2 size={14} />
-                  <span className="@[500px]:inline hidden">Tools</span>
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Select Tools</TooltipContent>
-          </Tooltip>
+          <PopoverTrigger asChild>
+            <Button
+              className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5"
+              title="Select Tools"
+              variant="ghost"
+            >
+              <Settings2 size={14} />
+              <span className="@[500px]:inline hidden">Tools</span>
+            </Button>
+          </PopoverTrigger>
           <PopoverContent align="start" className="w-80 p-0">
             <LoginPrompt
               description="Access web search, deep research, and more to get better answers."
@@ -80,21 +75,17 @@ export function ResponsiveTools({
         </Popover>
       ) : (
         <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5 px-2.5"
-                  size="sm"
-                  variant="ghost"
-                >
-                  <Settings2 size={14} />
-                  <span className="@[500px]:inline hidden">Tools</span>
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Select Tools</TooltipContent>
-          </Tooltip>
+          <DropdownMenuTrigger asChild>
+            <Button
+              className="@[500px]:h-10 h-8 @[500px]:gap-2 gap-1 p-1.5 px-2.5"
+              size="sm"
+              title="Select Tools"
+              variant="ghost"
+            >
+              <Settings2 size={14} />
+              <span className="@[500px]:inline hidden">Tools</span>
+            </Button>
+          </DropdownMenuTrigger>
           <DropdownMenuContent
             align="start"
             className="w-48"

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -17,12 +17,12 @@ export function RetryButton({
   messageId: string;
   className?: string;
 }) {
-  const { setMessages, sendMessage } = useChatActions<ChatMessage>();
+  const { setMessages, regenerate } = useChatActions<ChatMessage>();
   const chatStore = useChatStoreApi<ChatMessage>();
   const status = useChatStatus();
 
   const handleRetry = useCallback(() => {
-    if (!sendMessage) {
+    if (!regenerate) {
       toast.error("Cannot retry this message");
       return;
     }
@@ -47,11 +47,15 @@ export function RetryButton({
 
     setMessages(retryInput.messagesBeforeRetry);
 
-    // Resend the parent user message
-    sendMessage(retryInput.message, {});
+    regenerate({
+      body: {
+        selectedModelId: retryInput.selectedModelId,
+      },
+      messageId,
+    });
 
     toast.success("Retrying message...");
-  }, [sendMessage, messageId, setMessages, chatStore]);
+  }, [regenerate, messageId, setMessages, chatStore]);
 
   if (status === "streaming" || status === "submitted") {
     return null;

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -4,11 +4,7 @@ import { toast } from "sonner";
 import { Action } from "@/components/ai-elements/actions";
 import type { ChatMessage } from "@/lib/ai/types";
 import { getRetryMessageInput } from "@/lib/chat-tree-actions";
-import {
-  useChatActions,
-  useChatStatus,
-  useChatStoreApi,
-} from "@/lib/stores/base";
+import { useChatStatus, useChatStoreApi } from "@/lib/stores/base";
 
 export function RetryButton({
   messageId,
@@ -17,11 +13,11 @@ export function RetryButton({
   messageId: string;
   className?: string;
 }) {
-  const { regenerate } = useChatActions<ChatMessage>();
   const chatStore = useChatStoreApi<ChatMessage>();
   const status = useChatStatus();
 
   const handleRetry = useCallback(() => {
+    const { messages, regenerate } = chatStore.getState();
     if (!regenerate) {
       toast.error("Cannot retry this message");
       return;
@@ -29,7 +25,7 @@ export function RetryButton({
 
     const retryInput = getRetryMessageInput({
       messageId,
-      messages: chatStore.getState().messages,
+      messages,
     });
 
     if (!retryInput.ok) {
@@ -47,13 +43,18 @@ export function RetryButton({
 
     regenerate({
       body: {
+        isPrimaryParallel: retryInput.isPrimaryParallel,
+        parallelGroupId: retryInput.parallelGroupId,
+        parallelIndex: retryInput.parallelIndex,
         selectedModelId: retryInput.selectedModelId,
       },
       messageId,
+    }).catch(() => {
+      toast.error("Could not retry this message");
     });
 
     toast.success("Retrying message...");
-  }, [regenerate, messageId, chatStore]);
+  }, [messageId, chatStore]);
 
   if (status === "streaming" || status === "submitted") {
     return null;

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -17,7 +17,7 @@ export function RetryButton({
   messageId: string;
   className?: string;
 }) {
-  const { setMessages, regenerate } = useChatActions<ChatMessage>();
+  const { regenerate } = useChatActions<ChatMessage>();
   const chatStore = useChatStoreApi<ChatMessage>();
   const status = useChatStatus();
 
@@ -45,8 +45,6 @@ export function RetryButton({
       return;
     }
 
-    setMessages(retryInput.messagesBeforeRetry);
-
     regenerate({
       body: {
         selectedModelId: retryInput.selectedModelId,
@@ -55,7 +53,7 @@ export function RetryButton({
     });
 
     toast.success("Retrying message...");
-  }, [regenerate, messageId, setMessages, chatStore]);
+  }, [regenerate, messageId, chatStore]);
 
   if (status === "streaming" || status === "submitted") {
     return null;

--- a/apps/chat/components/retry-button.tsx
+++ b/apps/chat/components/retry-button.tsx
@@ -52,8 +52,6 @@ export function RetryButton({
     }).catch(() => {
       toast.error("Could not retry this message");
     });
-
-    toast.success("Retrying message...");
   }, [messageId, chatStore]);
 
   if (status === "streaming" || status === "submitted") {

--- a/apps/chat/hooks/use-navigate-to-message.ts
+++ b/apps/chat/hooks/use-navigate-to-message.ts
@@ -6,17 +6,19 @@ import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useSwitchToMessage } from "@/lib/stores/hooks-threads";
 
 export function useNavigateToMessage() {
-  const { stop } = useChatActions<ChatMessage>();
+  const { setMessages } = useChatActions<ChatMessage>();
   const { setDataStream } = useDataStream();
   const { artifact, closeArtifact } = useArtifact();
   const switchToMessage = useSwitchToMessage();
 
   return useCallback(
     (messageId: string) => {
-      stop?.();
       setDataStream([]);
 
       const newThread = switchToMessage(messageId);
+      if (newThread) {
+        setMessages(newThread);
+      }
 
       if (
         newThread &&
@@ -34,7 +36,7 @@ export function useNavigateToMessage() {
       artifact.messageId,
       closeArtifact,
       setDataStream,
-      stop,
+      setMessages,
       switchToMessage,
     ]
   );

--- a/apps/chat/hooks/use-navigate-to-message.ts
+++ b/apps/chat/hooks/use-navigate-to-message.ts
@@ -1,12 +1,10 @@
 import { useCallback } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ChatMessage } from "@/lib/ai/types";
-import { useChatActions } from "@/lib/stores/base";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useSwitchToMessage } from "@/lib/stores/hooks-threads";
 
 export function useNavigateToMessage() {
-  const { setMessages } = useChatActions<ChatMessage>();
   const { setDataStream } = useDataStream();
   const { artifact, closeArtifact } = useArtifact();
   const switchToMessage = useSwitchToMessage();
@@ -16,10 +14,6 @@ export function useNavigateToMessage() {
       setDataStream([]);
 
       const newThread = switchToMessage(messageId);
-      if (newThread) {
-        setMessages(newThread);
-      }
-
       if (
         newThread &&
         artifact.isVisible &&
@@ -36,7 +30,6 @@ export function useNavigateToMessage() {
       artifact.messageId,
       closeArtifact,
       setDataStream,
-      setMessages,
       switchToMessage,
     ]
   );

--- a/apps/chat/hooks/use-navigate-to-sibling.ts
+++ b/apps/chat/hooks/use-navigate-to-sibling.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ChatMessage } from "@/lib/ai/types";
-import { useChatActions } from "@/lib/stores/base";
 import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useSwitchToSibling } from "@/lib/stores/hooks-threads";
 
@@ -10,7 +9,6 @@ import { useSwitchToSibling } from "@/lib/stores/hooks-threads";
  * Uses the store's switchToSibling for the pure state transition.
  */
 export function useNavigateToSibling() {
-  const { setMessages } = useChatActions<ChatMessage>();
   const { setDataStream } = useDataStream();
   const { artifact, closeArtifact } = useArtifact();
   const switchToSibling = useSwitchToSibling();
@@ -22,10 +20,6 @@ export function useNavigateToSibling() {
       setDataStream([]);
 
       const newThread = switchToSibling(messageId, direction);
-      if (newThread) {
-        setMessages(newThread);
-      }
-
       // Close artifact if its message is not in the new thread
       if (
         newThread &&
@@ -43,7 +37,6 @@ export function useNavigateToSibling() {
       artifact.messageId,
       closeArtifact,
       setDataStream,
-      setMessages,
       switchToSibling,
     ]
   );

--- a/apps/chat/hooks/use-navigate-to-sibling.ts
+++ b/apps/chat/hooks/use-navigate-to-sibling.ts
@@ -6,22 +6,25 @@ import { useDataStream } from "@/lib/stores/hooks-data-stream";
 import { useSwitchToSibling } from "@/lib/stores/hooks-threads";
 
 /**
- * Navigate to a sibling thread with side effects (stop stream, close artifact).
+ * Navigate to a sibling thread while preserving branch-owned active runs.
  * Uses the store's switchToSibling for the pure state transition.
  */
 export function useNavigateToSibling() {
-  const { stop } = useChatActions<ChatMessage>();
+  const { setMessages } = useChatActions<ChatMessage>();
   const { setDataStream } = useDataStream();
   const { artifact, closeArtifact } = useArtifact();
   const switchToSibling = useSwitchToSibling();
 
   return useCallback(
     (messageId: string, direction: "prev" | "next") => {
-      // Hard-disconnect the current stream + clear buffered deltas
-      stop?.();
+      // Data parts belong to the previously selected path. Active runs remain
+      // owned by Thread and continue updating their tree nodes.
       setDataStream([]);
 
       const newThread = switchToSibling(messageId, direction);
+      if (newThread) {
+        setMessages(newThread);
+      }
 
       // Close artifact if its message is not in the new thread
       if (
@@ -40,7 +43,7 @@ export function useNavigateToSibling() {
       artifact.messageId,
       closeArtifact,
       setDataStream,
-      stop,
+      setMessages,
       switchToSibling,
     ]
   );

--- a/apps/chat/lib/chat-tree-actions.test.ts
+++ b/apps/chat/lib/chat-tree-actions.test.ts
@@ -30,7 +30,7 @@ function message({
 }
 
 describe("getRetryMessageInput", () => {
-  it("builds a retry message from an assistant response and trims before the parent user message", () => {
+  it("builds a retry message from an assistant response and keeps the parent user visible", () => {
     const root = message({ id: "root", role: "user" });
     const assistant = message({
       id: "assistant",
@@ -46,7 +46,7 @@ describe("getRetryMessageInput", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      messagesBeforeRetry: [],
+      messagesBeforeRetry: [root],
       message: {
         id: root.id,
         role: "user",
@@ -59,6 +59,7 @@ describe("getRetryMessageInput", () => {
           selectedModel: "openai/gpt-5-nano",
         },
       },
+      selectedModelId: "openai/gpt-5-nano",
     });
   });
 

--- a/apps/chat/lib/chat-tree-actions.test.ts
+++ b/apps/chat/lib/chat-tree-actions.test.ts
@@ -4,11 +4,17 @@ import { getRetryMessageInput } from "./chat-tree-actions";
 
 function message({
   id,
+  isPrimaryParallel = null,
+  parallelGroupId = null,
+  parallelIndex = null,
   parentMessageId = null,
   role,
   selectedModel = "openai/gpt-5-mini",
 }: {
   id: string;
+  isPrimaryParallel?: boolean | null;
+  parallelGroupId?: string | null;
+  parallelIndex?: number | null;
   parentMessageId?: string | null;
   role: "assistant" | "user";
   selectedModel?: ChatMessage["metadata"]["selectedModel"];
@@ -20,6 +26,9 @@ function message({
     metadata: {
       activeStreamId: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      isPrimaryParallel,
+      parallelGroupId,
+      parallelIndex,
       parentMessageId,
       selectedModel,
     },
@@ -44,6 +53,30 @@ describe("getRetryMessageInput", () => {
     expect(result).toMatchObject({
       ok: true,
       selectedModelId: "openai/gpt-5-nano",
+    });
+  });
+
+  it("preserves the parallel response slot for an assistant retry", () => {
+    const root = message({ id: "root", role: "user" });
+    const assistant = message({
+      id: "assistant",
+      isPrimaryParallel: false,
+      parallelGroupId: "group-1",
+      parallelIndex: 1,
+      parentMessageId: root.id,
+      role: "assistant",
+    });
+
+    const result = getRetryMessageInput({
+      messageId: assistant.id,
+      messages: [root, assistant],
+    });
+
+    expect(result).toMatchObject({
+      isPrimaryParallel: false,
+      ok: true,
+      parallelGroupId: "group-1",
+      parallelIndex: 1,
     });
   });
 

--- a/apps/chat/lib/chat-tree-actions.test.ts
+++ b/apps/chat/lib/chat-tree-actions.test.ts
@@ -30,7 +30,7 @@ function message({
 }
 
 describe("getRetryMessageInput", () => {
-  it("builds a retry message from an assistant response and keeps the parent user visible", () => {
+  it("selects the response model for an assistant retry", () => {
     const root = message({ id: "root", role: "user" });
     const assistant = message({
       id: "assistant",
@@ -46,19 +46,6 @@ describe("getRetryMessageInput", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      messagesBeforeRetry: [root],
-      message: {
-        id: root.id,
-        role: "user",
-        metadata: {
-          activeStreamId: null,
-          isPrimaryParallel: null,
-          parallelGroupId: null,
-          parallelIndex: null,
-          parentMessageId: null,
-          selectedModel: "openai/gpt-5-nano",
-        },
-      },
       selectedModelId: "openai/gpt-5-nano",
     });
   });
@@ -73,7 +60,7 @@ describe("getRetryMessageInput", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.ok ? result.message.id : null).toBe(root.id);
+    expect(result.ok ? result.selectedModelId : null).toBe("openai/gpt-5-mini");
   });
 
   it("reports missing parent messages", () => {

--- a/apps/chat/lib/chat-tree-actions.test.ts
+++ b/apps/chat/lib/chat-tree-actions.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "@/lib/ai/types";
-import {
-  getRetryMessageInput,
-  removeTrailingAssistantMessage,
-} from "./chat-tree-actions";
+import { getRetryMessageInput } from "./chat-tree-actions";
 
 function message({
   id,
@@ -73,20 +70,5 @@ describe("getRetryMessageInput", () => {
     expect(
       getRetryMessageInput({ messageId: assistant.id, messages: [assistant] })
     ).toEqual({ ok: false, reason: "parent_not_found" });
-  });
-});
-
-describe("removeTrailingAssistantMessage", () => {
-  it("removes a trailing assistant message", () => {
-    const root = message({ id: "root", role: "user" });
-    const assistant = message({ id: "assistant", role: "assistant" });
-
-    expect(removeTrailingAssistantMessage([root, assistant])).toEqual([root]);
-  });
-
-  it("preserves messages when the last message is not an assistant", () => {
-    const messages = [message({ id: "root", role: "user" })];
-
-    expect(removeTrailingAssistantMessage(messages)).toBe(messages);
   });
 });

--- a/apps/chat/lib/chat-tree-actions.ts
+++ b/apps/chat/lib/chat-tree-actions.ts
@@ -1,3 +1,4 @@
+import type { AppModelId } from "@/lib/ai/app-models";
 import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
 
 export type RetryMessageResult =
@@ -5,6 +6,7 @@ export type RetryMessageResult =
       message: ChatMessage;
       messagesBeforeRetry: ChatMessage[];
       ok: true;
+      selectedModelId: AppModelId;
     }
   | {
       ok: false;
@@ -54,7 +56,7 @@ export function getRetryMessageInput({
 
   return {
     ok: true,
-    messagesBeforeRetry: messages.slice(0, parentMessageIndex),
+    messagesBeforeRetry: messages.slice(0, parentMessageIndex + 1),
     message: {
       ...parentMessage,
       metadata: {
@@ -68,6 +70,7 @@ export function getRetryMessageInput({
         selectedModel: retryModelId,
       },
     },
+    selectedModelId: retryModelId as AppModelId,
   };
 }
 

--- a/apps/chat/lib/chat-tree-actions.ts
+++ b/apps/chat/lib/chat-tree-actions.ts
@@ -3,8 +3,6 @@ import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
 
 export type RetryMessageResult =
   | {
-      message: ChatMessage;
-      messagesBeforeRetry: ChatMessage[];
       ok: true;
       selectedModelId: AppModelId;
     }
@@ -56,20 +54,6 @@ export function getRetryMessageInput({
 
   return {
     ok: true,
-    messagesBeforeRetry: messages.slice(0, parentMessageIndex + 1),
-    message: {
-      ...parentMessage,
-      metadata: {
-        ...parentMessage.metadata,
-        activeStreamId: null,
-        createdAt: parentMessage.metadata?.createdAt || new Date(),
-        isPrimaryParallel: null,
-        parallelGroupId: null,
-        parallelIndex: null,
-        parentMessageId: parentMessage.metadata?.parentMessageId || null,
-        selectedModel: retryModelId,
-      },
-    },
     selectedModelId: retryModelId as AppModelId,
   };
 }

--- a/apps/chat/lib/chat-tree-actions.ts
+++ b/apps/chat/lib/chat-tree-actions.ts
@@ -3,7 +3,10 @@ import { type ChatMessage, getPrimarySelectedModelId } from "@/lib/ai/types";
 
 export type RetryMessageResult =
   | {
+      isPrimaryParallel: boolean | null;
       ok: true;
+      parallelGroupId: string | null;
+      parallelIndex: number | null;
       selectedModelId: AppModelId;
     }
   | {
@@ -53,7 +56,10 @@ export function getRetryMessageInput({
   }
 
   return {
+    isPrimaryParallel: currentMessage.metadata.isPrimaryParallel ?? null,
     ok: true,
+    parallelGroupId: currentMessage.metadata.parallelGroupId ?? null,
+    parallelIndex: currentMessage.metadata.parallelIndex ?? null,
     selectedModelId: retryModelId as AppModelId,
   };
 }

--- a/apps/chat/lib/chat-tree-actions.ts
+++ b/apps/chat/lib/chat-tree-actions.ts
@@ -57,8 +57,3 @@ export function getRetryMessageInput({
     selectedModelId: retryModelId as AppModelId,
   };
 }
-
-export function removeTrailingAssistantMessage(messages: ChatMessage[]) {
-  const lastMessage = messages.at(-1);
-  return lastMessage?.role === "assistant" ? messages.slice(0, -1) : messages;
-}

--- a/apps/chat/lib/data-stream.test.ts
+++ b/apps/chat/lib/data-stream.test.ts
@@ -1,0 +1,66 @@
+import type { DataUIPart } from "ai";
+import { describe, expect, it } from "vitest";
+import type { ChatMessage, CustomUIDataTypes } from "@/lib/ai/types";
+import { isDataPartOnMessagePath } from "./data-stream";
+
+function messageWithDataPart(part: ChatMessage["parts"][number]): ChatMessage {
+  return {
+    id: "assistant-1",
+    metadata: {
+      activeStreamId: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      parentMessageId: "user-1",
+      selectedModel: "openai/gpt-5-mini",
+    },
+    parts: [part],
+    role: "assistant",
+  };
+}
+
+describe("isDataPartOnMessagePath", () => {
+  it("accepts selected-path data and rejects a hidden branch part", () => {
+    const selectedPart = {
+      id: "selected-update",
+      type: "data-researchUpdate",
+      data: {
+        timestamp: 1,
+        title: "Research complete",
+        toolCallId: "tool-1",
+        type: "completed",
+      },
+    } satisfies ChatMessage["parts"][number];
+    const hiddenPart = {
+      ...selectedPart,
+      id: "hidden-update",
+    } satisfies ChatMessage["parts"][number];
+    const messages = [messageWithDataPart(selectedPart)];
+
+    expect(isDataPartOnMessagePath(selectedPart, messages)).toBe(true);
+    expect(isDataPartOnMessagePath(hiddenPart, messages)).toBe(false);
+  });
+
+  it("matches id-less data parts by their typed payload", () => {
+    const selectedPart: DataUIPart<CustomUIDataTypes> = {
+      type: "data-researchUpdate",
+      data: {
+        timestamp: 1,
+        title: "Research complete",
+        toolCallId: "tool-1",
+        type: "completed",
+      },
+    };
+    const otherPart: DataUIPart<CustomUIDataTypes> = {
+      type: "data-researchUpdate",
+      data: {
+        timestamp: 2,
+        title: "Research complete",
+        toolCallId: "tool-1",
+        type: "completed",
+      },
+    };
+    const messages = [messageWithDataPart(selectedPart)];
+
+    expect(isDataPartOnMessagePath(selectedPart, messages)).toBe(true);
+    expect(isDataPartOnMessagePath(otherPart, messages)).toBe(false);
+  });
+});

--- a/apps/chat/lib/data-stream.test.ts
+++ b/apps/chat/lib/data-stream.test.ts
@@ -63,4 +63,28 @@ describe("isDataPartOnMessagePath", () => {
     expect(isDataPartOnMessagePath(selectedPart, messages)).toBe(true);
     expect(isDataPartOnMessagePath(otherPart, messages)).toBe(false);
   });
+
+  it("falls back to the payload when only the streamed part has an id", () => {
+    const data = {
+      timestamp: 1,
+      title: "Research complete",
+      toolCallId: "tool-1",
+      type: "completed",
+    } satisfies CustomUIDataTypes["researchUpdate"];
+    const persistedPart: DataUIPart<CustomUIDataTypes> = {
+      type: "data-researchUpdate",
+      data,
+    };
+    const streamedPart: DataUIPart<CustomUIDataTypes> = {
+      id: "stream-update",
+      type: "data-researchUpdate",
+      data,
+    };
+
+    expect(
+      isDataPartOnMessagePath(streamedPart, [
+        messageWithDataPart(persistedPart),
+      ])
+    ).toBe(true);
+  });
 });

--- a/apps/chat/lib/data-stream.ts
+++ b/apps/chat/lib/data-stream.ts
@@ -12,7 +12,7 @@ export function isDataPartOnMessagePath(
         return false;
       }
 
-      if (part.id !== undefined || dataPart.id !== undefined) {
+      if (part.id !== undefined && dataPart.id !== undefined) {
         return part.id === dataPart.id;
       }
 

--- a/apps/chat/lib/data-stream.ts
+++ b/apps/chat/lib/data-stream.ts
@@ -1,0 +1,22 @@
+import { type DataUIPart, isDataUIPart } from "ai";
+import equal from "fast-deep-equal";
+import type { ChatMessage, CustomUIDataTypes } from "@/lib/ai/types";
+
+export function isDataPartOnMessagePath(
+  dataPart: DataUIPart<CustomUIDataTypes>,
+  messages: ChatMessage[]
+): boolean {
+  return messages.some((message) =>
+    message.parts.some((part) => {
+      if (!(isDataUIPart(part) && part.type === dataPart.type)) {
+        return false;
+      }
+
+      if (part.id !== undefined || dataPart.id !== undefined) {
+        return part.id === dataPart.id;
+      }
+
+      return equal(part.data, dataPart.data);
+    })
+  );
+}

--- a/apps/chat/lib/thread-utils.test.ts
+++ b/apps/chat/lib/thread-utils.test.ts
@@ -1,7 +1,10 @@
 import { createThreadStateSnapshot } from "@chatjs/thread";
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "@/lib/ai/types";
-import { buildTreeSnapshotFromMessages } from "./thread-utils";
+import {
+  buildTreeSnapshotFromMessages,
+  getParallelResponseForSlot,
+} from "./thread-utils";
 
 function message({
   id,
@@ -89,5 +92,45 @@ describe("buildTreeSnapshotFromMessages", () => {
       parent.id,
       child.id,
     ]);
+  });
+});
+
+describe("getParallelResponseForSlot", () => {
+  it("keeps the selected version of a parallel response slot", () => {
+    const root = message({ id: "root", parentMessageId: null, role: "user" });
+    const original = message({
+      id: "original",
+      parallelIndex: 1,
+      parentMessageId: root.id,
+      role: "assistant",
+    });
+    const retry = message({
+      id: "retry",
+      parallelIndex: 1,
+      parentMessageId: root.id,
+      role: "assistant",
+    });
+
+    expect(getParallelResponseForSlot([original, retry], 1, original.id)).toBe(
+      original
+    );
+  });
+
+  it("uses the latest version when another parallel slot is selected", () => {
+    const root = message({ id: "root", parentMessageId: null, role: "user" });
+    const original = message({
+      id: "original",
+      parallelIndex: 1,
+      parentMessageId: root.id,
+      role: "assistant",
+    });
+    const retry = message({
+      id: "retry",
+      parallelIndex: 1,
+      parentMessageId: root.id,
+      role: "assistant",
+    });
+
+    expect(getParallelResponseForSlot([original, retry], 1, null)).toBe(retry);
   });
 });

--- a/apps/chat/lib/thread-utils.ts
+++ b/apps/chat/lib/thread-utils.ts
@@ -13,6 +13,30 @@ export interface MessageNode {
   };
 }
 
+export function getParallelResponseForSlot<T extends MessageNode>(
+  messages: T[],
+  parallelIndex: number,
+  selectedMessageId: string | null
+): T | null {
+  const selected = messages.find(
+    (message) =>
+      message.id === selectedMessageId &&
+      message.metadata?.parallelIndex === parallelIndex
+  );
+  if (selected) {
+    return selected;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.metadata?.parallelIndex === parallelIndex) {
+      return message;
+    }
+  }
+
+  return null;
+}
+
 /** Safely extract a numeric timestamp from a Date object or ISO string. */
 function toTimestamp(value: Date | string | undefined | null): number {
   if (!value) {


### PR DESCRIPTION
## Summary
- Adds message sibling navigation over the canonical tree.
- Makes edit and retry create branches without duplicating ancestors.
- Keeps the cursor and visible path synchronized after navigation.

## Behavior
Users can move between edited/retried branches while hidden descendants remain intact.

## Verification
- Browser verified edit-created branches remain exactly `1/2` and `2/2`.
- Switching backward and forward preserves assistant order.

## Review focus
Branch creation semantics and cursor/path synchronization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds branch navigation and branch-aware retries without stopping streams or duplicating ancestors. Retries regenerate the branch in place and keep parallel response slots isolated.

- Navigation moves the `ApplicationThread` cursor, clears buffered data-stream parts, and closes off‑path artifacts; active runs remain active. Edit trim uses `thread.setCursor(parentId)`.
- Required: use `regenerate({ body: { selectedModelId }, messageId })` for retries. `getRetryMessageInput` now returns `selectedModelId` and parallel slot metadata (`parallelGroupId`, `parallelIndex`, `isPrimaryParallel`); remove `removeTrailingAssistantMessage` and any manual resend/trim logic.
- Data stream applies updates only on the selected message path, safely matches persisted parts by id or payload, and resets processing when the stream source changes.
- Parallel responses keep the selected version for a slot; otherwise use the latest. Tool controls use native `title` attributes.
- API: default the response `parallelGroupId` to the parent user message metadata when undefined to preserve group membership.

<sup>Written for commit 426d7c52ea8e43eaa39eb27760ec84880fdccb1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Add branch-aware navigation and retries that preserve the canonical conversation tree while keeping the visible chat state synchronized.

New Features:
- Enable navigation between message branches and siblings while preserving hidden descendants and branch ordering.

Bug Fixes:
- Create edit and retry branches without duplicating ancestor messages or resending the parent user message.
- Keep the selected cursor, visible message path, artifacts, and streamed data synchronized during navigation and retries.
- Allow valid message-tree relationships to be recovered when ancestors are missing.

Enhancements:
- Use Thread cursor and regeneration operations as the source of truth for editing, navigation, and retries.
- Preserve active branch-owned runs when navigating instead of stopping streams.
- Replace tooltips on tool controls with native titles.

Build:
- Build the Thread package before the chat application and update CLI template Thread imports.

Tests:
- Update retry action tests to validate model selection for regeneration rather than message trimming and resend behavior.