### PR TITLE
Threads 9: Align Thread with AI SDK request semantics

### DIFF
--- a/packages/thread/ARCHITECTURE.md
+++ b/packages/thread/ARCHITECTURE.md
@@ -290,7 +290,7 @@ message ID remains unknown until AI SDK first publishes the response and may
 then come from the server. Message-based helpers resolve the run associated with
 that node after this binding occurs.
 
-`Thread` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
+`AbstractThread` creates a `ThreadRunChat` when `sendMessage`, `startRun`, or a
 reconnection needs an AI SDK request lifecycle. Completed run records are
 currently retained so their status and ownership information remain
 addressable.
@@ -301,15 +301,26 @@ run has independent status, error, request serialization, and cancellation.
 Automatic tool continuations remain in the same run and update the same
 assistant response node.
 
-A new live run requires a non-assistant response parent. AI SDK interprets an
-assistant message at the end of a request as the response to continue, not as
-the parent of another response. Therefore, a bare `startRun` from an assistant
-message is rejected. Branching from an assistant remains supported by attaching
-a new input message with `sendMessage` and generating from that input.
+A new independent response requires a non-assistant response parent. AI SDK
+interprets an assistant message at the end of a request as the response to
+continue, not as the parent of another response. Therefore, a bare `startRun`
+from an assistant message is rejected.
+
+The `useChat`-compatible `sendMessage` surface keeps AI SDK's continuation
+semantics. Calling `sendMessage()` on a selected assistant continues that node,
+and passing an explicit assistant message attaches and streams into that same
+message ID. Neither operation creates a child response under the assistant.
+Applications create a branch below an assistant by attaching a new input
+message and generating from that input.
 
 This is a `Thread` live-run invariant, not a `MessageTree` invariant. The
 tree remains role-agnostic so persisted, restored, or server-created data may
 contain assistant-to-assistant edges.
+
+Reconnection does not create response topology. It reactivates the existing
+assistant node, so its parent may have any role or be `null`. Resume checks
+concurrency capacity but does not apply the new-response parent-role rule,
+matching AI SDK's `resumeStream` behavior over the current message history.
 
 ## AI SDK Integration
 
@@ -325,9 +336,10 @@ behavior for:
 - `sendAutomaticallyWhen`
 - regeneration and reconnection
 
-The internal `ThreadRunState` presents one linear branch path to
-`AbstractChat`. It writes accumulated assistant snapshots into `Thread`
-when AI SDK publishes the streaming response.
+The internal `ThreadRunState` presents one run-local linear branch path to
+`AbstractChat`. AI SDK may truncate that local path for regeneration without
+deleting nodes from the canonical tree. The state writes accumulated assistant
+snapshots into `Thread` when AI SDK publishes the streaming response.
 
 `ThreadRunChat` does not insert a synthetic response into that path. AI SDK
 creates the provisional assistant response using its normal last-message rules
@@ -378,6 +390,34 @@ As in AI SDK, expected transport and stream failures resolve after publishing
 `error` status. Unexpected application or state-layer exceptions that escape
 `AbstractChat` reject `sendMessage`, `resumeRun`, and the corresponding
 `finished` promise.
+
+## Regeneration
+
+`regenerate({ messageId })` invokes `AbstractChat.regenerate` inside an isolated
+run adapter. The transport therefore receives AI SDK's native
+`regenerate-message` trigger and target `messageId`.
+
+AI SDK truncates only the adapter's linear request path. The canonical tree
+retains the target response, then inserts the streamed replacement beside it
+using the run's reserved sibling order. A root assistant regenerates into
+another root. The cursor follows the replacement on its first write only when
+it still points to the regeneration target, so navigation during submission or
+streaming is not overwritten.
+
+### Known AI SDK Blocker
+
+Regenerating an assistant whose parent is another assistant remains rejected.
+This is blocked by an AI SDK regeneration bug: after truncating the path to the
+assistant parent, AI SDK treats that trailing assistant as the response to
+continue. Regenerating `[user, assistant A, assistant B]` therefore produces
+`[user, assistant A']` instead of creating a replacement sibling for
+`assistant B`.
+
+The intended tree result is to preserve `assistant B` and create another child
+of `assistant A`. Once AI SDK distinguishes regeneration from normal trailing
+assistant continuation, `Thread` can remove this rejection and keep using the
+native regeneration lifecycle. Until then, rejecting the operation avoids
+silently mutating a shared ancestor.
 
 ## Status and Cancellation
 

--- a/packages/thread/package.json
+++ b/packages/thread/package.json
@@ -51,7 +51,7 @@
 		"prepublishOnly": "bun run build",
 		"test": "bun test --pass-with-no-tests",
 		"test:unit": "bun test --pass-with-no-tests",
-		"test:types": "bun run build"
+		"test:types": "tsc -p tsconfig.json --noEmit && bun run build"
 	},
 	"peerDependencies": {
 		"@ai-sdk/react": "^3.0.0",

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -7,6 +7,7 @@ import {
 	convertFileListToFileUIParts,
 	DefaultChatTransport,
 	generateId,
+	isToolUIPart,
 	type UIMessage,
 } from "ai";
 import {
@@ -141,12 +142,12 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 
 	addToolApprovalResponse: AbstractChat<TMessage>["addToolApprovalResponse"] =
 		async (response) => {
-			const run = this.#runs.getForApproval(response.id);
+			const run = this.getOrCreateRunForApproval(response.id);
 			await run.chat.addToolApprovalResponse(response);
 		};
 
 	addToolOutput: AbstractChat<TMessage>["addToolOutput"] = async (output) => {
-		const run = this.#runs.getForToolCall(output.toolCallId);
+		const run = this.getOrCreateRunForToolCall(output.toolCallId);
 		await run.chat.addToolOutput(output);
 	};
 
@@ -190,11 +191,8 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		this.updateTree((tree) => tree.setCursorToParentOf(messageId));
 	}
 
-	private getRunPath(runId: string) {
-		const run = this.#runs.require(runId);
-		return this.readTree((tree) =>
-			tree.getPath(run.spec.messageId ?? run.spec.parentMessageId),
-		);
+	private getMessagePath(messageId: string | null) {
+		return this.readTree((tree) => tree.getPath(messageId));
 	}
 
 	private writeRunMessage(runId: string, message: TMessage) {
@@ -227,7 +225,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			this.indexMessageOwnership(runId, message);
 			if (
 				this.#runs.isExplicitlySelected(runId) &&
-				tree.cursorId === run.spec.parentMessageId
+				tree.cursorId === run.spec.initialPathMessageId
 			) {
 				tree.setCursor(message.id);
 			}
@@ -247,9 +245,11 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 					: tree.getMessage(messageId);
 			return {
 				parentMessageId:
-					selectedTarget?.role === "assistant"
-						? tree.getParentId(selectedTarget.id)
-						: selectedTarget?.id,
+					selectedTarget == null
+						? null
+						: selectedTarget.role === "assistant"
+							? (tree.getParentId(selectedTarget.id) ?? null)
+							: selectedTarget.id,
 				target: selectedTarget,
 			};
 		});
@@ -257,15 +257,41 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			throw new Error(`message ${messageId} not found`);
 		}
 
