### PR TITLE
feat: add OrcaRouter gateway

### DIFF
--- a/apps/chat/.env.example
+++ b/apps/chat/.env.example
@@ -10,6 +10,8 @@ DATABASE_URL=
 AI_GATEWAY_API_KEY=
 # OpenRouter (set gateway: "openrouter" in chat.config.ts) — https://openrouter.ai/keys
 OPENROUTER_API_KEY=
+# OrcaRouter (set gateway: "orcarouter" in chat.config.ts) — https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
 # LiteLLM Proxy (set gateway: "litellm" in chat.config.ts) — https://docs.litellm.ai/
 LITELLM_BASE_URL=
 # Optional; only if your LiteLLM proxy requires auth

--- a/apps/chat/lib/ai/gateway-model-defaults.ts
+++ b/apps/chat/lib/ai/gateway-model-defaults.ts
@@ -9,17 +9,15 @@ type VideoDefault<G extends GatewayType> = [GatewayVideoModelIdMap[G]] extends [
   never,
 ]
   ? { enabled: false }
-  :
-      | { enabled: true; default: GatewayVideoModelIdMap[G] }
-      | { enabled: false; default?: GatewayVideoModelIdMap[G] };
+  : | { enabled: true; default: GatewayVideoModelIdMap[G] }
+    | { enabled: false; default?: GatewayVideoModelIdMap[G] };
 
 type ImageDefault<G extends GatewayType> = [GatewayImageModelIdMap[G]] extends [
   never,
 ]
   ? { enabled: false }
-  :
-      | { enabled: true; default: GatewayImageModelIdMap[G] }
-      | { enabled: false; default?: GatewayImageModelIdMap[G] };
+  : | { enabled: true; default: GatewayImageModelIdMap[G] }
+    | { enabled: false; default?: GatewayImageModelIdMap[G] };
 
 export interface ModelDefaultsFor<G extends GatewayType> {
   anonymousModels: GatewayModelIdMap[G][];
@@ -166,6 +164,59 @@ const openrouterDefaults = {
   },
 } satisfies ModelDefaultsFor<"openrouter">;
 
+const orcarouterDefaults = {
+  providerOrder: ["anthropic", "openai", "google", "deepseek"],
+  disabledModels: [],
+  curatedDefaults: [
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-haiku-4.5",
+    "anthropic/claude-opus-4.6",
+    "deepseek/deepseek-v4-flash",
+    "google/gemini-2.5-flash-lite",
+    "google/gemini-3-flash-preview",
+    "orcarouter/fusion",
+    "orcarouter/fusion-flash",
+  ],
+  anonymousModels: ["anthropic/claude-haiku-4.5", "orcarouter/fusion-flash"],
+  workflows: {
+    chat: "anthropic/claude-sonnet-5",
+    title: "anthropic/claude-haiku-4.5",
+    pdf: "anthropic/claude-sonnet-5",
+    chatImageCompatible: "anthropic/claude-sonnet-5",
+  },
+  tools: {
+    webSearch: { enabled: false },
+    urlRetrieval: { enabled: false },
+    codeExecution: { enabled: false },
+    mcp: { enabled: false },
+    documents: {
+      enabled: true,
+      types: { text: true, code: true, sheet: true },
+    },
+    followupSuggestions: {
+      enabled: false,
+      default: "anthropic/claude-haiku-4.5",
+    },
+    text: { polish: "anthropic/claude-sonnet-5" },
+    sheet: {
+      format: "anthropic/claude-sonnet-5",
+      analyze: "anthropic/claude-sonnet-5",
+    },
+    code: { edits: "anthropic/claude-sonnet-5" },
+    image: { enabled: false },
+    video: { enabled: false },
+    deepResearch: {
+      enabled: false,
+      defaultModel: "anthropic/claude-sonnet-5",
+      finalReportModel: "anthropic/claude-opus-4.6",
+      allowClarification: true,
+      maxResearcherIterations: 1,
+      maxConcurrentResearchUnits: 2,
+      maxSearchQueries: 2,
+    },
+  },
+} satisfies ModelDefaultsFor<"orcarouter">;
+
 const openaiDefaults = {
   providerOrder: ["openai"],
   disabledModels: [],
@@ -301,6 +352,7 @@ export const GATEWAY_MODEL_DEFAULTS: {
 } = {
   vercel: vercelDefaults,
   openrouter: openrouterDefaults,
+  orcarouter: orcarouterDefaults,
   openai: openaiDefaults,
   "openai-compatible": openaiCompatibleDefaults,
   litellm: litellmDefaults,

--- a/apps/chat/lib/ai/gateways/orcarouter-gateway.ts
+++ b/apps/chat/lib/ai/gateways/orcarouter-gateway.ts
@@ -1,0 +1,168 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import type { Experimental_VideoModelV3 } from "@ai-sdk/provider";
+import type { ImageModel, LanguageModel } from "ai";
+import { createModuleLogger } from "@/lib/logger";
+import type { AiGatewayModel } from "../ai-gateway-models-schemas";
+import { getFallbackModels } from "./fallback-models";
+import type { GatewayProvider } from "./gateway-provider";
+
+const log = createModuleLogger("ai/gateways/orcarouter");
+
+interface OrcaRouterModelResponse {
+  architecture: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+  } | null;
+  context_length: number | null;
+  created: number;
+  description?: string;
+  id: string;
+  name?: string;
+  object: string;
+  owned_by: string;
+  pricing: {
+    prompt?: string;
+    completion?: string;
+  } | null;
+  top_provider: {
+    max_completion_tokens: number | null;
+  } | null;
+}
+
+function deriveTags(model: OrcaRouterModelResponse): string[] {
+  // orcarouter/* meta-models omit `architecture` — they surface only the
+  // endpoints they support (`supported_endpoint_types`), not modalities.
+  const inputMods = model.architecture?.input_modalities ?? ["text"];
+  const outputMods = model.architecture?.output_modalities ?? ["text"];
+
+  const tags: string[] = [];
+  if (inputMods.includes("image")) {
+    tags.push("vision");
+  }
+  if (inputMods.includes("file")) {
+    tags.push("file-input");
+  }
+  if (outputMods.includes("image")) {
+    tags.push("image-generation");
+  }
+  return tags;
+}
+
+function toAiGatewayModel(model: OrcaRouterModelResponse): AiGatewayModel {
+  const tags = deriveTags(model);
+  const outputMods = model.architecture?.output_modalities ?? ["text"];
+
+  let type: "language" | "embedding" | "image" = "language";
+  if (!outputMods.includes("text") && outputMods.includes("image")) {
+    type = "image";
+  }
+
+  const owned_by = model.id.split("/")[0] ?? "orcarouter";
+
+  return {
+    id: model.id,
+    object: "model",
+    created: model.created ?? 0,
+    owned_by,
+    name: model.name ?? model.id,
+    description: model.description ?? "",
+    context_window: model.context_length ?? 0,
+    max_tokens: model.top_provider?.max_completion_tokens ?? 0,
+    type,
+    tags: tags.length > 0 ? (tags as AiGatewayModel["tags"]) : undefined,
+    pricing: {
+      input: model.pricing?.prompt,
+      output: model.pricing?.completion,
+    },
+  };
+}
+
+export class OrcaRouterGateway implements GatewayProvider<
+  "orcarouter",
+  string,
+  never,
+  never
+> {
+  readonly type = "orcarouter" as const;
+
+  private getProvider() {
+    const apiKey = this.getApiKey();
+    if (!apiKey) {
+      throw new Error("ORCAROUTER_API_KEY is not configured");
+    }
+    return createAnthropic({
+      apiKey,
+      // OrcaRouter serves the Anthropic Messages API on the same endpoint.
+      baseURL: "https://api.orcarouter.ai",
+    });
+  }
+
+  createLanguageModel(modelId: string): LanguageModel {
+    const provider = this.getProvider();
+    return provider.chat(modelId);
+  }
+
+  createImageModel(_modelId: never): ImageModel | null {
+    // OrcaRouter routes image generation through multimodal language models.
+    // Return null to signal callers should use createLanguageModel instead.
+    return null;
+  }
+
+  createVideoModel(_modelId: never): Experimental_VideoModelV3 | null {
+    return null;
+  }
+
+  private getApiKey(): string | undefined {
+    return process.env.ORCAROUTER_API_KEY;
+  }
+
+  private getModelsUrl(): string {
+    return "https://api.orcarouter.ai/v1/models";
+  }
+
+  async fetchModels(): Promise<AiGatewayModel[]> {
+    const apiKey = this.getApiKey();
+
+    if (!apiKey) {
+      log.warn("No ORCAROUTER_API_KEY found, using fallback models");
+      return [...getFallbackModels(this.type)];
+    }
+
+    const url = this.getModelsUrl();
+    log.debug({ url }, "Fetching models from OrcaRouter");
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        next: { revalidate: 3600 },
+      });
+
+      if (!response.ok) {
+        log.error(
+          { status: response.status, statusText: response.statusText, url },
+          "OrcaRouter returned non-OK response",
+        );
+        throw new Error(`Failed to fetch models: ${response.statusText}`);
+      }
+
+      const body = await response.json();
+      const models = (body.data ?? []) as OrcaRouterModelResponse[];
+      const result = models.map(toAiGatewayModel);
+
+      log.info(
+        { modelCount: result.length },
+        "Successfully fetched models from OrcaRouter",
+      );
+      return result;
+    } catch (error) {
+      log.error(
+        { err: error, url },
+        "Error fetching models from OrcaRouter, falling back to generated models",
+      );
+      return [...getFallbackModels(this.type)];
+    }
+  }
+}

