### PR TITLE
Add Workgrove-managed ChatJS development

### DIFF
--- a/.workgrove.json
+++ b/.workgrove.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/FranciscoMoretti/workgrove/main/schema/workgrove.schema.json",
+  "version": 1,
+  "setup": { "argv": ["bun", "install"] },
+  "appGroups": {
+    "Chat": {
+      "start": { "argv": ["bun", "run", "dev:workgrove"] },
+      "stop": "process",
+      "env": {
+        "CHAT_PORT": "{apps.chat.port}",
+        "CHAT_URL": "{apps.chat.url}"
+      },
+      "apps": {
+        "chat": { "protocol": "http", "readiness": "tcp" }
+      }
+    },
+    "Website": {
+      "start": { "argv": ["bun", "scripts/dev-workgrove.ts", "site"] },
+      "stop": "process",
+      "env": {
+        "SITE_PORT": "{apps.site.port}"
+      },
+      "apps": {
+        "site": { "protocol": "http", "readiness": "tcp" }
+      }
+    }
+  }
+}

--- a/apps/chat/next.config.ts
+++ b/apps/chat/next.config.ts
@@ -1,6 +1,18 @@
 import type { NextConfig } from "next";
 
+function appHostname(): string[] {
+  if (!process.env.APP_URL) {
+    return [];
+  }
+  try {
+    return [new URL(process.env.APP_URL).hostname];
+  } catch {
+    return [];
+  }
+}
+
 const nextConfig: NextConfig = {
+  allowedDevOrigins: appHostname(),
   typedRoutes: true,
   cacheComponents: false,
   experimental: {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"worktree-env": "bun .agents/skills/worktree-ports/scripts/worktree-env.ts",
 		"dev": "dotenv -e .env.worktree.local -e .env.local -- bun run worktree-env chat -- turbo run dev --filter=@chatjs/chat",
+		"dev:workgrove": "bun scripts/dev-workgrove.ts",
 		"dev:info": "dotenv -e .env.worktree.local -e .env.local -- bun run worktree-env --info",
 		"dev:docs": "dotenv -e .env.worktree.local -e .env.local -- bun run worktree-env docs -- turbo run dev --filter=@chatjs/docs",
 		"dev:site": "dotenv -e .env.worktree.local -e .env.local -- bun run worktree-env site -- turbo run dev --filter=@chatjs/site",

--- a/scripts/dev-workgrove.ts
+++ b/scripts/dev-workgrove.ts
@@ -1,0 +1,106 @@
+import { join } from "node:path";
+
+type ChildName = "chat" | "electron" | "site";
+type AppGroup = "chat" | "site";
+
+interface ChildSpec {
+	argv: string[];
+	cwd: string;
+	env: Record<string, string>;
+	name: ChildName;
+}
+
+function requiredEnvironment(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Workgrove did not provide ${name}`);
+	}
+	return value;
+}
+
+const repositoryRoot = join(import.meta.dir, "..");
+const appGroup = (Bun.argv[2] ?? "chat") as AppGroup;
+
+if (appGroup !== "chat" && appGroup !== "site") {
+	throw new Error(`Unknown Workgrove app group: ${appGroup}`);
+}
+
+const specs: ChildSpec[] =
+	appGroup === "chat"
+		? [
+				{
+					argv: ["bun", "run", "dev"],
+					cwd: "apps/chat",
+					env: {
+						APP_URL: requiredEnvironment("CHAT_URL"),
+						PORT: requiredEnvironment("CHAT_PORT"),
+					},
+					name: "chat",
+				},
+				{
+					argv: ["bun", "run", "dev"],
+					cwd: "apps/electron",
+					env: { ELECTRON_APP_URL: requiredEnvironment("CHAT_URL") },
+					name: "electron",
+				},
+			]
+		: [
+				{
+					argv: [
+						"bunx",
+						"--bun",
+						"next",
+						"dev",
+						"--port",
+						requiredEnvironment("SITE_PORT"),
+					],
+					cwd: "apps/site",
+					env: { PORT: requiredEnvironment("SITE_PORT") },
+					name: "site",
+				},
+			];
+
+const children = specs.map((spec) => ({
+	...spec,
+	process: Bun.spawn(spec.argv, {
+		cwd: join(repositoryRoot, spec.cwd),
+		env: { ...process.env, ...spec.env },
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	}),
+}));
+
+let stopping = false;
+
+async function stop(signal: NodeJS.Signals, exitCode: number): Promise<never> {
+	if (!stopping) {
+		stopping = true;
+		for (const child of children) {
+			child.process.kill(signal);
+		}
+	}
+	await Promise.allSettled(children.map((child) => child.process.exited));
+	process.exit(exitCode);
+}
+
+process.once("SIGINT", () => {
+	void stop("SIGINT", 0);
+});
+process.once("SIGTERM", () => {
+	void stop("SIGTERM", 0);
+});
+
+const firstExit = await Promise.race(
+	children.map(async (child) => ({
+		code: await child.process.exited,
+		name: child.name,
+	}))
+);
+
+if (!stopping) {
+	console.error(
+		`${firstExit.name} exited unexpectedly with code ${firstExit.code}`
+	);
+	await stop("SIGTERM", firstExit.code === 0 ? 1 : firstExit.code);
+}


### PR DESCRIPTION
## What changed

- adds a version 1 `.workgrove.json` with independently managed Chat and Website groups
- adds a foreground launcher that coordinates Chat web and Electron processes
- passes Workgrove-assigned ports and Friendly URLs into the applications
- allows the exact `APP_URL` hostname for Next development assets and HMR

## Why

ChatJS should run from any main checkout or worktree without fixed slot ports. Workgrove assigns backing endpoints dynamically and publishes stable Friendly URLs.

The live integration also exposed stale descendants and masked launcher failures. Those runtime fixes are in FranciscoMoretti/workgrove#42, which should merge before relying on failed-launch cleanup.

## Validation

- clean branch created from current remote `main`
- `bun install --frozen-lockfile`
- scoped Biome check
- `bun test:types`
- Workgrove version 1 schema load
- live Chat + Electron launch through Workgrove
- Friendly URL returned HTTP 200 and Next accepted the development hostname

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Workgrove-managed dev flow for ChatJS and the website. Uses dynamic ports and Friendly URLs, and launches Chat web + Electron together.

- New Features
  - Add v1 `.workgrove.json` with Chat and Website groups, TCP readiness, and dynamic env wiring.
  - Add `scripts/dev-workgrove.ts` foreground launcher to run Chat web + `electron` (or `site`), pass Workgrove ports/URLs, and clean up on exit.
  - Update Chat `next` config to set `allowedDevOrigins` from `APP_URL` so dev assets and HMR work on Friendly URLs.
  - Add `dev:workgrove` script in `package.json`.

<sup>Written for commit 199ed202eb76ef0c6d6f66c1a5f6fed281730c5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