-		if (!parentMessageId) return;
+		if (target.role === "assistant") {
+			if (parentMessageId) {
+				const parentMessage = this.getMessage(parentMessageId);
+				if (!parentMessage) {
+					throw new Error(`Unknown message ${parentMessageId}`);
+				}
+				if (parentMessage.role === "assistant") {
+					// AI SDK regeneration currently reuses a trailing assistant instead
+					// of creating a new response, which would mutate this shared parent.
+					throw new Error(
+						`Cannot regenerate assistant message ${target.id} because its parent ${parentMessage.id} is also an assistant`,
+					);
+				}
+				this.assertCanGenerateFrom(parentMessage);
+			} else {
+				this.#runs.assertHasCapacity(null);
+			}
+		} else {
+			this.assertCanGenerateFrom(target);
+		}
 
-		this.assertCanStartRun(parentMessageId);
-		const run = this.startRunFromParent({
-			follow: true,
+		const spec: ThreadRunSpec = {
 			id: this.#runs.reserveId(this.generateMessageId),
-			options,
+			initialPathMessageId: target.id,
 			parentMessageId,
-		});
+			siblingOrder: this.#runs.reserveSiblingOrder(
+				parentMessageId,
+				this.getChildren(parentMessageId).length,
+			),
+		};
+		this.#runs.select(spec.id);
+		this.updateTree((tree) => tree.setCursor(target.id));
+		const run = this.startRunRequest(spec, (chat) =>
+			chat.regenerateMessage(target.id, options),
+		);
 		await run.finished;
 	};
 