--- a/apps/chat/lib/ai/gateways/registry.ts
+++ b/apps/chat/lib/ai/gateways/registry.ts
@@ -4,11 +4,13 @@ import { LiteLLMGateway } from "./litellm-gateway";
 import { OpenAICompatibleGateway } from "./openai-compatible-gateway";
 import { OpenAIGateway } from "./openai-gateway";
 import { OpenRouterGateway } from "./openrouter-gateway";
+import { OrcaRouterGateway } from "./orcarouter-gateway";
 import { VercelGateway } from "./vercel-gateway";
 
 export const gatewayRegistry = {
   vercel: () => new VercelGateway(),
   openrouter: () => new OpenRouterGateway(),
+  orcarouter: () => new OrcaRouterGateway(),
   openai: () => new OpenAIGateway(),
   "openai-compatible": () => new OpenAICompatibleGateway(),
   litellm: () => new LiteLLMGateway(),

--- a/apps/chat/lib/config-requirements.ts
+++ b/apps/chat/lib/config-requirements.ts
@@ -9,7 +9,7 @@ export interface EnvRequirement {
 }
 
 export function formatRequirementDescription(
-  requirement: EnvRequirement
+  requirement: EnvRequirement,
 ): string {
   return (
     requirement.description ??
@@ -21,6 +21,10 @@ export const gatewayEnvRequirements: Record<GatewayType, EnvRequirement> = {
   openrouter: {
     options: [["OPENROUTER_API_KEY"]],
     description: "OPENROUTER_API_KEY",
+  },
+  orcarouter: {
+    options: [["ORCAROUTER_API_KEY"]],
+    description: "ORCAROUTER_API_KEY",
   },
   openai: {
     options: [["OPENAI_API_KEY"]],
@@ -85,16 +89,16 @@ export const authEnvRequirements: Record<
 
 export function isRequirementSatisfied(
   requirement: EnvRequirement,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
 ): boolean {
   return requirement.options.some((option) =>
-    option.every((name) => !!env[name])
+    option.every((name) => !!env[name]),
   );
 }
 
 export function getMissingRequirement(
   requirement: EnvRequirement,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
 ): string | null {
   return isRequirementSatisfied(requirement, env)
     ? null

--- a/apps/chat/lib/config-schema.ts
+++ b/apps/chat/lib/config-schema.ts
@@ -161,6 +161,7 @@ const gatewaySchemaMap: {
 } = {
   vercel: createAiSchema("vercel"),
   openrouter: createAiSchema("openrouter"),
+  orcarouter: createAiSchema("orcarouter"),
   openai: createAiSchema("openai"),
   "openai-compatible": createAiSchema("openai-compatible"),
   litellm: createAiSchema("litellm"),
@@ -170,6 +171,7 @@ export const aiConfigSchema = z
   .discriminatedUnion("gateway", [
     gatewaySchemaMap.vercel,
     gatewaySchemaMap.openrouter,
+    gatewaySchemaMap.orcarouter,
     gatewaySchemaMap.openai,
     gatewaySchemaMap["openai-compatible"],
     gatewaySchemaMap.litellm,
@@ -274,7 +276,7 @@ export const authenticationConfigObjectSchema = z.object({
   vercel: z
     .boolean()
     .describe(
-      "Vercel OAuth (requires VERCEL_APP_CLIENT_ID + VERCEL_APP_CLIENT_SECRET)"
+      "Vercel OAuth (requires VERCEL_APP_CLIENT_ID + VERCEL_APP_CLIENT_SECRET)",
     ),
 });
 
@@ -291,7 +293,7 @@ export const pathsConfigObjectSchema = z.object({
     .string()
     .default("@/tools/chatjs")
     .describe(
-      "Import alias for the installable tools registry index and tool files"
+      "Import alias for the installable tools registry index and tool files",
     ),
 });
 
@@ -473,16 +475,14 @@ type ImageToolInputFor<G extends GatewayType> = [
   GatewayImageModelIdMap[G],
 ] extends [never]
   ? { enabled?: false }
-  :
-      | { enabled: true; default: GatewayImageModelIdMap[G] }
-      | { enabled?: false; default?: GatewayImageModelIdMap[G] };
+  : | { enabled: true; default: GatewayImageModelIdMap[G] }
+    | { enabled?: false; default?: GatewayImageModelIdMap[G] };
 type VideoToolInputFor<G extends GatewayType> = [
   GatewayVideoModelIdMap[G],
 ] extends [never]
   ? { enabled?: false }
-  :
-      | { enabled: true; default: GatewayVideoModelIdMap[G] }
-      | { enabled?: false; default?: GatewayVideoModelIdMap[G] };
+  : | { enabled: true; default: GatewayVideoModelIdMap[G] }
+    | { enabled?: false; default?: GatewayVideoModelIdMap[G] };
 type FollowupSuggestionsToolInputFor<G extends GatewayType> = Partial<{
   enabled: boolean;
   default: GatewayModelIdMap[G];
@@ -540,7 +540,7 @@ export function defineConfig<const T extends ConfigInput>(config: T): T {
 
 function mergeToolsConfig<T extends Record<string, unknown>>(
   defaults: T,
-  user: Record<string, unknown> | undefined
+  user: Record<string, unknown> | undefined,
 ): T {
   if (!user) {
     return defaults;
@@ -580,7 +580,7 @@ export function applyDefaults(input: ConfigInput): Config {
     },
     tools: mergeToolsConfig(
       gatewayDefaults.tools,
-      aiInput?.tools as Record<string, unknown> | undefined
+      aiInput?.tools as Record<string, unknown> | undefined,
     ),
   };
 

--- a/apps/chat/lib/env-schema.ts
+++ b/apps/chat/lib/env-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { isPlaywrightTestEnvironment } from "@/lib/playwright-test-environment";
 
 const isPlaywrightTestEnvironmentEnabled = isPlaywrightTestEnvironment(
-  process.env
+  process.env,
 );
 
 /**
@@ -23,7 +23,7 @@ export const serverEnvSchema = {
         isPlaywrightTestEnvironmentEnabled && (value == null || value === "")
           ? "postgres://postgres:postgres@127.0.0.1:5432/playwright"
           : value,
-      z.string().min(1)
+      z.string().min(1),
     )
     .describe("Postgres connection string"),
   AUTH_SECRET: z
@@ -32,7 +32,7 @@ export const serverEnvSchema = {
         isPlaywrightTestEnvironmentEnabled && (value == null || value === "")
           ? "playwright-test-auth-secret"
           : value,
-      z.string().min(1)
+      z.string().min(1),
     )
     .describe("NextAuth.js secret for signing session tokens"),
 
@@ -66,6 +66,7 @@ export const serverEnvSchema = {
     .optional()
     .describe("Vercel OIDC token (auto-set on Vercel deployments)"),
   OPENROUTER_API_KEY: z.string().optional().describe("OpenRouter API key"),
+  ORCAROUTER_API_KEY: z.string().optional().describe("OrcaRouter API key"),
   OPENAI_COMPATIBLE_BASE_URL: z
     .string()
     .url()
@@ -142,7 +143,7 @@ export const serverEnvSchema = {
     .url()
     .optional()
     .describe(
-      "App URL for non-Vercel deployments (full URL including https://)"
+      "App URL for non-Vercel deployments (full URL including https://)",
     ),
 
   // Vercel platform (auto-set by Vercel)

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -140,6 +140,7 @@ export default defineConfig({
                 "/gateways/overview",
                 "/gateways/vercel",
                 "/gateways/openrouter",
+                "/gateways/orcarouter",
                 "/gateways/openai",
                 "/gateways/openai-compatible",
                 "/gateways/litellm",

--- a/apps/docs/core/configuration.mdx
+++ b/apps/docs/core/configuration.mdx
@@ -23,7 +23,7 @@ const config: ConfigInput = {
   },
 
   ai: {
-    gateway: "vercel", // "vercel" | "openrouter" | "openai" | "openai-compatible"
+    gateway: "vercel", // "vercel" | "openrouter" | "orcarouter" | "openai" | "openai-compatible" | "litellm"
     tools: {
       webSearch: { enabled: true },
       urlRetrieval: { enabled: true },
@@ -68,6 +68,7 @@ The `ai.gateway` field selects which AI backend to use. All model routing, fetch
 | --------------------- | ------------------------------------------------ | ------------------------------------------- |
 | `"vercel"` (default)  | [Vercel AI Gateway](/gateways/vercel)            | `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` |
 | `"openrouter"`        | [OpenRouter](/gateways/openrouter)               | `OPENROUTER_API_KEY`                        |
+| `"orcarouter"`        | [OrcaRouter](/gateways/orcarouter)               | `ORCAROUTER_API_KEY`                        |
 | `"openai"`            | [OpenAI](/gateways/openai)                       | `OPENAI_API_KEY`                            |
 | `"openai-compatible"` | [OpenAI Compatible](/gateways/openai-compatible) | `OPENAI_COMPATIBLE_BASE_URL`                |
 | `"litellm"`           | [LiteLLM](/gateways/litellm)                     | `LITELLM_BASE_URL`                          |
@@ -85,17 +86,17 @@ See [Gateways](/gateways/overview) for detailed setup and comparison.
 
 Toggle feature flags on/off. Tool flags live under `ai.tools.*.enabled`. `features` currently contains only attachments. Missing env vars are caught at build time via `bun run prebuild`.
 
-| Feature               | Config Key                            | Env Dependency                                                                           |
-| --------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Code Execution        | `ai.tools.codeExecution.enabled`      | `VERCEL_OIDC_TOKEN` (on Vercel) or `VERCEL_TEAM_ID + VERCEL_PROJECT_ID + VERCEL_TOKEN` |
-| Web Search            | `ai.tools.webSearch.enabled`          | `TAVILY_API_KEY` or `FIRECRAWL_API_KEY`                                                 |
-| URL Retrieval         | `ai.tools.urlRetrieval.enabled`       | `FIRECRAWL_API_KEY`                                                                      |
-| MCP Connectors        | `ai.tools.mcp.enabled`                | `MCP_ENCRYPTION_KEY`                                                                     |
-| Image Generation      | `ai.tools.image.enabled`              | Configured file storage provider                                                         |
-| Video Generation      | `ai.tools.video.enabled`              | Configured file storage provider                                                         |
-| Deep Research         | `ai.tools.deepResearch.enabled`       | `TAVILY_API_KEY` or `FIRECRAWL_API_KEY`                                                  |
-| Follow-up Suggestions | `ai.tools.followupSuggestions.enabled` | Uses your configured language model provider                                              |
-| Attachments           | `features.attachments`                | Configured file storage provider                                                         |
+| Feature               | Config Key                             | Env Dependency                                                                         |
+| --------------------- | -------------------------------------- | -------------------------------------------------------------------------------------- |
+| Code Execution        | `ai.tools.codeExecution.enabled`       | `VERCEL_OIDC_TOKEN` (on Vercel) or `VERCEL_TEAM_ID + VERCEL_PROJECT_ID + VERCEL_TOKEN` |
+| Web Search            | `ai.tools.webSearch.enabled`           | `TAVILY_API_KEY` or `FIRECRAWL_API_KEY`                                                |
+| URL Retrieval         | `ai.tools.urlRetrieval.enabled`        | `FIRECRAWL_API_KEY`                                                                    |
+| MCP Connectors        | `ai.tools.mcp.enabled`                 | `MCP_ENCRYPTION_KEY`                                                                   |
+| Image Generation      | `ai.tools.image.enabled`               | Configured file storage provider                                                       |
+| Video Generation      | `ai.tools.video.enabled`               | Configured file storage provider                                                       |
+| Deep Research         | `ai.tools.deepResearch.enabled`        | `TAVILY_API_KEY` or `FIRECRAWL_API_KEY`                                                |
+| Follow-up Suggestions | `ai.tools.followupSuggestions.enabled` | Uses your configured language model provider                                           |
+| Attachments           | `features.attachments`                 | Configured file storage provider                                                       |
 
 ```typescript
 ai: {

--- a/apps/docs/gateways/orcarouter.mdx
+++ b/apps/docs/gateways/orcarouter.mdx
@@ -1,0 +1,66 @@
+---
+title: "OrcaRouter Gateway"
+description: "Route requests through OrcaRouter, a zero-trust AI gateway"
+---
+
+The OrcaRouter gateway connects ChatJS to [OrcaRouter](https://www.orcarouter.ai), an Anthropic-compatible AI gateway that routes to frontier models from Anthropic, OpenAI, Google, DeepSeek, and more through a single endpoint.
+
+Use this gateway when you want the widest model selection with gateway-level, zero-trust security — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+## Setup
+
+1. Create an account at [OrcaRouter](https://www.orcarouter.ai)
+2. Generate an API key in the OrcaRouter dashboard
+3. Add to `.env.local`:
+
+```bash
+ORCAROUTER_API_KEY=or-...
+```
+
+4. Set the gateway in your config:
+
+```typescript title="chat.config.ts"
+const config: ConfigInput = {
+  ai: {
+    gateway: "orcarouter",
+    // ...
+  },
+};
+```
+
+## Authentication
+
+| Variable             | Description                       |
+| -------------------- | --------------------------------- |
+| `ORCAROUTER_API_KEY` | Required. Your OrcaRouter API key |
+
+## Available Models
+
+Frontier models from Anthropic, OpenAI, Google, DeepSeek, and others, plus OrcaRouter's own `orcarouter/*` routing models. The full list is fetched at runtime from `https://api.orcarouter.ai/v1/models` and cached for 1 hour. The response format is automatically normalized to match the internal model schema.
+
+## Model IDs
+
+Model IDs use the same `provider/model` format as other gateways. For example:
+
+- `anthropic/claude-sonnet-5`
+- `anthropic/claude-haiku-4.5`
+- `deepseek/deepseek-v4-flash`
+- `google/gemini-2.5-flash-lite`
+- `orcarouter/fusion`
+
+Your existing model configuration in `chat.config.ts` works across gateways as long as the model IDs match.
+
+## API Compatibility
+
+OrcaRouter serves the Anthropic Messages API on its endpoint, so the gateway uses the `@ai-sdk/anthropic` provider pointed at `https://api.orcarouter.ai`. This keeps model IDs namespaced (e.g. `anthropic/claude-sonnet-5`) while requests flow through the same secure gateway.
+
+## Image Generation
+
+OrcaRouter routes image generation through multimodal language models rather than dedicated image APIs. `createImageModel()` returns `null` for this gateway.
+
+Models with the `image-generation` tag (those with `image` in their output modalities) can still generate images inline through `createLanguageModel()`. The existing [Image Generation](/features/image-generation) feature handles this automatically.
+
+## Related
+
+- [Gateways Overview](/gateways/overview) for the full gateway comparison
+- [Vercel Gateway](/gateways/vercel) for the default gateway

--- a/apps/docs/gateways/overview.mdx
+++ b/apps/docs/gateways/overview.mdx
@@ -7,13 +7,14 @@ ChatJS uses a **gateway** to route all AI requests (model listing, chat completi
 
 ## Available Gateways
 
-| Gateway | Models | Auth | Image Generation | Best For |
-|---------|--------|------|------------------|----------|
-| [Vercel AI Gateway](/gateways/vercel) (default) | 120+ | `AI_GATEWAY_API_KEY` or auto OIDC | Dedicated image models | Vercel deployments |
-| [OpenRouter](/gateways/openrouter) | Hundreds | `OPENROUTER_API_KEY` | Via multimodal models | Broadest model access |
-| [OpenAI](/gateways/openai) | OpenAI only | `OPENAI_API_KEY` | `gpt-image-1` and others | Direct OpenAI access |
-| [LiteLLM](/gateways/litellm) | 100+ providers | `LITELLM_BASE_URL` + optional key | Provider-dependent | Unified proxy for all major providers |
-| [OpenAI Compatible](/gateways/openai-compatible) | Varies | `OPENAI_COMPATIBLE_API_KEY` (optional) | Provider-dependent | Ollama, LM Studio, vLLM, Azure |
+| Gateway                                          | Models         | Auth                                   | Image Generation         | Best For                              |
+| ------------------------------------------------ | -------------- | -------------------------------------- | ------------------------ | ------------------------------------- |
+| [Vercel AI Gateway](/gateways/vercel) (default)  | 120+           | `AI_GATEWAY_API_KEY` or auto OIDC      | Dedicated image models   | Vercel deployments                    |
+| [OpenRouter](/gateways/openrouter)               | Hundreds       | `OPENROUTER_API_KEY`                   | Via multimodal models    | Broadest model access                 |
+| [OrcaRouter](/gateways/orcarouter)               | 200+           | `ORCAROUTER_API_KEY`                   | Via multimodal models    | Anthropic-compatible unified gateway  |
+| [OpenAI](/gateways/openai)                       | OpenAI only    | `OPENAI_API_KEY`                       | `gpt-image-1` and others | Direct OpenAI access                  |
+| [LiteLLM](/gateways/litellm)                     | 100+ providers | `LITELLM_BASE_URL` + optional key      | Provider-dependent       | Unified proxy for all major providers |
+| [OpenAI Compatible](/gateways/openai-compatible) | Varies         | `OPENAI_COMPATIBLE_API_KEY` (optional) | Provider-dependent       | Ollama, LM Studio, vLLM, Azure        |
 
 Need a provider not listed here? See [Custom Gateway](/gateways/custom).
 
@@ -21,6 +22,7 @@ Need a provider not listed here? See [Custom Gateway](/gateways/custom).
 
 - **Vercel AI Gateway** is the default. It aggregates 120+ models from multiple providers behind a single key. Zero-config on Vercel deployments.
 - **OpenRouter** gives access to hundreds of models with per-token pricing. Good when you want the widest selection or models not on Vercel's gateway.
+- **OrcaRouter** routes to frontier models from Anthropic, OpenAI, Google, DeepSeek, and more through one Anthropic-compatible endpoint, with gateway-level, zero-trust security built in.
 - **OpenAI** connects directly to the OpenAI API. Use this when you only need OpenAI models and want type-safe model IDs.
 - **LiteLLM** proxies requests to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, and more) through a single unified endpoint. Ideal when you want provider-agnostic access with centralized key management and spend tracking.
 - **OpenAI Compatible** works with any endpoint that follows the OpenAI API format (local servers, self-hosted inference, or cloud services).
@@ -32,14 +34,15 @@ Set the gateway in `chat.config.ts`:
 ```typescript title="chat.config.ts"
 const config: ConfigInput = {
   ai: {
-    gateway: "openrouter", // "vercel" | "openrouter" | "openai" | "openai-compatible" | "litellm"
+    gateway: "openrouter", // "vercel" | "openrouter" | "orcarouter" | "openai" | "openai-compatible" | "litellm"
     // ...
   },
 };
 ```
 
 <Callout type="note">
-The `gateway` field lives inside the `ai` key and defaults to `"vercel"` when omitted.
+  The `gateway` field lives inside the `ai` key and defaults to `"vercel"` when
+  omitted.
 </Callout>
 
 ## How Model Fetching Works
@@ -82,7 +85,8 @@ This is caught at two levels:
 - **Runtime**: each gateway checks `generatedForGateway` before using the fallback. If it doesn't match, the fallback is skipped and an empty model list is returned instead of stale model IDs.
 
 <Callout type="tip">
-After changing `gateway` in `chat.config.ts`, always run `bun fetch:models` to keep the fallback snapshot in sync.
+  After changing `gateway` in `chat.config.ts`, always run `bun fetch:models` to
+  keep the fallback snapshot in sync.
 </Callout>
 
 See [Auto-Updating Models](/cookbook/auto-updating-models) for the full implementation pattern.

--- a/apps/docs/reference/env-vars.mdx
+++ b/apps/docs/reference/env-vars.mdx
@@ -7,18 +7,18 @@ This page lists every environment variable recognized by ChatJS, grouped by cate
 
 <Callout type="note">
   Missing required variables will cause the build to fail immediately. Variables
-  that are required only when a feature or gateway is enabled are validated based
-  on your `chat.config.ts` settings.
+  that are required only when a feature or gateway is enabled are validated
+  based on your `chat.config.ts` settings.
 </Callout>
 
 ## Required
 
 These two variables must always be set. Without them the app will not start.
 
-| Variable | Description | How to get it |
-|----------|-------------|---------------|
-| `DATABASE_URL` | PostgreSQL connection string | [Neon](https://neon.tech), [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres/quickstart), or any Postgres provider |
-| `AUTH_SECRET` | Secret used to sign and encrypt session tokens (Better Auth) | Run `openssl rand -base64 32` or use [generate-secret.vercel.app/32](https://generate-secret.vercel.app/32) |
+| Variable       | Description                                                  | How to get it                                                                                                                      |
+| -------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL` | PostgreSQL connection string                                 | [Neon](https://neon.tech), [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres/quickstart), or any Postgres provider |
+| `AUTH_SECRET`  | Secret used to sign and encrypt session tokens (Better Auth) | Run `openssl rand -base64 32` or use [generate-secret.vercel.app/32](https://generate-secret.vercel.app/32)                        |
 
 In addition to the two variables above, **at least one AI gateway credential** and **at least one OAuth provider** must be configured. See the sections below.
 
@@ -38,27 +38,27 @@ authentication: {
 
 ### GitHub OAuth
 
-| Variable | Description |
-|----------|-------------|
-| `AUTH_GITHUB_ID` | GitHub OAuth app client ID |
+| Variable             | Description                    |
+| -------------------- | ------------------------------ |
+| `AUTH_GITHUB_ID`     | GitHub OAuth app client ID     |
 | `AUTH_GITHUB_SECRET` | GitHub OAuth app client secret |
 
 **Setup:** Go to [GitHub Developer Settings](https://github.com/settings/developers) → **New OAuth App**. Set the callback URL to `https://yourdomain.com/api/auth/callback/github`.
 
 ### Google OAuth
 
-| Variable | Description |
-|----------|-------------|
-| `AUTH_GOOGLE_ID` | Google OAuth 2.0 client ID |
+| Variable             | Description                    |
+| -------------------- | ------------------------------ |
+| `AUTH_GOOGLE_ID`     | Google OAuth 2.0 client ID     |
 | `AUTH_GOOGLE_SECRET` | Google OAuth 2.0 client secret |
 
 **Setup:** Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials) → **Create credentials** → **OAuth 2.0 Client ID** (Web application). Add `https://yourdomain.com/api/auth/callback/google` as an authorized redirect URI.
 
 ### Vercel OAuth
 
-| Variable | Description |
-|----------|-------------|
-| `VERCEL_APP_CLIENT_ID` | Vercel OAuth integration client ID |
+| Variable                   | Description                            |
+| -------------------------- | -------------------------------------- |
+| `VERCEL_APP_CLIENT_ID`     | Vercel OAuth integration client ID     |
 | `VERCEL_APP_CLIENT_SECRET` | Vercel OAuth integration client secret |
 
 **Setup:** Follow the [Sign In with Vercel](https://vercel.com/docs/integrations/create-integration) guide to create an integration.
@@ -71,7 +71,7 @@ Exactly one gateway must be active. Set `ai.gateway` in `chat.config.ts` to sele
 
 ```typescript title="chat.config.ts"
 ai: {
-  gateway: "vercel", // "vercel" | "openrouter" | "openai" | "openai-compatible" | "litellm"
+  gateway: "vercel", // "vercel" | "openrouter" | "orcarouter" | "openai" | "openai-compatible" | "litellm"
 }
 ```
 
@@ -79,13 +79,14 @@ ai: {
 
 Provides access to 120+ models from OpenAI, Anthropic, Google, xAI, Meta, and more through a single key. This is the default gateway.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `AI_GATEWAY_API_KEY` | Self-hosted / local dev | API key for Vercel AI Gateway |
-| `VERCEL_OIDC_TOKEN` | Auto-set on Vercel | OIDC token injected automatically on Vercel deployments |
+| Variable             | Required                | Description                                             |
+| -------------------- | ----------------------- | ------------------------------------------------------- |
+| `AI_GATEWAY_API_KEY` | Self-hosted / local dev | API key for Vercel AI Gateway                           |
+| `VERCEL_OIDC_TOKEN`  | Auto-set on Vercel      | OIDC token injected automatically on Vercel deployments |
 
 <Callout type="tip">
-  On Vercel deployments, `VERCEL_OIDC_TOKEN` is injected automatically. You only need `AI_GATEWAY_API_KEY` for local development or non-Vercel hosting.
+  On Vercel deployments, `VERCEL_OIDC_TOKEN` is injected automatically. You only
+  need `AI_GATEWAY_API_KEY` for local development or non-Vercel hosting.
 </Callout>
 
 **Setup:** Go to [Vercel AI Gateway](https://vercel.com/ai-gateway) and create an API key.
@@ -94,19 +95,29 @@ Provides access to 120+ models from OpenAI, Anthropic, Google, xAI, Meta, and mo
 
 Provides access to hundreds of models with per-token pricing.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OPENROUTER_API_KEY` | Yes | Your OpenRouter API key (`sk-or-v1-...`) |
+| Variable             | Required | Description                              |
+| -------------------- | -------- | ---------------------------------------- |
+| `OPENROUTER_API_KEY` | Yes      | Your OpenRouter API key (`sk-or-v1-...`) |
 
 **Setup:** Create an account at [OpenRouter](https://openrouter.ai), then go to [API Keys](https://openrouter.ai/keys).
+
+### OrcaRouter
+
+Routes requests through [OrcaRouter](https://www.orcarouter.ai), an Anthropic-compatible unified gateway that provides access to frontier models from Anthropic, OpenAI, Google, DeepSeek, and more with gateway-level, zero-trust security.
+
+| Variable             | Required | Description                        |
+| -------------------- | -------- | ---------------------------------- |
+| `ORCAROUTER_API_KEY` | Yes      | Your OrcaRouter API key (`or-...`) |
+
+**Setup:** Create an account at [OrcaRouter](https://www.orcarouter.ai), then generate an API key in the dashboard.
 
 ### OpenAI
 
 Direct connection to the OpenAI API. Use when you only need OpenAI models.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OPENAI_API_KEY` | Yes | Your OpenAI API key (`sk-...`) |
+| Variable         | Required | Description                    |
+| ---------------- | -------- | ------------------------------ |
+| `OPENAI_API_KEY` | Yes      | Your OpenAI API key (`sk-...`) |
 
 **Setup:** Follow the [OpenAI quickstart](https://developers.openai.com/api/docs/quickstart) to create an API key.
 
@@ -114,10 +125,10 @@ Direct connection to the OpenAI API. Use when you only need OpenAI models.
 
 Works with any endpoint that follows the OpenAI API format: Ollama, LM Studio, vLLM, Azure OpenAI, and others.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OPENAI_COMPATIBLE_BASE_URL` | Yes | Base URL of the compatible API (e.g., `http://localhost:11434/v1`) |
-| `OPENAI_COMPATIBLE_API_KEY` | Yes | API key for the compatible provider |
+| Variable                     | Required | Description                                                        |
+| ---------------------------- | -------- | ------------------------------------------------------------------ |
+| `OPENAI_COMPATIBLE_BASE_URL` | Yes      | Base URL of the compatible API (e.g., `http://localhost:11434/v1`) |
+| `OPENAI_COMPATIBLE_API_KEY`  | Yes      | API key for the compatible provider                                |
 
 **Setup:** Start your compatible server (for example, run `ollama serve` for Ollama), set `OPENAI_COMPATIBLE_BASE_URL` to its `/v1` endpoint, and provide `OPENAI_COMPATIBLE_API_KEY`.
 
@@ -125,10 +136,10 @@ Works with any endpoint that follows the OpenAI API format: Ollama, LM Studio, v
 
 Routes requests through a LiteLLM proxy for centralized model access, key management, routing, and spend tracking.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `LITELLM_BASE_URL` | Yes | Base URL of the LiteLLM proxy (e.g., `http://localhost:4000`) |
-| `LITELLM_API_KEY` | Optional | Master key or virtual key if your LiteLLM proxy requires authentication |
+| Variable           | Required | Description                                                             |
+| ------------------ | -------- | ----------------------------------------------------------------------- |
+| `LITELLM_BASE_URL` | Yes      | Base URL of the LiteLLM proxy (e.g., `http://localhost:4000`)           |
+| `LITELLM_API_KEY`  | Optional | Master key or virtual key if your LiteLLM proxy requires authentication |
 
 **Setup:** Start your LiteLLM proxy, set `LITELLM_BASE_URL` to the proxy root URL without `/v1`, and provide `LITELLM_API_KEY` only when the proxy requires auth.
 
@@ -151,14 +162,15 @@ ai: {
 }
 ```
 
-| Variable | Feature | Description | Get it |
-|----------|---------|-------------|--------|
-| `TAVILY_API_KEY` | `webSearch` | Tavily API key for web search (recommended) | [app.tavily.com](https://app.tavily.com) |
-| `FIRECRAWL_API_KEY` | `webSearch`, `urlRetrieval` | Firecrawl API key for web search and URL content extraction | [firecrawl.dev](https://www.firecrawl.dev) |
-| `EXA_API_KEY` | _none_ | Recognized by env schema but not used by build-time `webSearch` validation | [Exa API key guide](https://docs.exa.ai/reference/getting-started) |
+| Variable            | Feature                     | Description                                                                | Get it                                                             |
+| ------------------- | --------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `TAVILY_API_KEY`    | `webSearch`                 | Tavily API key for web search (recommended)                                | [app.tavily.com](https://app.tavily.com)                           |
+| `FIRECRAWL_API_KEY` | `webSearch`, `urlRetrieval` | Firecrawl API key for web search and URL content extraction                | [firecrawl.dev](https://www.firecrawl.dev)                         |
+| `EXA_API_KEY`       | _none_                      | Recognized by env schema but not used by build-time `webSearch` validation | [Exa API key guide](https://docs.exa.ai/reference/getting-started) |
 
 <Callout type="note">
-  If both `TAVILY_API_KEY` and `FIRECRAWL_API_KEY` are set, Tavily is used for regular chat web search. Firecrawl is always used for URL retrieval.
+  If both `TAVILY_API_KEY` and `FIRECRAWL_API_KEY` are set, Tavily is used for
+  regular chat web search. Firecrawl is always used for URL retrieval.
 </Callout>
 
 ### MCP Connectors
@@ -173,9 +185,9 @@ ai: {
 }
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `MCP_ENCRYPTION_KEY` | Yes | 44-character base64 key used to encrypt stored MCP server credentials (URLs, OAuth tokens) |
+| Variable             | Required | Description                                                                                |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `MCP_ENCRYPTION_KEY` | Yes      | 44-character base64 key used to encrypt stored MCP server credentials (URLs, OAuth tokens) |
 
 **Generate a key:**
 
@@ -184,7 +196,9 @@ openssl rand -base64 32
 ```
 
 <Callout type="note">
-  The key must be exactly 44 characters (32 bytes encoded as base64). Changing this key after deployment will invalidate all stored MCP connector credentials.
+  The key must be exactly 44 characters (32 bytes encoded as base64). Changing
+  this key after deployment will invalidate all stored MCP connector
+  credentials.
 </Callout>
 
 ### File Storage
@@ -229,15 +243,15 @@ ai: {
 }
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `VERCEL_OIDC_TOKEN` | Auto-set on Vercel | Used automatically for OIDC auth on Vercel deployments |
-| `VERCEL_TEAM_ID` | Self-hosted only | Your Vercel team ID (`team_...`) |
-| `VERCEL_PROJECT_ID` | Self-hosted only | Your Vercel project ID (`prj_...`) |
-| `VERCEL_TOKEN` | Self-hosted only | Vercel API token with sandbox permissions |
-| `VERCEL_SANDBOX_RUNTIME_PYTHON` | Optional | Python runtime identifier (default: `python3.13`) |
-| `VERCEL_SANDBOX_RUNTIME_JAVASCRIPT` | Optional | JavaScript runtime identifier (default: `node22`) |
-| `VERCEL_SANDBOX_RUNTIME` | Optional | Legacy Python runtime fallback. Prefer `VERCEL_SANDBOX_RUNTIME_PYTHON` |
+| Variable                            | Required           | Description                                                            |
+| ----------------------------------- | ------------------ | ---------------------------------------------------------------------- |
+| `VERCEL_OIDC_TOKEN`                 | Auto-set on Vercel | Used automatically for OIDC auth on Vercel deployments                 |
+| `VERCEL_TEAM_ID`                    | Self-hosted only   | Your Vercel team ID (`team_...`)                                       |
+| `VERCEL_PROJECT_ID`                 | Self-hosted only   | Your Vercel project ID (`prj_...`)                                     |
+| `VERCEL_TOKEN`                      | Self-hosted only   | Vercel API token with sandbox permissions                              |
+| `VERCEL_SANDBOX_RUNTIME_PYTHON`     | Optional           | Python runtime identifier (default: `python3.13`)                      |
+| `VERCEL_SANDBOX_RUNTIME_JAVASCRIPT` | Optional           | JavaScript runtime identifier (default: `node22`)                      |
+| `VERCEL_SANDBOX_RUNTIME`            | Optional           | Legacy Python runtime fallback. Prefer `VERCEL_SANDBOX_RUNTIME_PYTHON` |
 
 <Callout type="note">
   On Vercel deployments, sandbox authentication happens automatically via OIDC,
@@ -254,8 +268,8 @@ ai: {
 
 Allows users to reconnect to an ongoing AI generation after a page refresh or network interruption.
 
-| Variable | Description | Get it |
-|----------|-------------|--------|
+| Variable    | Description                                   | Get it                                                                       |
+| ----------- | --------------------------------------------- | ---------------------------------------------------------------------------- |
 | `REDIS_URL` | Redis connection URL for stream state storage | [Vercel KV](https://vercel.com/docs/storage/vercel-kv) or any Redis provider |
 
 Without `REDIS_URL`, streams work normally but cannot be resumed after disconnection.
@@ -264,8 +278,8 @@ Without `REDIS_URL`, streams work normally but cannot be resumed after disconnec
 
 Secures the `/api/cron/cleanup` endpoint that removes orphaned managed files.
 
-| Variable | Description |
-|----------|-------------|
+| Variable      | Description                                                 |
+| ------------- | ----------------------------------------------------------- |
 | `CRON_SECRET` | Bearer token that the cron runner must send to authenticate |
 
 **Generate a secret:**
@@ -278,20 +292,20 @@ On Vercel, the platform automatically sends `CRON_SECRET` as a `Authorization: B
 
 ### App URL
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `APP_URL` | Non-Vercel deployments | Full public URL of the app including protocol (e.g., `https://myapp.com`) |
-| `VERCEL_URL` | Auto-set by Vercel | Hostname auto-injected by the Vercel platform; used when `APP_URL` is not set |
+| Variable     | Required               | Description                                                                   |
+| ------------ | ---------------------- | ----------------------------------------------------------------------------- |
+| `APP_URL`    | Non-Vercel deployments | Full public URL of the app including protocol (e.g., `https://myapp.com`)     |
+| `VERCEL_URL` | Auto-set by Vercel     | Hostname auto-injected by the Vercel platform; used when `APP_URL` is not set |
 
 ### Observability (Langfuse)
 
 ChatJS uses [OpenTelemetry](https://opentelemetry.io) via `@vercel/otel` and exports traces to [Langfuse](https://langfuse.com) for LLM observability. These variables are read by the `langfuse-vercel` exporter and are not part of the Zod env schema. The Langfuse SDK picks them up automatically from the environment.
 
-| Variable | Description | Get it |
-|----------|-------------|--------|
-| `LANGFUSE_PUBLIC_KEY` | Langfuse project public key | [Langfuse Cloud](https://cloud.langfuse.com) → Project Settings → API Keys |
-| `LANGFUSE_SECRET_KEY` | Langfuse project secret key | Same as above |
-| `LANGFUSE_BASE_URL` | Langfuse API base URL (default: `https://cloud.langfuse.com`) | Set to your self-hosted Langfuse URL if applicable |
+| Variable              | Description                                                   | Get it                                                                     |
+| --------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `LANGFUSE_PUBLIC_KEY` | Langfuse project public key                                   | [Langfuse Cloud](https://cloud.langfuse.com) → Project Settings → API Keys |
+| `LANGFUSE_SECRET_KEY` | Langfuse project secret key                                   | Same as above                                                              |
+| `LANGFUSE_BASE_URL`   | Langfuse API base URL (default: `https://cloud.langfuse.com`) | Set to your self-hosted Langfuse URL if applicable                         |
 
 Omitting these variables disables trace export. The app runs normally without them.
 
@@ -301,42 +315,43 @@ Omitting these variables disables trace export. The app runs normally without th
 
 All variables in one place:
 
-| Variable | Category | Required |
-|----------|----------|----------|
-| `DATABASE_URL` | Core | Always |
-| `AUTH_SECRET` | Core | Always |
-| `AI_GATEWAY_API_KEY` | Gateway | Vercel gateway (non-Vercel hosting) |
-| `VERCEL_OIDC_TOKEN` | Gateway | Auto-set on Vercel |
-| `OPENROUTER_API_KEY` | Gateway | OpenRouter gateway |
-| `OPENAI_API_KEY` | Gateway | OpenAI gateway |
-| `OPENAI_COMPATIBLE_BASE_URL` | Gateway | OpenAI-compatible gateway |
-| `OPENAI_COMPATIBLE_API_KEY` | Gateway | OpenAI-compatible gateway |
-| `LITELLM_BASE_URL` | Gateway | LiteLLM gateway |
-| `LITELLM_API_KEY` | Gateway | Optional for LiteLLM gateway |
-| `AUTH_GITHUB_ID` | Auth | If `authentication.github: true` |
-| `AUTH_GITHUB_SECRET` | Auth | If `authentication.github: true` |
-| `AUTH_GOOGLE_ID` | Auth | If `authentication.google: true` |
-| `AUTH_GOOGLE_SECRET` | Auth | If `authentication.google: true` |
-| `VERCEL_APP_CLIENT_ID` | Auth | If `authentication.vercel: true` |
-| `VERCEL_APP_CLIENT_SECRET` | Auth | If `authentication.vercel: true` |
-| `BLOB_READ_WRITE_TOKEN` | Storage | When Vercel Blob is the selected provider |
-| `TAVILY_API_KEY` | Feature | If `ai.tools.webSearch.enabled` (one search key required) |
-| `FIRECRAWL_API_KEY` | Feature | If `ai.tools.webSearch.enabled` or `ai.tools.urlRetrieval.enabled` |
-| `EXA_API_KEY` | Optional | Recognized by env schema but not required by current validation |
-| `MCP_ENCRYPTION_KEY` | Feature | If `ai.tools.mcp.enabled` |
-| `VERCEL_TEAM_ID` | Feature | If `ai.tools.codeExecution.enabled` on non-Vercel hosting |
-| `VERCEL_PROJECT_ID` | Feature | If `ai.tools.codeExecution.enabled` on non-Vercel hosting |
-| `VERCEL_TOKEN` | Feature | If `ai.tools.codeExecution.enabled` on non-Vercel hosting |
-| `VERCEL_SANDBOX_RUNTIME_PYTHON` | Feature | Optional Python sandbox runtime override |
-| `VERCEL_SANDBOX_RUNTIME_JAVASCRIPT` | Feature | Optional JavaScript sandbox runtime override |
-| `VERCEL_SANDBOX_RUNTIME` | Feature | Legacy Python sandbox runtime override |
-| `REDIS_URL` | Optional | Resumable streams |
-| `CRON_SECRET` | Optional | Secure cleanup cron endpoint |
-| `APP_URL` | Optional | Required on non-Vercel deployments |
-| `VERCEL_URL` | Optional | Auto-set by Vercel platform |
-| `LANGFUSE_PUBLIC_KEY` | Optional | LLM observability |
-| `LANGFUSE_SECRET_KEY` | Optional | LLM observability |
-| `LANGFUSE_BASE_URL` | Optional | Self-hosted Langfuse endpoint |
+| Variable                            | Category | Required                                                           |
+| ----------------------------------- | -------- | ------------------------------------------------------------------ |
+| `DATABASE_URL`                      | Core     | Always                                                             |
+| `AUTH_SECRET`                       | Core     | Always                                                             |
+| `AI_GATEWAY_API_KEY`                | Gateway  | Vercel gateway (non-Vercel hosting)                                |
+| `VERCEL_OIDC_TOKEN`                 | Gateway  | Auto-set on Vercel                                                 |
+| `OPENROUTER_API_KEY`                | Gateway  | OpenRouter gateway                                                 |
+| `ORCAROUTER_API_KEY`                | Gateway  | OrcaRouter gateway                                                 |
+| `OPENAI_API_KEY`                    | Gateway  | OpenAI gateway                                                     |
+| `OPENAI_COMPATIBLE_BASE_URL`        | Gateway  | OpenAI-compatible gateway                                          |
+| `OPENAI_COMPATIBLE_API_KEY`         | Gateway  | OpenAI-compatible gateway                                          |
+| `LITELLM_BASE_URL`                  | Gateway  | LiteLLM gateway                                                    |
+| `LITELLM_API_KEY`                   | Gateway  | Optional for LiteLLM gateway                                       |
+| `AUTH_GITHUB_ID`                    | Auth     | If `authentication.github: true`                                   |
+| `AUTH_GITHUB_SECRET`                | Auth     | If `authentication.github: true`                                   |
+| `AUTH_GOOGLE_ID`                    | Auth     | If `authentication.google: true`                                   |
+| `AUTH_GOOGLE_SECRET`                | Auth     | If `authentication.google: true`                                   |
+| `VERCEL_APP_CLIENT_ID`              | Auth     | If `authentication.vercel: true`                                   |
+| `VERCEL_APP_CLIENT_SECRET`          | Auth     | If `authentication.vercel: true`                                   |
+| `BLOB_READ_WRITE_TOKEN`             | Storage  | When Vercel Blob is the selected provider                          |
+| `TAVILY_API_KEY`                    | Feature  | If `ai.tools.webSearch.enabled` (one search key required)          |
+| `FIRECRAWL_API_KEY`                 | Feature  | If `ai.tools.webSearch.enabled` or `ai.tools.urlRetrieval.enabled` |
+| `EXA_API_KEY`                       | Optional | Recognized by env schema but not required by current validation    |
+| `MCP_ENCRYPTION_KEY`                | Feature  | If `ai.tools.mcp.enabled`                                          |
+| `VERCEL_TEAM_ID`                    | Feature  | If `ai.tools.codeExecution.enabled` on non-Vercel hosting          |
+| `VERCEL_PROJECT_ID`                 | Feature  | If `ai.tools.codeExecution.enabled` on non-Vercel hosting          |
+| `VERCEL_TOKEN`                      | Feature  | If `ai.tools.codeExecution.enabled` on non-Vercel hosting          |
+| `VERCEL_SANDBOX_RUNTIME_PYTHON`     | Feature  | Optional Python sandbox runtime override                           |
+| `VERCEL_SANDBOX_RUNTIME_JAVASCRIPT` | Feature  | Optional JavaScript sandbox runtime override                       |
+| `VERCEL_SANDBOX_RUNTIME`            | Feature  | Legacy Python sandbox runtime override                             |
+| `REDIS_URL`                         | Optional | Resumable streams                                                  |
+| `CRON_SECRET`                       | Optional | Secure cleanup cron endpoint                                       |
+| `APP_URL`                           | Optional | Required on non-Vercel deployments                                 |
+| `VERCEL_URL`                        | Optional | Auto-set by Vercel platform                                        |
+| `LANGFUSE_PUBLIC_KEY`               | Optional | LLM observability                                                  |
+| `LANGFUSE_SECRET_KEY`               | Optional | LLM observability                                                  |
+| `LANGFUSE_BASE_URL`                 | Optional | Self-hosted Langfuse endpoint                                      |
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds a named **OrcaRouter** gateway to ChatJS, mirroring the existing OpenRouter wiring. [OrcaRouter](https://www.orcarouter.ai) is an Anthropic-compatible AI gateway that routes to frontier models from Anthropic, OpenAI, Google, DeepSeek, and more through a single endpoint.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **New gateway**: `OrcaRouterGateway` in `apps/chat/lib/ai/gateways/orcarouter-gateway.ts`, built on `@ai-sdk/anthropic` pointed at `https://api.orcarouter.ai` (the gateway already depends on `@ai-sdk/anthropic`)
  - `createLanguageModel()` returns models namespaced as `anthropic/*`, `openai/*`, `google/*`, `deepseek/*`, and `orcarouter/*`
  - `createImageModel()` / `createVideoModel()` return `null` (multimodal image generation flows through the language model)
  - `fetchModels()` pulls the live model catalog from `https://api.orcarouter.ai/v1/models`, normalizes both model response shapes, and falls back to the `generatedForGateway` snapshot
- **Registry & config**: registered `orcarouter` in the gateway registry, discriminated union config schema, `GATEWAY_MODEL_DEFAULTS`, env schema, and `config-requirements`
- **Env example**: `ORCAROUTER_API_KEY` added to `.env.example`
- **Docs**: new `/gateways/orcarouter` page; OrcaRouter row in the gateways overview, nav, config reference, and env-var reference

## Verification

- `bun run test:types` (next typegen + `tsc --noEmit`) passes
- `prettier` formatting applied to all touched files
- Gateway live-checked against `https://api.orcarouter.ai`:
  - `GET /v1/models` → 200 with the model catalog
  - `POST /v1/messages` (Anthropic protocol, `x-api-key` auth) → 200 for `anthropic/claude-sonnet-5` and `orcarouter/fusion`

## Notes

Set `gateway: "orcarouter"` in `chat.config.ts` and `ORCAROUTER_API_KEY` in your environment to use it. No breaking changes — the `vercel` default is untouched.

I'm an engineer on the OrcaRouter team.

## Summary by Sourcery

Add OrcaRouter as a configurable, Anthropic-compatible AI gateway for ChatJS.

New Features:
- Add the OrcaRouter gateway for routing ChatJS requests to Anthropic-compatible models across multiple providers.
- Fetch and normalize OrcaRouter’s live model catalog with a generated fallback snapshot.

Enhancements:
- Register OrcaRouter across gateway configuration, model defaults, environment validation, and runtime gateway selection.

Documentation:
- Document OrcaRouter setup, authentication, model availability, and configuration in the gateway and reference documentation.

Chores:
- Add the OrcaRouter API key to the environment example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a named `orcarouter` gateway that routes through `@ai-sdk/anthropic` to `https://api.orcarouter.ai`, giving access to Anthropic/OpenAI/Google/DeepSeek models behind one endpoint. The default remains `vercel`; existing behavior is unchanged.

- Registers `orcarouter` in the gateway registry, config discriminated union, env schema, and `GATEWAY_MODEL_DEFAULTS` (adds curated defaults and tool settings).
- Adds `OrcaRouterGateway` with `createLanguageModel(modelId)` (namespaced IDs like `anthropic/*`, `openai/*`, `google/*`, `deepseek/*`, `orcarouter/*`); `createImageModel()` and `createVideoModel()` return null since image generation flows through multimodal language models.
- Fetches models from `https://api.orcarouter.ai/v1/models` with `Authorization: Bearer`, normalizes the response, and caches for 1 hour; falls back to generated models when unreachable or unset key.
- Adds `ORCAROUTER_API_KEY` to env schema and `.env.example`; updates docs (overview, config reference, env vars) and adds `/gateways/orcarouter`.

- Required to adopt: set `ai.gateway: "orcarouter"` in `chat.config.ts` and define `ORCAROUTER_API_KEY`.

<sup>Written for commit 8ef648527ed5e08930d277019fef7bb21ba7dc94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FranciscoMoretti/chat-js/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported AI gateway for chat and model discovery.
  * Added support for configuring OrcaRouter with an API key and selecting available models.
  * Included provider defaults for curated, anonymous, workflow, tool, and deep-research scenarios.

* **Documentation**
  * Added setup instructions, configuration references, gateway comparisons, and model guidance for OrcaRouter.
  * Documented Anthropic API compatibility, zero-trust routing, and image-generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->