### PR TITLE
Threads 7: Rename the thread controller

### DIFF
--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -110,9 +110,10 @@ if (threadRef.current === null) {
 }
 ```
 
-The same `Thread` is used for the lifetime of that hook instance. Updated
-callbacks and transports are applied to it without replacing its tree or
-active runs.
+The same `Thread` is retained while its identity inputs remain unchanged.
+Supplying a different external `thread` or a different defined `id` replaces
+the controller, including its tree and active runs. Updated callbacks and
+transports do not replace the retained controller.
 
 An existing `Thread` can also be supplied:
 

--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -12,7 +12,7 @@ parallel responses do not require additional hooks or mounted components.
 
 ```text
 useThread
-  -> ThreadChat
+  -> Thread
      -> message tree
      -> RunRecord A -> ThreadRunChat A -> ChatTransport
      -> RunRecord B -> ThreadRunChat B -> ChatTransport
@@ -21,7 +21,7 @@ useThread
 The three layers have separate responsibilities:
 
 - `useThread` is the public React interface.
-- `ThreadChat` is the observable, tree-backed chat engine.
+- `Thread` is the observable, tree-backed chat engine.
 - `ThreadRunChat` is an internal AI SDK request engine for one response.
 
 ## Compatibility Decision Rule
@@ -101,26 +101,26 @@ Whole-conversation state is exposed through `tree`:
 
 ## Hook Ownership
 
-By default, `useThread` creates one `ThreadChat` and keeps it in a React ref:
+By default, `useThread` creates one `Thread` and keeps it in a React ref:
 
 ```ts
-const chatRef = useRef<ThreadChat | null>(null);
-if (chatRef.current === null) {
-	chatRef.current = new ThreadChat(options);
+const threadRef = useRef<Thread | null>(null);
+if (threadRef.current === null) {
+	threadRef.current = new Thread(options);
 }
 ```
 
-The same `ThreadChat` is used for the lifetime of that hook instance. Updated
+The same `Thread` is used for the lifetime of that hook instance. Updated
 callbacks and transports are applied to it without replacing its tree or
 active runs.
 
-An existing `ThreadChat` can also be supplied:
+An existing `Thread` can also be supplied:
 
 ```ts
-const threadChat = createThreadChat({ transport });
+const thread = createThread({ transport });
 
 function useConversation() {
-  return useThread({ chat: threadChat });
+  return useThread({ thread });
 }
 ```
 
@@ -128,12 +128,12 @@ In this mode, `useThread` subscribes to the supplied engine instead of creating
 one. This changes engine ownership, not the returned hook interface.
 
 In both modes there is one mounted `useThread`. `ThreadRunChat` instances are
-ordinary class instances created imperatively by `ThreadChat`; they are not
+ordinary class instances created imperatively by `Thread`; they are not
 React hooks or components.
 
-## ThreadChat State
+## Thread State
 
-`ThreadChat` is the canonical state owner. It stores:
+`Thread` is the canonical state owner. It stores:
 
 - each message once, keyed by message ID
 - one parent ID per message
@@ -164,7 +164,7 @@ Tree mutations enforce these invariants:
 
 ## Identity and Continuity
 
-`ThreadChat.id` identifies the complete threaded conversation. It has the same
+`Thread.id` identifies the complete threaded conversation. It has the same
 role as AI SDK's `Chat.id`, remains stable as messages are added, and is sent to
 the transport as `chatId` on every request.
 
@@ -180,13 +180,13 @@ the new user beneath the selected head, then attaches and selects the assistant
 when AI SDK first publishes it. Starting from an earlier node creates siblings
 without changing existing identities or ancestry.
 
-Tree snapshots persist topology and cursor selection, but not `ThreadChat.id`.
+Tree snapshots persist topology and cursor selection, but not `Thread.id`.
 Callers that restore a conversation associate the snapshot with its stable
-conversation ID and supply that ID to the new `ThreadChat` instance.
+conversation ID and supply that ID to the new `Thread` instance.
 
 ## React Subscription
 
-`useThread` subscribes to `ThreadChat` with `useSyncExternalStore`. A tree
+`useThread` subscribes to `Thread` with `useSyncExternalStore`. A tree
 mutation, cursor change, stream update, or run status change publishes a new
 snapshot.
 
@@ -216,7 +216,7 @@ message ID remains unknown until AI SDK first publishes the response and may
 then come from the server. Message-based helpers resolve the run associated with
 that node after this binding occurs.
 
-`ThreadChat` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
+`Thread` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
 reconnection needs an AI SDK request lifecycle. Completed run records are
 currently retained so their status and ownership information remain
 addressable.
@@ -233,7 +233,7 @@ the parent of another response. Therefore, a bare `startRun` from an assistant
 message is rejected. Branching from an assistant remains supported by attaching
 a new input message with `sendMessage` and generating from that input.
 