@@ -314,6 +340,22 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		options?: TreeSendOptions,
 	) => {
 		const { tree, ...request } = options ?? {};
+		if (!input) {
+			const cursorId =
+				tree && "from" in tree
+					? (tree.from ?? null)
+					: this.getSnapshot().cursorId;
+			const cursorMessage = cursorId ? this.getMessage(cursorId) : undefined;
+			if (cursorMessage?.role === "assistant") {
+				const run = this.continueAssistant({
+					follow: tree?.follow ?? cursorId === this.getSnapshot().cursorId,
+					messageId: cursorMessage.id,
+					options: request,
+				});
+				await run.finished;
+				return;
+			}
+		}
 		const run = await this.startRun({
 			follow: tree?.follow,
 			from: tree && "from" in tree ? (tree.from ?? null) : undefined,
@@ -348,7 +390,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			if (!originMessage) {
 				throw new Error("Select a message before starting a run");
 			}
-			this.assertCanStartRun(originMessage.id);
+			this.assertCanGenerateFrom(originMessage);
 			return this.startRunFromParent({
 				follow,
 				id: this.#runs.reserveId(this.generateMessageId),
@@ -361,8 +403,15 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			fallbackId: getInputMessageId(input) ?? this.generateMessageId(),
 			input,
 		});
-		this.assertValidRunParent(message);
-		this.assertCanStartRun(message.id);
+		if (message.role === "assistant") {
+			return this.startAssistantMessage({
+				follow,
+				message,
+				options,
+				parentMessageId: cursorId,
+			});
+		}
+		this.assertCanGenerateFrom(message);
 		this.updateTree((tree) => {
 			const existingMessage = tree.getMessage(message.id);
 			const attachmentId = existingMessage
@@ -460,7 +509,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 				return thread.dataPartSchemas;
 			},
 			generateMessageId: () => thread.generateMessageId(),
-			getRunPath: (runId) => thread.getRunPath(runId),
+			getMessagePath: (messageId) => thread.getMessagePath(messageId),
 			get id() {
 				return thread.id;
 			},
@@ -560,11 +609,9 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		}
 	}
 
-	private assertCanStartRun(parentMessageId: string | null) {
-		const parentMessage =
-			parentMessageId == null ? undefined : this.getMessage(parentMessageId);
-		if (parentMessage) this.assertValidRunParent(parentMessage);
-		this.#runs.assertCanStart(parentMessageId);
+	private assertCanGenerateFrom(parentMessage: TMessage) {
+		this.assertValidRunParent(parentMessage);
+		this.#runs.assertHasCapacity(parentMessage.id);
 	}
 
 	private assertValidRunParent(message: TMessage) {
@@ -582,23 +629,97 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		});
 	}
 
+	private findAssistantOwningPart({
+		id,
+		label,
+		matches,
+	}: {
+		id: string;
+		label: string;
+		matches: (part: TMessage["parts"][number]) => boolean;
+	}) {
+		let owner: TMessage | undefined;
+		for (const { message } of this.getTreeSnapshot().nodes) {
+			if (message.role !== "assistant" || !message.parts.some(matches)) {
+				continue;
+			}
+			if (owner && owner.id !== message.id) {
+				throw new Error(
+					`${label} ${id} appears in more than one assistant message`,
+				);
+			}
+			owner = message;
+		}
+		return owner;
+	}
+
+	private getOrCreateRunForApproval(approvalId: string) {
+		const existing = this.#runs.findForApproval(approvalId);
+		if (existing) return existing;
+		const owner = this.findAssistantOwningPart({
+			id: approvalId,
+			label: "Tool approval",
+			matches: (part) => isToolUIPart(part) && part.approval?.id === approvalId,
+		});
+		if (!owner) {
+			throw new Error(`No run owns tool approval ${approvalId}`);
+		}
+		const run = this.createRunForAssistant(owner.id);
+		if (!run) {
+			throw new Error(`Assistant message ${owner.id} cannot own a run`);
+		}
+		return run;
+	}
+
+	private getOrCreateRunForToolCall(toolCallId: string) {
+		const existing = this.#runs.findForToolCall(toolCallId);
+		if (existing) return existing;
+		const owner = this.findAssistantOwningPart({
+			id: toolCallId,
+			label: "Tool call",
+			matches: (part) => isToolUIPart(part) && part.toolCallId === toolCallId,
+		});
+		if (!owner) {
+			throw new Error(`No run owns tool call ${toolCallId}`);
+		}
+		const run = this.createRunForAssistant(owner.id);
+		if (!run) {
+			throw new Error(`Assistant message ${owner.id} cannot own a run`);
+		}
+		return run;
+	}
+
 	private createRunForSelectedAssistant() {
 		const tree = this.createTree();
 		const messageId = tree.cursorId;
 		if (!messageId) return;
+		return this.createRunForAssistant(messageId, true);
+	}
+
+	private createRunForAssistant(messageId: string, select = false) {
+		const existing = this.#runs.getForResponseMessage(messageId);
+		if (existing) {
+			if (select) this.#runs.select(existing.spec.id);
+			return existing;
+		}
+		const tree = this.createTree();
 		const message = tree.getMessage(messageId);
 		if (!message || message.role !== "assistant") {
 			return;
 		}
-		const parentMessageId = tree.getParentId(messageId);
-		if (!parentMessageId) return;
+		const parentMessageId = tree.getParentId(messageId) ?? null;
+		const siblingOrder = tree
+			.getChildren(parentMessageId)
+			.findIndex((child) => child.id === messageId);
+		if (siblingOrder === -1) {
+			throw new Error(`Message ${messageId} is missing from its sibling order`);
+		}
 
-		const spec: ThreadRunSpec & { parentMessageId: string } = {
+		const spec: ThreadRunSpec = {
+			initialPathMessageId: messageId,
 			messageId,
 			parentMessageId,
-			siblingOrder: tree
-				.getChildren(parentMessageId)
-				.findIndex((child) => child.id === messageId),
+			siblingOrder,
 			id: this.#runs.reserveId(this.generateMessageId),
 		};
 		const record: RunRecord<TMessage> = {
@@ -609,7 +730,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			status: "ready",
 		};
 		this.#runs.add(record);
-		this.#runs.select(spec.id);
+		if (select) this.#runs.select(spec.id);
 		this.indexMessageOwnership(spec.id, message);
 		this.publish();
 		return record;
@@ -626,13 +747,17 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		id,
 		options,
 		parentMessageId,
-	}: Omit<ThreadRunSpec, "messageId" | "parentMessageId" | "siblingOrder"> & {
+	}: Omit<
+		ThreadRunSpec,
+		"initialPathMessageId" | "messageId" | "parentMessageId" | "siblingOrder"
+	> & {
 		follow: boolean;
 		options?: ChatRequestOptions;
 		parentMessageId: string;
 	}) {
 		const spec: ThreadRunSpec & { parentMessageId: string } = {
 			id,
+			initialPathMessageId: parentMessageId,
 			parentMessageId,
 			siblingOrder: this.#runs.reserveSiblingOrder(
 				parentMessageId,
@@ -643,15 +768,14 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 			this.#runs.select(id);
 			this.updateTree((tree) => tree.setCursor(parentMessageId));
 		}
-		return this.startRunRequest(spec, options);
+		return this.startRunRequest(spec, (chat) => chat.start(options));
 	}
 
 	private startRunRequest(
-		spec: ThreadRunSpec & { parentMessageId: string },
-		options?: ChatRequestOptions,
+		spec: ThreadRunSpec,
+		start: (chat: ThreadRunChat<TMessage>) => Promise<void>,
 	) {
-		const parentMessage = this.getMessage(spec.parentMessageId);
-		if (!parentMessage) {
+		if (spec.parentMessageId && !this.getMessage(spec.parentMessageId)) {
 			throw new Error(`Unknown message ${spec.parentMessageId}`);
 		}
 		const chat = new ThreadRunChat(this.#runHost, spec);
@@ -664,11 +788,70 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		};
 		this.#runs.add(record);
 		this.publish();
-		const finished = chat.start(options).finally(() => this.publish());
+		const finished = start(chat).finally(() => this.publish());
 		// startRun may be detached; observing the rejection keeps finished awaitable.
 		void finished.catch(() => undefined);
 		record.finished = finished;
 		return this.createRunHandle(record);
+	}
+
+	private continueAssistant({
+		follow,
+		messageId,
+		options,
+	}: {
+		follow: boolean;
+		messageId: string;
+		options?: ChatRequestOptions;
+	}) {
+		const run = this.createRunForAssistant(messageId);
+		if (!run) {
+			throw new Error(`Message ${messageId} is not an assistant message`);
+		}
+		if (run.status === "submitted" || run.status === "streaming") {
+			throw new Error(
+				`Assistant message ${messageId} already has an active run`,
+			);
+		}
+		this.#runs.assertHasCapacity(run.spec.parentMessageId);
+		if (follow) {
+			this.#runs.select(run.spec.id);
+			this.updateTree((tree) => tree.setCursor(messageId));
+		}
+		const finished = run.chat.start(options).finally(() => this.publish());
+		run.finished = finished;
+		this.publish();
+		return this.createRunHandle(run);
+	}
+
+	private startAssistantMessage({
+		follow,
+		message,
+		options,
+		parentMessageId,
+	}: {
+		follow: boolean;
+		message: TMessage;
+		options?: ChatRequestOptions;
+		parentMessageId: string | null;
+	}) {
+		this.#runs.assertHasCapacity(parentMessageId);
+		const spec: ThreadRunSpec = {
+			id: this.#runs.reserveId(this.generateMessageId),
+			initialPathMessageId: parentMessageId,
+			messageId: message.id,
+			parentMessageId,
+			siblingOrder: this.#runs.reserveSiblingOrder(
+				parentMessageId,
+				this.getChildren(parentMessageId).length,
+			),
+		};
+		if (follow) {
+			this.#runs.select(spec.id);
+		}
+		return this.startRunRequest(spec, (chat) =>
+			chat.startWithMessage(message, options),
+		);
 	}
 
 	private createRunHandle(run: RunRecord<TMessage>): ThreadRunHandle {
@@ -686,7 +869,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		run: RunRecord<TMessage>,
 		options: ChatRequestOptions,
 	) {
-		this.assertCanStartRun(run.spec.parentMessageId);
+		this.#runs.assertHasCapacity(run.spec.parentMessageId);
 		const finished = run.chat
 			.resumeStream(options)
 			.finally(() => this.publish());

--- a/packages/thread/src/abstract-thread.ts
+++ b/packages/thread/src/abstract-thread.ts
@@ -804,16 +804,27 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		messageId: string;
 		options?: ChatRequestOptions;
 	}) {
-		const run = this.createRunForAssistant(messageId);
-		if (!run) {
-			throw new Error(`Message ${messageId} is not an assistant message`);
-		}
-		if (run.status === "submitted" || run.status === "streaming") {
+		const existing = this.#runs.getForResponseMessage(messageId);
+		if (existing?.status === "submitted" || existing?.status === "streaming") {
 			throw new Error(
 				`Assistant message ${messageId} already has an active run`,
 			);
 		}
-		this.#runs.assertHasCapacity(run.spec.parentMessageId);
+		if (existing) {
+			this.#runs.assertHasCapacity(existing.spec.parentMessageId);
+		} else {
+			const tree = this.createTree();
+			const message = tree.getMessage(messageId);
+			if (!message || message.role !== "assistant") {
+				throw new Error(`Message ${messageId} is not an assistant message`);
+			}
+			this.#runs.assertHasCapacity(tree.getParentId(messageId) ?? null);
+		}
+
+		const run = this.createRunForAssistant(messageId);
+		if (!run) {
+			throw new Error(`Message ${messageId} is not an assistant message`);
+		}
 		if (follow) {
 			this.#runs.select(run.spec.id);
 			this.updateTree((tree) => tree.setCursor(messageId));
@@ -870,6 +881,7 @@ export abstract class AbstractThread<TMessage extends UIMessage = UIMessage> {
 		options: ChatRequestOptions,
 	) {
 		this.#runs.assertHasCapacity(run.spec.parentMessageId);
+		run.chat.refreshPath();
 		const finished = run.chat
 			.resumeStream(options)
 			.finally(() => this.publish());

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -78,6 +78,12 @@ class ThreadRunState<TMessage extends UIMessage>
 		this.#host.setRunStatus(this.#spec.id, status);
 	}
 
+	refreshPath() {
+		this.#messages = this.#host.getMessagePath(
+			this.#spec.messageId ?? this.#spec.initialPathMessageId,
+		);
+	}
+
 	popMessage = () => {
 		const lastMessage = this.#messages.pop();
 		if (lastMessage) this.#host.removeMessage(lastMessage.id);
@@ -106,8 +112,11 @@ class ThreadRunState<TMessage extends UIMessage>
 export class ThreadRunChat<
 	TMessage extends UIMessage,
 > extends AbstractChat<TMessage> {
+	readonly #state: ThreadRunState<TMessage>;
+
 	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
 		const responseMessageId = host.generateMessageId();
+		const state = new ThreadRunState(host, spec);
 		const transport: ChatTransport<TMessage> = {
 			reconnectToStream: (options) => host.transport.reconnectToStream(options),
 			sendMessages: (options) => {
@@ -141,9 +150,14 @@ export class ThreadRunChat<
 			},
 			sendAutomaticallyWhen: (event) =>
 				host.sendAutomaticallyWhen?.(event) ?? false,
-			state: new ThreadRunState(host, spec),
+			state,
 			transport,
 		});
+		this.#state = state;
+	}
+
+	refreshPath() {
+		this.#state.refreshPath();
 	}
 
 	start(options?: ChatRequestOptions) {

--- a/packages/thread/src/ai-sdk-run-chat.ts
+++ b/packages/thread/src/ai-sdk-run-chat.ts
@@ -10,6 +10,7 @@ import {
 
 export type ThreadRunSpec = {
 	id: string;
+	initialPathMessageId: string | null;
 	messageId?: string;
 	parentMessageId: string | null;
 	siblingOrder: number;
@@ -26,7 +27,7 @@ export interface ThreadRunHost<TMessage extends UIMessage> {
 	sendAutomaticallyWhen: ChatInit<TMessage>["sendAutomaticallyWhen"];
 	transport: ChatTransport<TMessage>;
 	generateMessageId: () => string;
-	getRunPath: (runId: string) => TMessage[];
+	getMessagePath: (messageId: string | null) => TMessage[];
 	updateRunPath: (messages: TMessage[]) => void;
 	registerToolCall: (runId: string, toolCallId: string) => void;
 	removeMessage: (messageId: string) => void;
@@ -40,11 +41,13 @@ class ThreadRunState<TMessage extends UIMessage>
 {
 	#error: Error | undefined;
 	readonly #host: ThreadRunHost<TMessage>;
+	#messages: TMessage[];
 	readonly #spec: ThreadRunSpec;
 	#status: ChatStatus = "ready";
 
 	constructor(host: ThreadRunHost<TMessage>, spec: ThreadRunSpec) {
 		this.#host = host;
+		this.#messages = host.getMessagePath(spec.initialPathMessageId);
 		this.#spec = spec;
 	}
 
@@ -58,10 +61,11 @@ class ThreadRunState<TMessage extends UIMessage>
 	}
 
 	get messages() {
-		return this.#host.getRunPath(this.#spec.id);
+		return this.#messages;
 	}
 
 	set messages(messages: TMessage[]) {
+		this.#messages = messages;
 		this.#host.updateRunPath(messages);
 	}
 
@@ -75,18 +79,20 @@ class ThreadRunState<TMessage extends UIMessage>
 	}
 
 	popMessage = () => {
-		const lastMessage = this.messages.at(-1);
+		const lastMessage = this.#messages.pop();
 		if (lastMessage) this.#host.removeMessage(lastMessage.id);
 	};
 
 	pushMessage = (message: TMessage) => {
+		this.#messages.push(message);
 		this.writeMessage(message);
 	};
 
 	replaceMessage = (index: number, message: TMessage) => {
-		if (index !== this.messages.length - 1) {
+		if (index !== this.#messages.length - 1) {
 			throw new Error("A thread run can only replace its current response");
 		}
+		this.#messages[index] = message;
 		this.writeMessage(message);
 	};
 
@@ -108,7 +114,9 @@ export class ThreadRunChat<
 				return host.transport.sendMessages({
 					...options,
 					messageId:
-						spec.messageId === undefined ? undefined : options.messageId,
+						spec.messageId === undefined && options.trigger === "submit-message"
+							? undefined
+							: options.messageId,
 				});
 			},
 		};
@@ -124,7 +132,7 @@ export class ThreadRunChat<
 			onFinish: (event) => {
 				host.onFinish?.({
 					...event,
-					messages: host.getRunPath(spec.id),
+					messages: host.getMessagePath(spec.messageId ?? spec.parentMessageId),
 				});
 			},
 			onToolCall: async (event) => {
@@ -140,5 +148,16 @@ export class ThreadRunChat<
 
 	start(options?: ChatRequestOptions) {
 		return this.sendMessage(undefined, options);
+	}
+
+	startWithMessage(
+		message: NonNullable<Parameters<AbstractChat<TMessage>["sendMessage"]>[0]>,
+		options?: ChatRequestOptions,
+	) {
+		return this.sendMessage(message, options);
+	}
+
+	regenerateMessage(messageId: string, options?: ChatRequestOptions) {
+		return this.regenerate({ ...options, messageId });
 	}
 }

--- a/packages/thread/src/run-registry.ts
+++ b/packages/thread/src/run-registry.ts
@@ -32,7 +32,7 @@ export class RunRegistry<TMessage extends UIMessage> {
 		this.#runsById.set(record.spec.id, record);
 	}
 
-	assertCanStart(parentMessageId: string | null) {
+	assertHasCapacity(parentMessageId: string | null) {
 		const activeRuns = this.getActive();
 		if (activeRuns.length >= this.#concurrency.maxActiveRuns) {
 			throw new Error("Cannot start run: max active runs reached");
@@ -62,10 +62,9 @@ export class RunRegistry<TMessage extends UIMessage> {
 		);
 	}
 
-	getForApproval(approvalId: string) {
+	findForApproval(approvalId: string) {
 		const runId = this.#runIdByApprovalId.get(approvalId);
-		if (!runId) throw new Error(`No run owns tool approval ${approvalId}`);
-		return this.require(runId);
+		return runId ? this.#runsById.get(runId) : undefined;
 	}
 
 	getForMessage(messageId: string) {
@@ -82,10 +81,15 @@ export class RunRegistry<TMessage extends UIMessage> {
 		);
 	}
 
-	getForToolCall(toolCallId: string) {
+	findForToolCall(toolCallId: string) {
 		const runId = this.#runIdByToolCallId.get(toolCallId);
-		if (!runId) throw new Error(`No run owns tool call ${toolCallId}`);
-		return this.require(runId);
+		return runId ? this.#runsById.get(runId) : undefined;
+	}
+
+	getForResponseMessage(messageId: string) {
+		return this.values()
+			.reverse()
+			.find((candidate) => candidate.spec.messageId === messageId);
 	}
 
 	getInsertionIndex({

--- a/packages/thread/test/ai-sdk-run-chat.test.ts
+++ b/packages/thread/test/ai-sdk-run-chat.test.ts
@@ -73,8 +73,7 @@ class TestRunHost implements ThreadRunHost<UIMessage> {
 		this.tree = new MessageTree({ messages: [userMessage] });
 	}
 
-	getRunPath = () =>
-		this.tree.getPath(this.spec.messageId ?? this.spec.parentMessageId);
+	getMessagePath = (messageId: string | null) => this.tree.getPath(messageId);
 	updateRunPath = (messages: UIMessage[]) => {
 		this.tree.updatePath(messages);
 	};
@@ -109,6 +108,7 @@ function userMessage(): UIMessage {
 function createSpec(): ThreadRunSpec {
 	return {
 		id: "run-1",
+		initialPathMessageId: "user-1",
 		parentMessageId: "user-1",
 		siblingOrder: 0,
 	};

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -131,6 +131,23 @@ function user(id: string): UIMessage {
 	return { id, parts: [{ text: id, type: "text" }], role: "user" };
 }
 
+function assistantWithTool(id: string): UIMessage {
+	return {
+		id,
+		parts: [
+			{
+				approval: { id: "shared-approval" },
+				input: { value: id },
+				state: "approval-requested",
+				toolCallId: "shared-tool",
+				toolName: "test-tool",
+				type: "dynamic-tool",
+			},
+		],
+		role: "assistant",
+	};
+}
+
 function requireMessage(message: UIMessage | undefined) {
 	if (!message) throw new Error("Expected message to exist");
 	return message;
@@ -388,6 +405,29 @@ describe("Thread", () => {
 		expect(chat.getSnapshot().cursorId).toBe("user-1");
 	});
 
+	test("reports the completed run path to onFinish after navigation", async () => {
+		const transport = new ControlledTransport();
+		let finishedMessages: UIMessage[] | undefined;
+		const chat = new Thread({
+			onFinish: ({ messages }) => {
+				finishedMessages = messages;
+			},
+			transport,
+		});
+		const run = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		chat.addMessage(user("other-root"), null);
+		chat.setCursor("other-root");
+
+		transport.emitText(0, "assistant-1", "complete");
+		await run.finished;
+
+		expect(finishedMessages?.map(({ id }) => id)).toEqual([
+			"user-1",
+			"assistant-1",
+		]);
+	});
+
 	test("rejects concurrency before adding another user message", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({
@@ -404,6 +444,39 @@ describe("Thread", () => {
 			}),
 		).rejects.toThrow("max active runs");
 		expect(chat.getMessage("user-2")).toBeUndefined();
+	});
+
+	test("rejects assistant continuation without creating a phantom run", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({
+			concurrency: { maxActiveRuns: 1 },
+			initialTree: {
+				cursorId: "user-active",
+				nodes: [
+					{ message: user("user-active"), parentId: null },
+					{
+						message: { ...user("assistant-ready"), role: "assistant" },
+						parentId: null,
+					},
+				],
+				version: 1,
+			},
+			transport,
+		});
+		const active = await chat.startRun({ from: "user-active" });
+		await waitFor(() => transport.requests.length === 1);
+		const runCount = chat.getSnapshot().runs.length;
+
+		await expect(
+			chat.sendMessage(undefined, {
+				tree: { follow: false, from: "assistant-ready" },
+			}),
+		).rejects.toThrow("max active runs");
+
+		expect(chat.getSnapshot().runs).toHaveLength(runCount);
+		expect(chat.getRunForMessage("assistant-ready")).toBeUndefined();
+		transport.finish(0);
+		await active.finished;
 	});
 
 	test("stopping one run does not abort another", async () => {
@@ -486,6 +559,37 @@ describe("Thread", () => {
 		expect(finished).toBeFalse();
 		reconnect.close();
 		await Promise.all([resumed, run.finished]);
+	});
+
+	test("refreshes the canonical message path before resuming", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({ transport });
+		const run = await chat.startRun({ message: user("user-1") });
+		await waitFor(() => transport.requests.length === 1);
+		transport.emitText(0, "assistant-1", "original");
+		await run.finished;
+		chat.setMessages([
+			user("user-1"),
+			{
+				id: "assistant-1",
+				parts: [{ text: "edited ", type: "text" }],
+				role: "assistant",
+			},
+		]);
+		const reconnect = transport.prepareReconnect();
+
+		const resumed = chat.resumeRun(run.id);
+		await Bun.sleep(0);
+		reconnect.enqueue({ id: "resumed", type: "text-start" });
+		reconnect.enqueue({ delta: "resumed", id: "resumed", type: "text-delta" });
+		reconnect.enqueue({ id: "resumed", type: "text-end" });
+		reconnect.enqueue({ finishReason: "stop", type: "finish" });
+		reconnect.close();
+		await resumed;
+
+		expect(getMessageText(requireMessage(chat.getMessage("assistant-1")))).toBe(
+			"edited resumed",
+		);
 	});
 
 	test("aggregate status ignores historical run errors", async () => {
@@ -768,6 +872,55 @@ describe("Thread", () => {
 				output: "restored output",
 				toolCallId: "tool-1",
 			}),
+		);
+	});
+
+	test("rejects missing restored tool and approval ownership", async () => {
+		const chat = new Thread({ messages: [user("user-1")] });
+
+		await expect(
+			chat.addToolOutput({
+				output: "missing",
+				tool: "test-tool",
+				toolCallId: "missing-tool",
+			}),
+		).rejects.toThrow("No run owns tool call missing-tool");
+		await expect(
+			chat.addToolApprovalResponse({
+				approved: true,
+				id: "missing-approval",
+			}),
+		).rejects.toThrow("No run owns tool approval missing-approval");
+	});
+
+	test("rejects duplicate restored tool and approval ownership", async () => {
+		const chat = new Thread({
+			initialTree: {
+				cursorId: "assistant-a",
+				nodes: [
+					{ message: assistantWithTool("assistant-a"), parentId: null },
+					{ message: assistantWithTool("assistant-b"), parentId: null },
+				],
+				version: 1,
+			},
+		});
+
+		await expect(
+			chat.addToolOutput({
+				output: "duplicate",
+				tool: "test-tool",
+				toolCallId: "shared-tool",
+			}),
+		).rejects.toThrow(
+			"Tool call shared-tool appears in more than one assistant message",
+		);
+		await expect(
+			chat.addToolApprovalResponse({
+				approved: true,
+				id: "shared-approval",
+			}),
+		).rejects.toThrow(
+			"Tool approval shared-approval appears in more than one assistant message",
 		);
 	});
 

--- a/packages/thread/test/thread.test.ts
+++ b/packages/thread/test/thread.test.ts
@@ -10,6 +10,7 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 	readonly requests: Array<{
 		abortSignal: AbortSignal | undefined;
 		controller: ReadableStreamDefaultController<UIMessageChunk>;
+		options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0];
 	}> = [];
 	#reconnectStream: ReadableStream<UIMessageChunk> | null = null;
 
@@ -20,6 +21,7 @@ class ControlledTransport implements ChatTransport<UIMessage> {
 					this.requests.push({
 						abortSignal: options.abortSignal,
 						controller,
+						options,
 					});
 					options.abortSignal?.addEventListener(
 						"abort",
@@ -294,23 +296,61 @@ describe("Thread", () => {
 		expect(chat.getSnapshot().runs).toHaveLength(0);
 	});
 
-	test("rejects an assistant input without mutating the tree", async () => {
+	test("continues an explicit assistant input in the same tree node", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({ messages: [user("user-1")], transport });
 
-		await expect(
-			chat.sendMessage({
-				id: "assistant-input",
-				parts: [{ text: "prebuilt response", type: "text" }],
-				role: "assistant",
-			}),
-		).rejects.toThrow(
-			"Cannot start a new run directly from assistant message assistant-input; attach an input message first",
+		const sending = chat.sendMessage({
+			id: "assistant-input",
+			parts: [{ text: "prebuilt response", type: "text" }],
+			role: "assistant",
+		});
+		await waitFor(() => transport.requests.length === 1);
+
+		expect(transport.requests[0]?.options.trigger).toBe("submit-message");
+		expect(transport.requests[0]?.options.messageId).toBeUndefined();
+		expect(transport.requests[0]?.options.messages.map(({ id }) => id)).toEqual(
+			["user-1", "assistant-input"],
 		);
-		expect(transport.requests).toHaveLength(0);
-		expect(chat.getMessage("assistant-input")).toBeUndefined();
-		expect(chat.getSnapshot().cursorId).toBe("user-1");
-		expect(chat.getSnapshot().runs).toHaveLength(0);
+		expect(chat.getParent("assistant-input")?.id).toBe("user-1");
+		expect(chat.getSnapshot().cursorId).toBe("assistant-input");
+
+		transport.emitText(0, "assistant-input", "continued");
+		await sending;
+
+		expect(chat.getChildren("user-1").map(({ id }) => id)).toEqual([
+			"assistant-input",
+		]);
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-input"))),
+		).toBe("prebuilt responsecontinued");
+	});
+
+	test("continues the selected assistant without creating a sibling", async () => {
+		const transport = new ControlledTransport();
+		const assistant = {
+			...user("assistant-1"),
+			role: "assistant" as const,
+		};
+		const chat = new Thread({
+			messages: [user("user-1"), assistant],
+			transport,
+		});
+
+		const sending = chat.sendMessage();
+		await waitFor(() => transport.requests.length === 1);
+
+		expect(transport.requests[0]?.options.trigger).toBe("submit-message");
+		expect(transport.requests[0]?.options.messageId).toBe("assistant-1");
+		transport.emitText(0, "assistant-1", " continued");
+		await sending;
+
+		expect(chat.getChildren("user-1").map(({ id }) => id)).toEqual([
+			"assistant-1",
+		]);
+		expect(getMessageText(requireMessage(chat.getMessage("assistant-1")))).toBe(
+			"assistant-1 continued",
+		);
 	});
 
 	test("keeps hidden branches when reconciling the selected path", () => {
@@ -496,6 +536,11 @@ describe("Thread", () => {
 
 		const regeneration = chat.regenerate({ messageId: "assistant-1" });
 		await waitFor(() => transport.requests.length === 2);
+		expect(transport.requests[1]?.options.trigger).toBe("regenerate-message");
+		expect(transport.requests[1]?.options.messageId).toBe("assistant-1");
+		expect(transport.requests[1]?.options.messages.map(({ id }) => id)).toEqual(
+			["user-1"],
+		);
 		transport.emitText(1, "assistant-2", "second");
 		await regeneration;
 
@@ -504,6 +549,50 @@ describe("Thread", () => {
 			"assistant-2",
 		]);
 		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
+	});
+
+	test("regenerates a root assistant as a root sibling", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({
+			messages: [{ ...user("assistant-1"), role: "assistant" }],
+			transport,
+		});
+
+		const regeneration = chat.regenerate({ messageId: "assistant-1" });
+		await waitFor(() => transport.requests.length === 1);
+		expect(transport.requests[0]?.options.trigger).toBe("regenerate-message");
+		expect(transport.requests[0]?.options.messageId).toBe("assistant-1");
+		expect(transport.requests[0]?.options.messages).toEqual([]);
+
+		transport.emitText(0, "assistant-2", "second");
+		await regeneration;
+
+		expect(chat.getSiblings("assistant-1").map(({ id }) => id)).toEqual([
+			"assistant-1",
+			"assistant-2",
+		]);
+		expect(chat.getSnapshot().cursorId).toBe("assistant-2");
+	});
+
+	test("does not follow regeneration after navigating to another branch", async () => {
+		const transport = new ControlledTransport();
+		const chat = new Thread({
+			messages: [user("user-1"), { ...user("assistant-1"), role: "assistant" }],
+			transport,
+		});
+		chat.addMessage(user("other-root"), null);
+
+		const regeneration = chat.regenerate({ messageId: "assistant-1" });
+		await waitFor(() => transport.requests.length === 1);
+		chat.setCursor("other-root");
+		transport.emitText(0, "assistant-2", "second");
+		await regeneration;
+
+		expect(chat.getParent("assistant-2")?.id).toBe("user-1");
+		expect(chat.getSnapshot().cursorId).toBe("other-root");
+		expect(chat.getSnapshot().messages.map(({ id }) => id)).toEqual([
+			"other-root",
+		]);
 	});
 
 	test("rejects an unknown explicit regeneration target", async () => {
@@ -533,7 +622,7 @@ describe("Thread", () => {
 		await expect(
 			chat.regenerate({ messageId: "assistant-child" }),
 		).rejects.toThrow(
-			"Cannot start a new run directly from assistant message assistant-parent; attach an input message first",
+			"Cannot regenerate assistant message assistant-child because its parent assistant-parent is also an assistant",
 		);
 		expect(transport.requests).toHaveLength(0);
 		expect(chat.getSnapshot().runs).toHaveLength(0);
@@ -636,6 +725,52 @@ describe("Thread", () => {
 		);
 	});
 
+	test("reconstructs tool and approval ownership after restoring a tree", async () => {
+		const source = new Thread();
+		source.addMessage(user("user-1"), null);
+		source.addMessage(
+			{
+				id: "assistant-1",
+				parts: [
+					{
+						approval: { id: "approval-1" },
+						input: { value: 1 },
+						state: "approval-requested",
+						toolCallId: "tool-1",
+						toolName: "test-tool",
+						type: "dynamic-tool",
+					},
+				],
+				role: "assistant",
+			},
+			"user-1",
+		);
+		source.setCursor("assistant-1");
+		const restored = new Thread();
+		restored.restore(source.getTreeSnapshot());
+
+		await restored.addToolApprovalResponse({
+			approved: true,
+			id: "approval-1",
+		});
+		await restored.addToolOutput({
+			output: "restored output",
+			tool: "test-tool",
+			toolCallId: "tool-1",
+		});
+
+		expect(restored.getMessage("assistant-1")?.parts).toContainEqual(
+			expect.objectContaining({
+				approval: expect.objectContaining({
+					approved: true,
+					id: "approval-1",
+				}),
+				output: "restored output",
+				toolCallId: "tool-1",
+			}),
+		);
+	});
+
 	test("enforces the global concurrency limit before resuming", async () => {
 		const transport = new ControlledTransport();
 		const chat = new Thread({
@@ -701,5 +836,70 @@ describe("Thread", () => {
 			"resumed",
 		);
 		expect(transport.lastReconnectOptions?.body).toBeUndefined();
+	});
+
+	test("resumes a restored root assistant", async () => {
+		const transport = new ResumeTransport();
+		const chat = new Thread({
+			initialTree: {
+				cursorId: "assistant-root",
+				nodes: [
+					{
+						message: {
+							id: "assistant-root",
+							parts: [],
+							role: "assistant",
+						},
+						parentId: null,
+					},
+				],
+				version: 1,
+			},
+			transport,
+		});
+
+		await chat.resumeStream();
+
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-root"))),
+		).toBe("resumed");
+	});
+
+	test("resumes a restored assistant whose parent is an assistant", async () => {
+		const transport = new ResumeTransport();
+		const chat = new Thread({
+			initialTree: {
+				cursorId: "assistant-child",
+				nodes: [
+					{
+						message: {
+							id: "assistant-parent",
+							parts: [{ text: "parent", type: "text" }],
+							role: "assistant",
+						},
+						parentId: null,
+					},
+					{
+						message: {
+							id: "assistant-child",
+							parts: [],
+							role: "assistant",
+						},
+						parentId: "assistant-parent",
+					},
+				],
+				version: 1,
+			},
+			transport,
+		});
+
+		await chat.resumeStream();
+
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-parent"))),
+		).toBe("parent");
+		expect(
+			getMessageText(requireMessage(chat.getMessage("assistant-child"))),
+		).toBe("resumed");
 	});
 });


### PR DESCRIPTION
## Summary\n- align isolated threaded runs with AI SDK continuation, regeneration, reconnection, and restored tool ownership behavior\n- preserve tree topology while each run exposes a linear AI SDK request path\n- document the assistant-parent regeneration blocker in AI SDK\n\n## Verification\n- bun test packages/thread/test\n- bun run lint (packages/thread)\n- bun test:types\n\nPart of the Threads stack.

## Summary by Sourcery

Align thread run lifecycle with AI SDK request semantics, including assistant continuation, regeneration, reconnection, and restored tool ownership behavior.

New Features:
- Support continuing assistant messages via sendMessage without creating new child responses.
- Allow regenerating assistant responses, including root assistants, while preserving tree topology and sibling order.
- Enable resuming restored assistant-only trees and assistant messages whose parents may be assistants.

Bug Fixes:
- Prevent regeneration of assistant messages whose parent is also an assistant to avoid unintended tree mutations under current AI SDK behavior.
- Ensure tool calls and approvals regain a run owner after restoring a message tree so subsequent tool interactions work correctly.

Enhancements:
- Refine run capacity checks and tracking to separate concurrency limiting from run creation, including for resumed and continued runs.
- Introduce per-run linear message paths that can be truncated for regeneration without modifying the canonical message tree.
- Adjust assistant run creation and selection so continuation, regeneration, and reconnection correctly reuse existing assistant nodes.

Build:
- Change the types test script to run TypeScript type-checking with tsc before building.

Documentation:
- Update architecture documentation to describe assistant continuation, regeneration semantics, reconnection behavior, and the current AI SDK regeneration blocker.

Tests:
- Expand thread and AI SDK integration tests to cover assistant continuation, regeneration scenarios, reconnection and resume behavior, and restored tool ownership.
- Add tests for resuming restored assistant-root trees and assistant-child trees whose parents are assistants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `Thread` run behavior with AI SDK semantics: assistant continuations stay on the same message, regeneration creates sibling responses (including roots), and reconnection resumes the existing assistant node across restored trees. Preserves tree topology with a linear run-local request path and hardens resume/continuation and restored tool ownership.

- **New Features**
  - `sendMessage` continues a selected or explicit assistant in-place; no child is created, overlapping continuations are rejected, and concurrency is enforced.
  - `regenerate({ messageId })` uses AI SDK’s native trigger, truncates only the run-local path, inserts a sibling replacement (supports roots), and only follows when still on the target.
  - Resume/reconnect reactivates the existing assistant node (including restored roots and assistant-with-assistant-parent) with global concurrency checks; `onFinish` receives the completed run path even after navigation.
  - Restores and validates tool call/approval ownership after `restore`, enabling `addToolApprovalResponse` and `addToolOutput`; errors on missing or duplicate owners.

- **Refactors**
  - Introduced `initialPathMessageId` and run-local path management; host now provides `getMessagePath`.
  - Registry enforces capacity with `assertHasCapacity` and can find runs for approvals/tool calls and response messages.
  - Blocks regeneration when an assistant’s parent is an assistant to avoid AI SDK miscontinuation.
  - `ThreadRunChat` adds `startWithMessage`, `regenerateMessage`, and `refreshPath`; aligns `sendMessages` ID handling and `onFinish` with the message path.
  - Updated docs; `test:types` runs `tsc` before build.

<sup>Written for commit f8e22edd5bfcc354084b0a9db4680c0480716cce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #262
2. **#266** 👈 current
3. #267
4. #241
5. #242
6. #243
7. #244
8. #263
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
<!-- stack:links:end -->