-This is a `ThreadChat` live-run invariant, not a `MessageTree` invariant. The
+This is a `Thread` live-run invariant, not a `MessageTree` invariant. The
 tree remains role-agnostic so persisted, restored, or server-created data may
 contain assistant-to-assistant edges.
 
@@ -251,8 +251,8 @@ behavior for:
 - `sendAutomaticallyWhen`
 - regeneration and reconnection
 
-The internal `ThreadChatState` presents one linear branch path to
-`AbstractChat`. It writes accumulated assistant snapshots into `ThreadChat`
+The internal `ThreadRunState` presents one linear branch path to
+`AbstractChat`. It writes accumulated assistant snapshots into `Thread`
 when AI SDK publishes the streaming response.
 
 `ThreadRunChat` does not insert a synthetic response into that path. AI SDK
@@ -265,7 +265,7 @@ continue the same node.
 The supplied AI SDK `ChatTransport` remains the request and stream boundary.
 The package does not define another transport protocol or manually parse
 `UIMessageChunk` values. A delegating transport ensures new and reconnected
-runs use the latest transport configured on `ThreadChat`.
+runs use the latest transport configured on `Thread`.
 
 Each request receives the selected linear path. `ChatRequestOptions` are passed
 to the configured transport unchanged; tree controls never leak into the
@@ -343,7 +343,7 @@ cursor.
 ## Tool Ownership
 
 Tool output and approval APIs retain their standard `useChat` signatures.
-`ThreadChat` indexes each tool call and approval ID to the run that emitted it,
+`Thread` indexes each tool call and approval ID to the run that emitted it,
 then routes subsequent mutations back to that run's `ThreadRunChat`.
 
 Tool-call and approval IDs must be unique across all retained, addressable
@@ -382,14 +382,14 @@ The snapshot can be supplied later as `initialTree`. Active request objects,
 abort controllers, and `ThreadRunChat` instances are not serialized.
 Restoration rebuilds tool-call and approval ownership from the serialized
 assistant messages. When a standard tool-output or approval helper targets a
-restored message, `ThreadChat` lazily creates the owning branch's internal run
+restored message, `Thread` lazily creates the owning branch's internal run
 adapter before applying the mutation. Reconnection uses the same lazy adapter
 creation. This preserves `useChat` tool behavior without eagerly retaining an
 adapter for every historical assistant message.
 
 ## Concurrency
 
-`ThreadChat` enforces optional limits before mutating the tree:
+`Thread` enforces optional limits before mutating the tree:
 
 ```ts
 useThread({

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -6,7 +6,7 @@ import {
 	type ChatTransport,
 	type UIMessage,
 } from "ai";
-import type { ThreadChatOptions } from "./types";
+import type { ThreadInit } from "./types";
 
 export type ThreadRunSpec = {
 	id: string;
@@ -16,14 +16,14 @@ export type ThreadRunSpec = {
 };
 
 export interface ThreadRunHost<TMessage extends UIMessage> {
-	readonly dataPartSchemas: ThreadChatOptions<TMessage>["dataPartSchemas"];
+	readonly dataPartSchemas: ThreadInit<TMessage>["dataPartSchemas"];
 	readonly id: string;
-	readonly messageMetadataSchema: ThreadChatOptions<TMessage>["messageMetadataSchema"];
-	onData: ThreadChatOptions<TMessage>["onData"];
-	onError: ThreadChatOptions<TMessage>["onError"];
-	onFinish: ThreadChatOptions<TMessage>["onFinish"];
-	onToolCall: ThreadChatOptions<TMessage>["onToolCall"];
-	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
+	readonly messageMetadataSchema: ThreadInit<TMessage>["messageMetadataSchema"];
+	onData: ThreadInit<TMessage>["onData"];
+	onError: ThreadInit<TMessage>["onError"];
+	onFinish: ThreadInit<TMessage>["onFinish"];
+	onToolCall: ThreadInit<TMessage>["onToolCall"];
+	sendAutomaticallyWhen: ThreadInit<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
 	generateMessageId: () => string;
 	getRunPath: (runId: string) => TMessage[];
@@ -35,7 +35,7 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	writeRunMessage: (runId: string, message: TMessage) => void;
 }
 
-class ThreadChatState<TMessage extends UIMessage>
+class ThreadRunState<TMessage extends UIMessage>
 	implements ChatState<TMessage>
 {
 	#error: Error | undefined;
@@ -133,7 +133,7 @@ export class ThreadRunChat<
 			},
 			sendAutomaticallyWhen: (event) =>
 				host.sendAutomaticallyWhen?.(event) ?? false,
-			state: new ThreadChatState(host, spec),
+			state: new ThreadRunState(host, spec),
 			transport,
 		});
 	}

--- a/packages/thread/src/index.ts
+++ b/packages/thread/src/index.ts
@@ -1,11 +1,11 @@
 export { getMessageText } from "./message-utils";
-export { createThreadChat, ThreadChat } from "./thread-chat";
+export { createThread, Thread } from "./thread";
 
 export type {
 	MessageTreeNode,
 	MessageTreeSnapshot,
-	ThreadChatOptions,
 	ThreadConcurrency,
+	ThreadInit,
 	ThreadRun,
 	ThreadRunHandle,
 	ThreadStartRunOptions,

--- a/packages/thread/src/thread.ts
+++ b/packages/thread/src/thread.ts
@@ -17,7 +17,7 @@ import { MessageTree } from "./message-tree";
 import { type RunRecord, RunRegistry } from "./run-registry";
 import type {
 	MessageTreeSnapshot,
-	ThreadChatOptions,
+	ThreadInit,
 	ThreadRunHandle,
 	ThreadStartRunOptions,
 	ThreadStateSnapshot,
@@ -73,20 +73,18 @@ async function createMessageFromInput<TMessage extends UIMessage>({
 	});
 }
 
-export class ThreadChat<TMessage extends UIMessage = UIMessage>
+export class Thread<TMessage extends UIMessage = UIMessage>
 	implements ThreadRunHost<TMessage>
 {
 	readonly id: string;
-	readonly dataPartSchemas: ThreadChatOptions<TMessage>["dataPartSchemas"];
-	readonly generateMessageId: NonNullable<
-		ThreadChatOptions<TMessage>["generateId"]
-	>;
-	readonly messageMetadataSchema: ThreadChatOptions<TMessage>["messageMetadataSchema"];
-	onData: ThreadChatOptions<TMessage>["onData"];
-	onError: ThreadChatOptions<TMessage>["onError"];
-	onFinish: ThreadChatOptions<TMessage>["onFinish"];
-	onToolCall: ThreadChatOptions<TMessage>["onToolCall"];
-	sendAutomaticallyWhen: ThreadChatOptions<TMessage>["sendAutomaticallyWhen"];
+	readonly dataPartSchemas: ThreadInit<TMessage>["dataPartSchemas"];
+	readonly generateMessageId: NonNullable<ThreadInit<TMessage>["generateId"]>;
+	readonly messageMetadataSchema: ThreadInit<TMessage>["messageMetadataSchema"];
+	onData: ThreadInit<TMessage>["onData"];
+	onError: ThreadInit<TMessage>["onError"];
+	onFinish: ThreadInit<TMessage>["onFinish"];
+	onToolCall: ThreadInit<TMessage>["onToolCall"];
+	sendAutomaticallyWhen: ThreadInit<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
 
 	readonly #listeners = new Set<() => void>();
@@ -94,7 +92,7 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	readonly #tree: MessageTree<TMessage>;
 	#snapshot: ThreadStateSnapshot<TMessage>;
 
-	constructor(options: ThreadChatOptions<TMessage> = {}) {
+	constructor(options: ThreadInit<TMessage> = {}) {
 		this.id = options.id ?? generateId();
 		this.dataPartSchemas = options.dataPartSchemas;
 		this.generateMessageId = options.generateId ?? generateId;
@@ -567,8 +565,8 @@ export class ThreadChat<TMessage extends UIMessage = UIMessage>
 	}
 }
 
-export function createThreadChat<TMessage extends UIMessage = UIMessage>(
-	options: ThreadChatOptions<TMessage> = {},
+export function createThread<TMessage extends UIMessage = UIMessage>(
+	options: ThreadInit<TMessage> = {},
 ) {
-	return new ThreadChat(options);
+	return new Thread(options);
 }

--- a/packages/thread/src/types.ts
+++ b/packages/thread/src/types.ts
@@ -67,7 +67,7 @@ type ThreadInitialState<TMessage extends UIMessage> =
 	| { initialTree: MessageTreeSnapshot<TMessage>; messages?: never }
 	| { initialTree?: never; messages?: TMessage[] };
 
-export type ThreadChatOptions<TMessage extends UIMessage = UIMessage> = Omit<
+export type ThreadInit<TMessage extends UIMessage = UIMessage> = Omit<
 	ChatInit<TMessage>,
 	"messages"
 > & {

--- a/packages/thread/src/use-thread.ts
+++ b/packages/thread/src/use-thread.ts
@@ -1,10 +1,10 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatRequestOptions, UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
-import { ThreadChat } from "./thread-chat";
+import { Thread } from "./thread";
 import type {
 	MessageTreeSnapshot,
-	ThreadChatOptions,
+	ThreadInit,
 	ThreadRun,
 	ThreadRunHandle,
 	ThreadStartRunOptions,
@@ -18,25 +18,25 @@ type ThreadHookOptions = {
 };
 
 type ThreadCallbacks<TMessage extends UIMessage> = Pick<
-	ThreadChatOptions<TMessage>,
+	ThreadInit<TMessage>,
 	"onData" | "onError" | "onFinish" | "onToolCall" | "sendAutomaticallyWhen"
 >;
 
 type ExternalThreadOptions<TMessage extends UIMessage> = ThreadHookOptions & {
-	chat: ThreadChat<TMessage>;
+	thread: Thread<TMessage>;
 };
 
 export type UseThreadOptions<TMessage extends UIMessage = UIMessage> =
 	| ExternalThreadOptions<TMessage>
 	| (ThreadHookOptions &
-			ThreadChatOptions<TMessage> & {
-				chat?: never;
+			ThreadInit<TMessage> & {
+				thread?: never;
 			});
 
-function hasSuppliedChat<TMessage extends UIMessage>(
+function hasSuppliedThread<TMessage extends UIMessage>(
 	options: UseThreadOptions<TMessage>,
 ): options is ExternalThreadOptions<TMessage> {
-	return "chat" in options && options.chat !== undefined;
+	return "thread" in options && options.thread !== undefined;
 }
 
 export type TreeHelpers<TMessage extends UIMessage = UIMessage> = {
@@ -62,7 +62,7 @@ export type TreeHelpers<TMessage extends UIMessage = UIMessage> = {
 	startRun: (
 		options?: ThreadStartRunOptions<TMessage>,
 	) => Promise<ThreadRunHandle>;
-	status: ReturnType<ThreadChat<TMessage>["getSnapshot"]>["treeStatus"];
+	status: ReturnType<Thread<TMessage>["getSnapshot"]>["treeStatus"];
 	stopAll: () => Promise<void>;
 	stopRun: (runId: string) => Promise<void>;
 	stopRunForMessage: (messageId: string) => Promise<void>;
@@ -77,29 +77,29 @@ export type UseThreadHelpers<TMessage extends UIMessage = UIMessage> =
 		tree: TreeHelpers<TMessage>;
 	};
 
-function useThreadChatSnapshot<TMessage extends UIMessage>(
-	chat: ThreadChat<TMessage>,
+function useThreadSnapshot<TMessage extends UIMessage>(
+	thread: Thread<TMessage>,
 	throttleWaitMs?: number,
 ) {
 	const stateRef = useRef({
-		chat,
-		snapshot: chat.getSnapshot(),
+		thread,
+		snapshot: thread.getSnapshot(),
 	});
-	if (stateRef.current.chat !== chat) {
+	if (stateRef.current.thread !== thread) {
 		stateRef.current = {
-			chat,
-			snapshot: chat.getSnapshot(),
+			thread,
+			snapshot: thread.getSnapshot(),
 		};
 	}
 
 	const subscribe = useCallback(
 		(listener: () => void) => {
-			stateRef.current.snapshot = chat.getSnapshot();
+			stateRef.current.snapshot = thread.getSnapshot();
 			const publish = () => {
-				stateRef.current.snapshot = chat.getSnapshot();
+				stateRef.current.snapshot = thread.getSnapshot();
 				listener();
 			};
-			if (!throttleWaitMs) return chat.subscribe(publish);
+			if (!throttleWaitMs) return thread.subscribe(publish);
 
 			let lastCall = 0;
 			let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -118,37 +118,40 @@ function useThreadChatSnapshot<TMessage extends UIMessage>(
 				}, throttleWaitMs - elapsed);
 			};
 
-			const unsubscribe = chat.subscribe(notify);
+			const unsubscribe = thread.subscribe(notify);
 			return () => {
 				unsubscribe();
 				if (timeout) clearTimeout(timeout);
 			};
 		},
-		[chat, throttleWaitMs],
+		[thread, throttleWaitMs],
 	);
 	const getSnapshot = useCallback(() => stateRef.current.snapshot, []);
 
 	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
-function useThreadChatField<
+function useThreadField<
 	TMessage extends UIMessage,
 	TKey extends keyof ThreadStateSnapshot<TMessage>,
->(chat: ThreadChat<TMessage>, key: TKey) {
+>(thread: Thread<TMessage>, key: TKey) {
 	const subscribe = useCallback(
-		(listener: () => void) => chat.subscribe(listener),
-		[chat],
+		(listener: () => void) => thread.subscribe(listener),
+		[thread],
 	);
-	const getSnapshot = useCallback(() => chat.getSnapshot()[key], [chat, key]);
+	const getSnapshot = useCallback(
+		() => thread.getSnapshot()[key],
+		[thread, key],
+	);
 	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useThread<TMessage extends UIMessage = UIMessage>(
 	options: UseThreadOptions<TMessage> = {},
 ): UseThreadHelpers<TMessage> {
-	const hasExternalChat = hasSuppliedChat(options);
+	const hasExternalThread = hasSuppliedThread(options);
 	const callbacksRef = useRef<ThreadCallbacks<TMessage>>(
-		hasExternalChat
+		hasExternalThread
 			? {}
 			: {
 					onData: options.onData,
@@ -159,7 +162,7 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 				},
 	);
 
-	if (!hasExternalChat) {
+	if (!hasExternalThread) {
 		callbacksRef.current = {
 			onData: options.onData,
 			onError: options.onError,
@@ -169,7 +172,7 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 		};
 	}
 
-	const chatOptions: ThreadChatOptions<TMessage> | undefined = hasExternalChat
+	const threadOptions: ThreadInit<TMessage> | undefined = hasExternalThread
 		? undefined
 		: {
 				...options,
@@ -181,71 +184,71 @@ export function useThread<TMessage extends UIMessage = UIMessage>(
 					callbacksRef.current.sendAutomaticallyWhen?.(event) ?? false,
 			};
 
-	const chatRef = useRef<ThreadChat<TMessage> | null>(null);
-	let chat = chatRef.current;
+	const threadRef = useRef<Thread<TMessage> | null>(null);
+	let thread = threadRef.current;
 	if (
-		chat === null ||
-		(hasExternalChat && options.chat !== chat) ||
-		(!hasExternalChat && options.id !== undefined && chat.id !== options.id)
+		thread === null ||
+		(hasExternalThread && options.thread !== thread) ||
+		(!hasExternalThread && options.id !== undefined && thread.id !== options.id)
 	) {
-		chat = hasExternalChat ? options.chat : new ThreadChat(chatOptions);
-		chatRef.current = chat;
+		thread = hasExternalThread ? options.thread : new Thread(threadOptions);
+		threadRef.current = thread;
 	}
 
-	const snapshot = useThreadChatSnapshot(chat, options.experimental_throttle);
-	const status = useThreadChatField(chat, "status");
-	const error = useThreadChatField(chat, "error");
-	const treeStatus = useThreadChatField(chat, "treeStatus");
+	const snapshot = useThreadSnapshot(thread, options.experimental_throttle);
+	const status = useThreadField(thread, "status");
+	const error = useThreadField(thread, "error");
+	const treeStatus = useThreadField(thread, "treeStatus");
 
 	useEffect(() => {
-		if (options.resume) chatRef.current?.resumeStream();
+		if (options.resume) threadRef.current?.resumeStream();
 	}, [options.resume]);
 
 	const setMessages = useCallback<UseChatHelpers<TMessage>["setMessages"]>(
-		(messages) => chatRef.current?.setMessages(messages),
+		(messages) => threadRef.current?.setMessages(messages),
 		[],
 	);
 
 	return {
-		addToolApprovalResponse: chat.addToolApprovalResponse,
-		addToolOutput: chat.addToolOutput,
-		addToolResult: chat.addToolResult,
-		clearError: chat.clearError,
+		addToolApprovalResponse: thread.addToolApprovalResponse,
+		addToolOutput: thread.addToolOutput,
+		addToolResult: thread.addToolResult,
+		clearError: thread.clearError,
 		error,
-		id: chat.id,
+		id: thread.id,
 		messages: snapshot.messages,
-		regenerate: chat.regenerate,
-		resumeStream: chat.resumeStream,
-		sendMessage: chat.sendMessage,
+		regenerate: thread.regenerate,
+		resumeStream: thread.resumeStream,
+		sendMessage: thread.sendMessage,
 		setMessages,
 		status,
-		stop: chat.stop,
+		stop: thread.stop,
 		tree: {
 			activeRuns: snapshot.activeRuns,
 			childrenByParentId: snapshot.childrenByParentId,
 			cursorId: snapshot.cursorId,
-			getChildren: (messageId) => chat.getChildren(messageId),
-			getLeaves: (messageId) => chat.getLeaves(messageId),
-			getMessage: (messageId) => chat.getMessage(messageId),
-			getParent: (messageId) => chat.getParent(messageId),
-			getPath: (messageId) => chat.getPath(messageId),
-			getRun: (runId) => chat.getRun(runId),
-			getRunForMessage: (messageId) => chat.getRunForMessage(messageId),
-			getSiblings: (messageId) => chat.getSiblings(messageId),
-			getSnapshot: () => chat.getTreeSnapshot(),
+			getChildren: (messageId) => thread.getChildren(messageId),
+			getLeaves: (messageId) => thread.getLeaves(messageId),
+			getMessage: (messageId) => thread.getMessage(messageId),
+			getParent: (messageId) => thread.getParent(messageId),
+			getPath: (messageId) => thread.getPath(messageId),
+			getRun: (runId) => thread.getRun(runId),
+			getRunForMessage: (messageId) => thread.getRunForMessage(messageId),
+			getSiblings: (messageId) => thread.getSiblings(messageId),
+			getSnapshot: () => thread.getTreeSnapshot(),
 			messagesById: snapshot.messagesById,
 			parentById: snapshot.parentById,
 			resumeRun: (runId, requestOptions) =>
-				chat.resumeRun(runId, requestOptions),
+				thread.resumeRun(runId, requestOptions),
 			rootIds: snapshot.rootIds,
 			runs: snapshot.runs,
-			setCursor: (messageId) => chat.setCursor(messageId),
-			setCursorToParentOf: (messageId) => chat.setCursorToParentOf(messageId),
-			startRun: (runOptions) => chat.startRun(runOptions),
+			setCursor: (messageId) => thread.setCursor(messageId),
+			setCursorToParentOf: (messageId) => thread.setCursorToParentOf(messageId),
+			startRun: (runOptions) => thread.startRun(runOptions),
 			status: treeStatus,
-			stopAll: () => chat.stopAll(),
-			stopRun: (runId) => chat.stopRun(runId),
-			stopRunForMessage: (messageId) => chat.stopRunForMessage(messageId),
+			stopAll: () => thread.stopAll(),
+			stopRun: (runId) => thread.stopRun(runId),
+			stopRunForMessage: (messageId) => thread.stopRunForMessage(messageId),
 		},
 	};
 }

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -49,7 +49,7 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 
 class TestRunHost implements ThreadRunHost<UIMessage> {
 	readonly dataPartSchemas = undefined;
-	readonly id = "thread-chat";
+	readonly id = "thread";
 	readonly messageMetadataSchema = undefined;
 	readonly generateMessageId = () => "client-response";
 	readonly spec: ThreadRunSpec;

--- a/packages/thread/test/package-smoke.test.ts
+++ b/packages/thread/test/package-smoke.test.ts
@@ -84,17 +84,17 @@ test("the packed package loads its core and React entry points", async () => {
 		expect(reactSource.startsWith('"use client";')).toBeTrue();
 		expect(indexChunk).toBeDefined();
 		expect(reactChunk).toBe(indexChunk);
-		expect(reactSource).not.toContain("class ThreadChat");
+		expect(reactSource).not.toContain("class Thread");
 		if (!reactChunk) throw new Error("Expected a shared package chunk");
 		expect(
 			await Bun.file(resolve(installedPackage, "dist", reactChunk)).exists(),
 		).toBeTrue();
 
 		const consumerSource = `
-import { ThreadChat } from "@chatjs/thread";
+import { Thread } from "@chatjs/thread";
 import { useThread } from "@chatjs/thread/react";
 
-const chat = new ThreadChat();
+const chat = new Thread();
 if (typeof chat.id !== "string" || typeof useThread !== "function") {
   throw new Error("Package exports did not load");
 }

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
 import { getMessageText } from "../src/message-utils";
-import { ThreadChat } from "../src/thread-chat";
+import { Thread } from "../src/thread";
 
 class ControlledTransport implements ChatTransport<UIMessage> {
 	readonly requests: Array<{
@@ -116,10 +116,10 @@ async function waitFor(predicate: () => boolean) {
 	throw new Error("Timed out waiting for request");
 }
 
-describe("ThreadChat", () => {
+describe("Thread", () => {
 	test("streams concurrent responses into separate assistant siblings", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const primary = await chat.startRun({
 			follow: true,
 			message: user("user-1"),
@@ -143,7 +143,7 @@ describe("ThreadChat", () => {
 
 	test("keeps a submitted response out of the tree until streaming starts", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const run = await chat.startRun({
 			message: user("user-1"),
 		});
@@ -168,7 +168,7 @@ describe("ThreadChat", () => {
 	test("uses AI SDK's client response ID when the stream omits one", async () => {
 		const generatedIds = ["run-1", "client-response"];
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			generateId: () => generatedIds.shift() ?? "unexpected-id",
 			id: "thread-1",
 			transport,
@@ -192,7 +192,7 @@ describe("ThreadChat", () => {
 
 	test("attaches streamed output without requiring a user parent", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const run = await chat.startRun({
 			message: {
 				id: "context-1",
@@ -216,7 +216,7 @@ describe("ThreadChat", () => {
 			parts: [{ text: "first", type: "text" }],
 			role: "assistant",
 		};
-		const chat = new ThreadChat({ messages: [parent], transport });
+		const chat = new Thread({ messages: [parent], transport });
 
 		await expect(chat.startRun({ from: parent.id })).rejects.toThrow(
 			"Cannot start a new run directly from assistant message assistant-parent; attach an input message first",
@@ -228,7 +228,7 @@ describe("ThreadChat", () => {
 
 	test("rejects an assistant input without mutating the tree", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ messages: [user("user-1")], transport });
+		const chat = new Thread({ messages: [user("user-1")], transport });
 
 		await expect(
 			chat.sendMessage({
@@ -246,7 +246,7 @@ describe("ThreadChat", () => {
 	});
 
 	test("keeps hidden branches when reconciling the selected path", () => {
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],
 		});
 		chat.addMessage(user("user-2"), "assistant-1");
@@ -268,7 +268,7 @@ describe("ThreadChat", () => {
 
 	test("does not follow a delayed run after the active path changes", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const primary = await chat.startRun({ message: user("user-1") });
 		await waitFor(() => transport.requests.length === 1);
 
@@ -282,7 +282,7 @@ describe("ThreadChat", () => {
 
 	test("rejects concurrency before adding another user message", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			concurrency: { maxActiveRuns: 1 },
 			transport,
 		});
@@ -300,7 +300,7 @@ describe("ThreadChat", () => {
 
 	test("stopping one run does not abort another", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const first = await chat.startRun({
 			message: user("user-1"),
 		});
@@ -319,7 +319,7 @@ describe("ThreadChat", () => {
 
 	test("keeps creation order after an earlier run fails without a message", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const failed = await chat.startRun({ message: user("user-1") });
 		await waitFor(() => transport.requests.length === 1);
 		transport.fail(0, new Error("failed before start"));
@@ -340,7 +340,7 @@ describe("ThreadChat", () => {
 
 	test("preserves an error when resume finds no stream", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const run = await chat.startRun({ message: user("user-1") });
 		await waitFor(() => transport.requests.length === 1);
 		transport.fail(0, new Error("failed"));
@@ -359,7 +359,7 @@ describe("ThreadChat", () => {
 
 	test("run handles expose the current resumed request", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const run = await chat.startRun({ message: user("user-1") });
 		await waitFor(() => transport.requests.length === 1);
 		transport.emitText(0, "assistant-1", "first");
@@ -382,7 +382,7 @@ describe("ThreadChat", () => {
 
 	test("aggregate status ignores historical run errors", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const failed = await chat.startRun({ message: user("user-1") });
 		await waitFor(() => transport.requests.length === 1);
 		transport.fail(0, new Error("failed"));
@@ -403,7 +403,7 @@ describe("ThreadChat", () => {
 
 	test("unexpected application errors reject the run promise", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			sendAutomaticallyWhen: () => {
 				throw new Error("application callback failed");
 			},
@@ -418,7 +418,7 @@ describe("ThreadChat", () => {
 
 	test("regenerates an assistant as a sibling response", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const first = await chat.startRun({
 			message: user("user-1"),
 		});
@@ -440,7 +440,7 @@ describe("ThreadChat", () => {
 
 	test("rejects an unknown explicit regeneration target", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],
 			transport,
 		});
@@ -454,7 +454,7 @@ describe("ThreadChat", () => {
 
 	test("rejects regeneration when the response parent is an assistant", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			messages: [
 				{ ...user("assistant-parent"), role: "assistant" },
 				{ ...user("assistant-child"), role: "assistant" },
@@ -480,7 +480,7 @@ describe("ThreadChat", () => {
 			...user("assistant-child"),
 			role: "assistant" as const,
 		};
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			initialTree: {
 				cursorId: assistantChild.id,
 				nodes: [
@@ -500,7 +500,7 @@ describe("ThreadChat", () => {
 
 	test("routes tool output and approval to their owning runs", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({ transport });
+		const chat = new Thread({ transport });
 		const runA = await chat.startRun({
 			message: user("user-a"),
 		});
@@ -570,7 +570,7 @@ describe("ThreadChat", () => {
 
 	test("enforces the global concurrency limit before resuming", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			concurrency: { maxActiveRuns: 1 },
 			transport,
 		});
@@ -595,7 +595,7 @@ describe("ThreadChat", () => {
 
 	test("enforces the per-message concurrency limit before resuming", async () => {
 		const transport = new ControlledTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			concurrency: { maxActiveRunsPerMessage: 1 },
 			transport,
 		});
@@ -619,7 +619,7 @@ describe("ThreadChat", () => {
 
 	test("resumes a restored assistant through its reconstructed run", async () => {
 		const transport = new ResumeTransport();
-		const chat = new ThreadChat({
+		const chat = new Thread({
 			messages: [
 				user("user-1"),
 				{ id: "assistant-1", parts: [], role: "assistant" },

--- a/packages/thread/test/use-thread-types.ts
+++ b/packages/thread/test/use-thread-types.ts
@@ -1,7 +1,7 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { type UseThreadHelpers, useThread } from "../src/react";
-import { ThreadChat } from "../src/thread-chat";
+import { Thread } from "../src/thread";
 
 declare const messageId: string;
 
@@ -30,10 +30,10 @@ function useCompatibilityCheck() {
 	return explicitHelpers;
 }
 
-function useExternalChatCheck() {
-	const chat = new ThreadChat<UIMessage>();
-	return useThread({ chat });
+function useExternalThreadCheck() {
+	const thread = new Thread<UIMessage>();
+	return useThread({ thread });
 }
 
 void useCompatibilityCheck;
-void useExternalChatCheck;
+void useExternalThreadCheck;

--- a/packages/thread/test/use-thread.test.ts
+++ b/packages/thread/test/use-thread.test.ts
@@ -3,7 +3,7 @@ import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
 import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { getMessageText } from "../src/message-utils";
-import { ThreadChat } from "../src/thread-chat";
+import { Thread } from "../src/thread";
 import {
 	type UseThreadHelpers,
 	type UseThreadOptions,
@@ -125,7 +125,7 @@ async function waitFor(predicate: () => boolean) {
 }
 
 describe("useThread", () => {
-	test("uses current callbacks without replacing the chat transport", async () => {
+	test("uses current callbacks without replacing the thread transport", async () => {
 		const firstTransport = new RejectingTransport();
 		const secondTransport = new RejectingTransport();
 		const firstError = mock(() => {});
@@ -164,24 +164,24 @@ describe("useThread", () => {
 		hook.unmount();
 	});
 
-	test("resubscribes when the supplied chat changes", () => {
-		const first = new ThreadChat({ messages: [user("user-a")] });
-		const second = new ThreadChat({ messages: [user("user-b")] });
-		const hook = renderUseThread({ chat: first });
+	test("resubscribes when the supplied thread changes", () => {
+		const first = new Thread({ messages: [user("user-a")] });
+		const second = new Thread({ messages: [user("user-b")] });
+		const hook = renderUseThread({ thread: first });
 
 		expect(hook.current.messages.map(({ id }) => id)).toEqual(["user-a"]);
-		hook.update({ chat: second });
+		hook.update({ thread: second });
 		expect(hook.current.messages.map(({ id }) => id)).toEqual(["user-b"]);
 		hook.unmount();
 	});
 
-	test("automatically resumes the supplied chat", async () => {
+	test("automatically resumes the supplied thread", async () => {
 		const transport = new ResumeTransport();
-		const chat = new ThreadChat({
+		const thread = new Thread({
 			messages: [user("user-1"), assistant("assistant-1")],
 			transport,
 		});
-		const hook = renderUseThread({ chat, resume: true });
+		const hook = renderUseThread({ thread, resume: true });
 
 		await act(async () => {
 			await Bun.sleep(0);


### PR DESCRIPTION
## Summary

- rename the imperative controller from `ThreadChat` to `Thread`
- rename `createThreadChat` to `createThread` and `ThreadChatOptions` to `ThreadInit`
- make `useThread({ thread })` match the ownership model introduced by the next PR

This is a behavior-free refactor that isolates terminology changes from the external-state architecture.

## Summary by Sourcery

Rename the core thread controller and associated React hook interfaces to use the `Thread` terminology without changing behavior.

Enhancements:
- Rename the imperative thread controller from `ThreadChat` to `Thread` and adjust exports accordingly.
- Update `useThread` to accept a `thread` instance instead of `chat`, aligning the hook ownership model with external thread engines.
- Rename initialization types and factory helpers from `ThreadChatOptions`/`createThreadChat` to `ThreadInit`/`createThread` for clearer API semantics.

Documentation:
- Update the thread package architecture documentation to describe the engine as `Thread` instead of `ThreadChat`, including ownership and state descriptions.

Tests:
- Rename and update thread-related tests to use the new `Thread` terminology and validate the unchanged behavior of the refactored APIs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the thread controller to `Thread` and updated the React hook to accept `{ thread }`. Clarified `useThread` identity rules; no behavior changes.

- **Refactors**
  - `ThreadChat` -> `Thread`, `createThreadChat` -> `createThread`.
  - `ThreadChatOptions` -> `ThreadInit`.
  - Internal `ThreadChatState` -> `ThreadRunState`.
  - Updated exports, docs, and tests to new names.
  - Documented identity lifetime: the same `Thread` is retained; changing the external `thread` or a defined `id` replaces the controller (including tree and active runs).

- **Migration**
  - Instantiate `new Thread()` instead of `new ThreadChat()`.
  - Use `createThread(...)` instead of `createThreadChat(...)`.
  - Call `useThread({ thread })` instead of `useThread({ chat })`.
  - Replace `ThreadChatOptions` with `ThreadInit`.

<sup>Written for commit 9b89d725ecb175fa6cb3e01808ad798732765930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the primary API from `ThreadChat` to `Thread`.
  * Renamed `createThreadChat` to `createThread`.
  * Renamed `ThreadChatOptions` to `ThreadInit`.
  * Updated `useThread` to accept a `thread` instance (replacing `chat`), with snapshot/status typings now aligning to `Thread`.
* **Documentation**
  * Refreshed architecture terminology and ownership boundaries to use `Thread` concepts.
* **Tests**
  * Updated smoke and unit tests to target the new `Thread` API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#261** 👈 current
2. #262
3. #240
4. #241
5. #242
6. #243
7. #244
8. #263
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
<!-- stack:links:end -->